### PR TITLE
Langchain: interrupt models runtime implementation

### DIFF
--- a/sdk/langchain/pyproject.toml
+++ b/sdk/langchain/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.76"
+version = "0.0.77"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
 dependencies = [
-    "uipath-sdk>=0.0.101",
+    "uipath-sdk>=0.0.106",
     "langgraph>=0.2.70",
     "langchain-core>=0.3.34",
     "langgraph-checkpoint-sqlite>=2.0.3",

--- a/sdk/langchain/uipath_langchain/_cli/_runtime/_escalation.py
+++ b/sdk/langchain/uipath_langchain/_cli/_runtime/_escalation.py
@@ -162,7 +162,7 @@ class Escalation:
         return current
 
     def extract_response_value(self, action_data: Dict[str, Any]) -> Any:
-        if not self.enabled or not self._config:
+        if not self._config:
             return ""
 
         response_template = self._config.get("response")
@@ -208,7 +208,7 @@ class Escalation:
 
                     return extracted_value
 
-        return ""
+        return action_data
 
     async def create(self, value: Any) -> Optional[Action]:
         """

--- a/sdk/langchain/uipath_langchain/_cli/_runtime/_input.py
+++ b/sdk/langchain/uipath_langchain/_cli/_runtime/_input.py
@@ -65,7 +65,7 @@ class LangGraphInputProcessor:
             logger.debug(f"Action: {action}")
             if action.data is None:
                 return Command(resume={})
-            if self.escalation:
+            if self.escalation and self.escalation.enabled:
                 extracted_value = self.escalation.extract_response_value(action.data)
                 return Command(resume=extracted_value)
             return Command(resume=action.data)


### PR DESCRIPTION
Added runtime interrupt implementation for `CreateAction`, `WaitAction` and `WaitJob` models.
Usage examples:
- CreateAction
```
    action_data = interrupt(CreateAction(name="Agent Handler",
                                      title="Action Required: Report Review -- FROM MODEL",
                                      data={"Question": f"Label: {state.label} Confidence: {state.confidence}",
                                               "AgentName": "ticket-classification "},
                                      app_version=1,))
```
- WaitAction
node 1 ->     
```
action = uipath.actions.create(title="Action Required: Report Review",
                                   data={"Question": f"Label: {state.label} Confidence: {state.confidence}"},
                                   app_name="Agent Handler")
state.action = action
```
node 2 ->
`action_data = interrupt(WaitAction(action = state.action))
`
- WaitJob
node 1 ->
```
 job = await uipath.processes.invoke_async(name="ticket-classification-agent",
                                              input_arguments={"message": state.message,
                                                               "ticket_id": state.ticket_id, })
state.job = job
```
node 2 ->
`job_output = interrupt(WaitJob(job = state.job))
`
## Possible issue:

If there is a `defaultEscalation` configuration in uipath.json, there is no way to decide in [runtime._input](https://github.com/UiPath/uipath-python/blob/main/sdk/langchain/uipath_langchain/_cli/_runtime/_input.py#L68) if the action was trigger via a `CreateAction/WaitAction` interrupt call or via plain interrupt (i.e. interrupt(str)).
Therefore, if `defaultEscalation` is enabled for the current graph we try to fetch from action_data the key specified in json configuration. If the key is not found, we return the entire action_data object.