### PR TITLE
Context grounding retriever [OR-85290]

### DIFF
--- a/sdk/langchain/uipath_langchain/retrievers/__init__.py
+++ b/sdk/langchain/uipath_langchain/retrievers/__init__.py
@@ -1,0 +1,3 @@
+from .context_grounding_retriever import ContextGroundingRetriever
+
+__all__ = ["ContextGroundingRetriever"]

--- a/sdk/langchain/uipath_langchain/retrievers/context_grounding_retriever.py
+++ b/sdk/langchain/uipath_langchain/retrievers/context_grounding_retriever.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from uipath_sdk import UiPathSDK  # type: ignore
+
+
+class ContextGroundingRetriever(BaseRetriever):
+    index_name: str
+    uipath_sdk: Optional[UiPathSDK] = None
+    number_of_results: Optional[int] = 10
+
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+    ) -> List[Document]:
+        """Sync implementations for retriever calls context_grounding API to search the requested index."""
+
+        sdk = self.uipath_sdk if self.uipath_sdk is not None else UiPathSDK()
+        results = sdk.context_grounding.search(
+            self.index_name, query, self.number_of_results
+        )
+
+        return [
+            Document(
+                page_content=x["content"],
+                metadata={
+                    "source": x["source"],
+                    "page_number": x["page_number"],
+                },
+            )
+            for x in results
+        ]


### PR DESCRIPTION
Add default implementation for uipath context grounding retriever that wraps the sdk call to context grounding in a retriever that can be used in langchain

example direct usage:
``` py
import os
from pprint import pprint
from uipath_langchain.retrievers import ContextGroundingRetriever

os.environ["UIPATH_URL"]="https://alpha.uipath.com/ao/DefaultTenant"
os.environ["UIPATH_ACCESS_TOKEN"]="xxx"
os.environ["UIPATH_FOLDER_KEY"]="d955732e-120e-4e1d-a924-9ccbcd7b6017"

retriever = ContextGroundingRetriever(index_name = "Company Policy Conext")
pprint(retriever.invoke("What is the company policy on remote work?"))

```

example langchain tool usage:
``` py
from langchain.tools.retriever import create_retriever_tool
from uipath_langchain.retrievers import ContextGroundingRetriever

retriever = ContextGroundingRetriever(index_name = "Company Policy Conext")
retriever_tool = create_retriever_tool(
    retriever,
    "ContextforInvoiceDisputeInvestigation",
   """
   Use this tool to search the company internal documents for information about policies around dispute resolution.
   Use a meaningful query to load relevant information from the documents. Save the citation for later use.
   """
)
```

[OR-85290](https://uipath.atlassian.net/browse/OR-85290)


[OR-85290]: https://uipath.atlassian.net/browse/OR-85290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ