### PR TITLE
Langchain: remove interrupt type checks

### DIFF
--- a/sdk/langchain/pyproject.toml
+++ b/sdk/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-langchain"
-version = "0.0.80"
+version = "0.0.81"
 description = "UiPath Langchain"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/sdk/langchain/uipath_langchain/_cli/_runtime/_output.py
+++ b/sdk/langchain/uipath_langchain/_cli/_runtime/_output.py
@@ -278,10 +278,6 @@ class LangGraphOutputProcessor:
                                     triggerType=UiPathResumeTriggerType.ACTION,
                                     itemKey=self.interrupt_value.action.key,
                                 )
-                        elif not isinstance(self.interrupt_value, str):
-                            raise Exception(
-                                f"Unknown interrupt value type {type(self.interrupt_value)}"
-                            )
 
                 except Exception as e:
                     raise LangGraphRuntimeError(


### PR DESCRIPTION
- remove interrupt type checks
- on unknown type we'll default to API trigger