### PR TITLE
Langgraph runtime: add default requesting feature

### DIFF
--- a/sdk/langchain/pyproject.toml
+++ b/sdk/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath_langchain"
-version = "0.0.63"
+version = "0.0.64"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/sdk/langchain/uipath_langchain/_cli/cli_run.py
+++ b/sdk/langchain/uipath_langchain/_cli/cli_run.py
@@ -42,6 +42,10 @@ def langgraph_run_middleware(
             context.tracing_enabled = env.get("UIPATH_TRACING_ENABLED", True)
             context.langsmith_tracing_enabled = env.get("LANGSMITH_TRACING", False)
 
+            # Add default env variables
+            env["UIPATH_REQUESTING_PRODUCT"] = "uipath-python-sdk"
+            env["UIPATH_REQUESTING_FEATURE"] = "langgraph-agent"
+
             async with LangGraphRuntime.from_context(context) as runtime:
                 await runtime.execute()
 


### PR DESCRIPTION
# Description
adds defaults needed for llm gateway chat

```
            # Add default env variables
            env["UIPATH_REQUESTING_PRODUCT"] = "uipath-python-sdk"
            env["UIPATH_REQUESTING_FEATURE"] = "langgraph-agent"
```