### PR TITLE
Tracer: send traces async

### DIFF
--- a/sdk/langchain/pyproject.toml
+++ b/sdk/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath_langchain"
-version = "0.0.61"
+version = "0.0.62"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/sdk/langchain/uipath_langchain/_cli/_runtime/_runtime.py
+++ b/sdk/langchain/uipath_langchain/_cli/_runtime/_runtime.py
@@ -67,6 +67,7 @@ class LangGraphRuntime(UiPathBaseRuntime):
                 # Set up tracing if available
                 callbacks: List[BaseCallbackHandler] = []
 
+                tracer = None
                 if self.context.job_id and self.context.tracing_enabled:
                     tracer = AsyncUiPathTracer()
                     await tracer.init_trace(
@@ -91,6 +92,9 @@ class LangGraphRuntime(UiPathBaseRuntime):
                     self.context.state = await graph.aget_state(graph_config)
                 except Exception:
                     pass
+
+                if tracer is not None:
+                    await tracer.wait_for_all_tracers()
 
                 if self.context.langsmith_tracing_enabled:
                     wait_for_all_tracers()


### PR DESCRIPTION
# Description
- send trace at the beginning of events also (`_start_trace`)
- send traces completely async, traces are not awaited to continue graph execution
- `_end_trace` can override `_start_trace` but not the other way around, (llmops has UPSERT)