### PR TITLE
sdk: connections ping helper for token

### DIFF
--- a/sdk/core/pyproject.toml
+++ b/sdk/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath_sdk"
-version = "0.0.66"
+version = "0.0.67"
 description = "UiPath SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/sdk/core/uipath_sdk/_models/connections.py
+++ b/sdk/core/uipath_sdk/_models/connections.py
@@ -1,0 +1,17 @@
+from typing import TypedDict
+
+
+class ConnectionPing(TypedDict):
+    dateTime: str
+    elementId: str
+    hasTokenRefresh: str
+    accessToken: str
+    responseCode: str
+    valid: bool
+    accessTokenExpiry: str
+    endpoint: str
+    accessTokenScope: str
+    instanceId: str
+    authenticationType: str
+    responseMessage: str
+    connectionIdentity: str

--- a/sdk/core/uipath_sdk/_services/__init__.py
+++ b/sdk/core/uipath_sdk/_services/__init__.py
@@ -2,14 +2,16 @@ from .actions_service import ActionsService
 from .api_client import ApiClient
 from .assets_service import AssetsService
 from .buckets_service import BucketsService
+from .connections_service import ConnectionsService
 from .context_grounding_service import ContextGroundingService
 from .processes_service import ProcessesService
 
 __all__ = [
     "ActionsService",
     "AssetsService",
-    "ProcessesService",
     "BucketsService",
+    "ConnectionsService",
     "ContextGroundingService",
+    "ProcessesService",
     "ApiClient",
 ]

--- a/sdk/core/uipath_sdk/_services/connections_service.py
+++ b/sdk/core/uipath_sdk/_services/connections_service.py
@@ -1,0 +1,23 @@
+from typing import cast
+
+from uipath_sdk._utils._endpoint import Endpoint
+
+from .._config import Config
+from .._execution_context import ExecutionContext
+from .._models.connections import ConnectionPing
+from ._base_service import BaseService
+
+
+class ConnectionsService(BaseService):
+    def __init__(self, config: Config, execution_context: ExecutionContext) -> None:
+        super().__init__(config=config, execution_context=execution_context)
+
+    def token(self, elementInstanceId: int) -> ConnectionPing:
+        return cast(
+            ConnectionPing,
+            self.request(
+                "GET",
+                Endpoint(f"/elements_/v3/element/instances/{elementInstanceId}/ping"),
+                params={"forcePing": True, "disableOnFailure": True},
+            ).json(),
+        )

--- a/sdk/core/uipath_sdk/_uipath_sdk.py
+++ b/sdk/core/uipath_sdk/_uipath_sdk.py
@@ -10,6 +10,7 @@ from ._services import (
     ApiClient,
     AssetsService,
     BucketsService,
+    ConnectionsService,
     ContextGroundingService,
     ProcessesService,
 )
@@ -60,6 +61,10 @@ class UiPathSDK:
     @property
     def buckets(self) -> BucketsService:
         return BucketsService(self._config, self._execution_context)
+
+    @property
+    def connections(self) -> ConnectionsService:
+        return ConnectionsService(self._config, self._execution_context)
 
     @property
     def context_grounding(self) -> ContextGroundingService:


### PR DESCRIPTION
Sdk method that takes the access token from an active connection, to use it in a native client.

Example usage:

``` python
from os import environ as env
from pprint import pprint

from uipath_sdk import UiPathSDK

env["UIPATH_URL"]="https://alpha.uipath.com/edisinc/roprau"
env["UIPATH_ACCESS_TOKEN"]="XXX"

tokenResponse = UiPathSDK().connections.token(340602)

pprint(tokenResponse)
print(tokenResponse['accessToken'])
```
