### PR TITLE
feat(trace): add otel tracing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "titleBar.inactiveBackground": "#0099cc"
   },
   "python.testing.pytestArgs": [
-    "sdk"
+    "tests"
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
   "click>=8.1.8",
   "httpx>=0.28.1",
+  "opentelemetry-sdk>=1.32.1",
   "pydantic>=2.11.1",
   "pytest-asyncio>=0.25.3",
   "python-dotenv>=1.0.1",

--- a/src/uipath/tracing/__init__.py
+++ b/src/uipath/tracing/__init__.py
@@ -1,0 +1,3 @@
+from ._traced import TracedDecoratorRegistry, traced, wait_for_tracers  # noqa: D104
+
+__all__ = ["TracedDecoratorRegistry", "traced", "wait_for_tracers"]

--- a/src/uipath/tracing/_otel_exporters.py
+++ b/src/uipath/tracing/_otel_exporters.py
@@ -1,0 +1,67 @@
+import json
+import logging
+import os
+from typing import Sequence
+
+from httpx import Client
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import (
+    SpanExporter,
+    SpanExportResult,
+)
+
+from ._utils import _SpanUtils
+
+logger = logging.getLogger(__name__)
+
+
+class LlmOpsHttpExporter(SpanExporter):
+    """An OpenTelemetry span exporter that sends spans to UiPath LLM Ops."""
+
+    def __init__(self, **kwargs):
+        """Initialize the exporter with the base URL and authentication token."""
+        super().__init__(**kwargs)
+        self.base_url = self._get_base_url()
+        self.auth_token = os.environ.get("UIPATH_ACCESS_TOKEN")
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.auth_token}",
+        }
+
+        self.http_client = Client(headers=self.headers)
+
+    def export(self, spans: Sequence[ReadableSpan]):
+        """Export spans to UiPath LLM Ops."""
+        logger.debug(
+            f"Exporting {len(spans)} spans to {self.base_url}/llmopstenant_/api/Traces/spans"
+        )
+
+        span_list = [
+            _SpanUtils.otel_span_to_uipath_span(span).to_dict() for span in spans
+        ]
+
+        trace_id = str(span_list[0]["TraceId"])
+        url = f"{self.base_url}/llmopstenant_/api/Traces/spans?traceId={trace_id}&source=Robots"
+
+        logger.debug("payload: ", json.dumps(span_list))
+
+        res = self.http_client.post(url, json=span_list)
+
+        if res.status_code == 200:
+            return SpanExportResult.SUCCESS
+        else:
+            return SpanExportResult.FAILURE
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Force flush the exporter."""
+        return True
+
+    def _get_base_url(self) -> str:
+        uipath_url = (
+            os.environ.get("UIPATH_URL")
+            or "https://cloud.uipath.com/dummyOrg/dummyTennant/"
+        )
+
+        uipath_url = uipath_url.rstrip("/")
+
+        return uipath_url

--- a/src/uipath/tracing/_traced.py
+++ b/src/uipath/tracing/_traced.py
@@ -1,0 +1,165 @@
+import inspect
+import json
+import logging
+from functools import wraps
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from ._otel_exporters import LlmOpsHttpExporter
+from ._utils import _SpanUtils
+
+logger = logging.getLogger(__name__)
+
+trace.set_tracer_provider(TracerProvider())
+trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(LlmOpsHttpExporter()))  # type: ignore
+tracer = trace.get_tracer(__name__)
+
+
+def wait_for_tracers():
+    """Wait for all tracers to finish."""
+    trace.get_tracer_provider().shutdown()  # type: ignore
+
+
+class TracedDecoratorRegistry:
+    """Registry for tracing decorators."""
+
+    _decorators: dict[str, Any] = {}
+    _active_decorator = "opentelemetry"
+
+    @classmethod
+    def register_decorator(cls, name, decorator_factory):
+        """Register a decorator factory function with a name."""
+        cls._decorators[name] = decorator_factory
+        cls._active_decorator = name
+        return cls
+
+    @classmethod
+    def get_decorator(cls):
+        """Get the currently active decorator factory."""
+        return cls._decorators.get(cls._active_decorator)
+
+
+def _opentelemetry_traced():
+    def decorator(func):
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(func.__name__) as span:
+                span.set_attribute("span_type", "function_call_sync")
+                span.set_attribute(
+                    "inputs",
+                    _SpanUtils.format_args_for_trace_json(
+                        inspect.signature(func), *args, **kwargs
+                    ),
+                )
+                try:
+                    result = func(*args, **kwargs)
+                    span.set_attribute(
+                        "output", json.dumps(result, default=str)
+                    )  # Record output
+                    return result
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(
+                        trace.status.Status(trace.status.StatusCode.ERROR, str(e))
+                    )
+                    raise
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(func.__name__) as span:
+                span.set_attribute("span_type", "function_call_async")
+                span.set_attribute(
+                    "inputs",
+                    _SpanUtils.format_args_for_trace_json(
+                        inspect.signature(func), *args, **kwargs
+                    ),
+                )
+                try:
+                    result = await func(*args, **kwargs)
+                    span.set_attribute(
+                        "output", json.dumps(result, default=str)
+                    )  # Record output
+                    return result
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(
+                        trace.status.Status(trace.status.StatusCode.ERROR, str(e))
+                    )
+                    raise
+
+        @wraps(func)
+        def generator_wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(func.__name__) as span:
+                span.set_attribute("span_type", "function_call_generator_sync")
+                span.set_attribute(
+                    "inputs",
+                    _SpanUtils.format_args_for_trace_json(
+                        inspect.signature(func), *args, **kwargs
+                    ),
+                )
+                outputs = []
+                try:
+                    for item in func(*args, **kwargs):
+                        outputs.append(item)
+                        span.add_event(f"Yielded: {item}")  # Add event for each yield
+                        yield item
+                    span.set_attribute(
+                        "output", json.dumps(outputs, default=str)
+                    )  # Record aggregated outputs
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(
+                        trace.status.Status(trace.status.StatusCode.ERROR, str(e))
+                    )
+                    raise
+
+        @wraps(func)
+        async def async_generator_wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(func.__name__) as span:
+                span.set_attribute("span_type", "function_call_generator_async")
+                span.set_attribute(
+                    "inputs",
+                    _SpanUtils.format_args_for_trace_json(
+                        inspect.signature(func), *args, **kwargs
+                    ),
+                )
+                outputs = []
+                try:
+                    async for item in func(*args, **kwargs):
+                        outputs.append(item)
+                        span.add_event(f"Yielded: {item}")  # Add event for each yield
+                        yield item
+                    span.set_attribute(
+                        "output", json.dumps(outputs, default=str)
+                    )  # Record aggregated outputs
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(
+                        trace.status.Status(trace.status.StatusCode.ERROR, str(e))
+                    )
+                    raise
+
+        if inspect.iscoroutinefunction(func):
+            return async_wrapper
+        elif inspect.isgeneratorfunction(func):
+            return generator_wrapper
+        elif inspect.isasyncgenfunction(func):
+            return async_generator_wrapper
+        else:
+            return sync_wrapper
+
+    return decorator
+
+
+def traced():
+    """Decorator that will trace function invocations."""
+    decorator_factory = TracedDecoratorRegistry.get_decorator()
+
+    if decorator_factory:
+        return decorator_factory()
+    else:
+        # Fallback to original implementation if no active decorator
+        return _opentelemetry_traced()

--- a/src/uipath/tracing/_utils.py
+++ b/src/uipath/tracing/_utils.py
@@ -1,0 +1,267 @@
+import inspect
+import json
+import logging
+import os
+import random
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from os import environ as env
+from typing import Any, Dict, Optional
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import StatusCode
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UiPathSpan:
+    """Represents a span in the UiPath tracing system."""
+
+    id: uuid.UUID
+    trace_id: uuid.UUID
+    name: str
+    attributes: str
+    parent_id: Optional[uuid.UUID] = None
+    start_time: str = field(default_factory=lambda: datetime.now().isoformat())
+    end_time: str = field(default_factory=lambda: datetime.now().isoformat())
+    status: int = 1
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat() + "Z")
+    updated_at: str = field(default_factory=lambda: datetime.now().isoformat() + "Z")
+    organization_id: Optional[str] = field(
+        default_factory=lambda: env.get("UIPATH_ORGANIZATION_ID", "")
+    )
+    tenant_id: Optional[str] = field(
+        default_factory=lambda: env.get("UIPATH_TENANT_ID", "")
+    )
+    expiry_time_utc: Optional[str] = None
+    folder_key: Optional[str] = field(
+        default_factory=lambda: env.get("UIPATH_FOLDER_KEY_XYZ", "")
+    )
+    source: Optional[str] = None
+    span_type: str = "Coded Agents"
+    process_key: Optional[str] = field(
+        default_factory=lambda: env.get("UIPATH_PROCESS_UUID")
+    )
+    job_key: Optional[str] = field(default_factory=lambda: env.get("UIPATH_JOB_KEY"))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the Span to a dictionary suitable for JSON serialization."""
+        return {
+            "Id": str(self.id),
+            "TraceId": str(self.trace_id),
+            "ParentId": str(self.parent_id) if self.parent_id else None,
+            "Name": self.name,
+            "StartTime": self.start_time,
+            "EndTime": self.end_time,
+            "Attributes": self.attributes,
+            "Status": self.status,
+            "CreatedAt": self.created_at,
+            "UpdatedAt": self.updated_at,
+            "OrganizationId": self.organization_id,
+            "TenantId": self.tenant_id,
+            "ExpiryTimeUtc": self.expiry_time_utc,
+            "FolderKey": self.folder_key,
+            "Source": self.source,
+            "SpanType": self.span_type,
+            "ProcessKey": self.process_key,
+            "JobKey": self.job_key,
+        }
+
+
+class _SpanUtils:
+    @staticmethod
+    def span_id_to_uuid4(span_id: int) -> uuid.UUID:
+        """Convert a 64-bit span ID to a valid UUID4 format.
+
+        Creates a UUID where:
+        - The 64 least significant bits contain the span ID
+        - The UUID version (bits 48-51) is set to 4
+        - The UUID variant (bits 64-65) is set to binary 10
+        """
+        # Generate deterministic high bits using the span_id as seed
+        temp_random = random.Random(span_id)
+        high_bits = temp_random.getrandbits(64)
+
+        # Combine high bits and span ID into a 128-bit integer
+        combined = (high_bits << 64) | span_id
+
+        # Set version to 4 (UUID4)
+        combined = (combined & ~(0xF << 76)) | (0x4 << 76)
+
+        # Set variant to binary 10
+        combined = (combined & ~(0x3 << 62)) | (2 << 62)
+
+        # Convert to hex string in UUID format
+        hex_str = format(combined, "032x")
+        return uuid.UUID(hex_str)
+
+    @staticmethod
+    def trace_id_to_uuid4(trace_id: int) -> uuid.UUID:
+        """Convert a 128-bit trace ID to a valid UUID4 format.
+
+        Modifies the trace ID to conform to UUID4 requirements:
+        - The UUID version (bits 48-51) is set to 4
+        - The UUID variant (bits 64-65) is set to binary 10
+        """
+        # Set version to 4 (UUID4)
+        uuid_int = (trace_id & ~(0xF << 76)) | (0x4 << 76)
+
+        # Set variant to binary 10
+        uuid_int = (uuid_int & ~(0x3 << 62)) | (2 << 62)
+
+        # Convert to hex string in UUID format
+        hex_str = format(uuid_int, "032x")
+        return uuid.UUID(hex_str)
+
+    @staticmethod
+    def otel_span_to_uipath_span(otel_span: ReadableSpan) -> UiPathSpan:
+        """Convert an OpenTelemetry span to a UiPathSpan."""
+        # Extract the context information from the OTel span
+        span_context = otel_span.get_span_context()
+
+        # OTel uses hexadecimal strings, we need to convert to UUID
+        trace_id = _SpanUtils.trace_id_to_uuid4(span_context.trace_id)
+        span_id = _SpanUtils.span_id_to_uuid4(span_context.span_id)
+
+        trace_id_str = os.environ.get("UIPATH_TRACE_ID")
+        if trace_id_str:
+            trace_id = uuid.UUID(trace_id_str)
+
+        # Get parent span ID if it exists
+        parent_id = None
+        if otel_span.parent is not None:
+            parent_id = _SpanUtils.span_id_to_uuid4(otel_span.parent.span_id)
+
+        # Map status
+        status = 1  # Default to OK
+        if otel_span.status.status_code == StatusCode.ERROR:
+            status = 2  # Error
+
+        # Convert attributes to a format compatible with UiPathSpan
+        attributes_dict: dict[str, Any] = (
+            dict(otel_span.attributes) if otel_span.attributes else {}
+        )
+
+        original_inputs = attributes_dict.get("inputs", None)
+        original_outputs = attributes_dict.get("outputs", None)
+
+        if original_inputs:
+            try:
+                if isinstance(original_inputs, str):
+                    json_inputs = json.loads(original_inputs)
+                    attributes_dict["inputs"] = json_inputs
+                else:
+                    attributes_dict["inputs"] = original_inputs
+            except Exception as e:
+                print(f"Error parsing inputs: {e}")
+                attributes_dict["inputs"] = str(original_inputs)
+
+        if original_outputs:
+            try:
+                if isinstance(original_outputs, str):
+                    json_outputs = json.loads(original_outputs)
+                    attributes_dict["outputs"] = json_outputs
+                else:
+                    attributes_dict["outputs"] = original_outputs
+            except Exception as e:
+                print(f"Error parsing outputs: {e}")
+                attributes_dict["outputs"] = str(original_outputs)
+
+        # Add events as additional attributes if they exist
+        if otel_span.events:
+            events_list = [
+                {
+                    "name": event.name,
+                    "timestamp": event.timestamp,
+                    "attributes": dict(event.attributes) if event.attributes else {},
+                }
+                for event in otel_span.events
+            ]
+            attributes_dict["events"] = events_list
+
+        # Add links as additional attributes if they exist
+        if hasattr(otel_span, "links") and otel_span.links:
+            links_list = [
+                {
+                    "trace_id": link.context.trace_id,
+                    "span_id": link.context.span_id,
+                    "attributes": dict(link.attributes) if link.attributes else {},
+                }
+                for link in otel_span.links
+            ]
+            attributes_dict["links"] = links_list
+
+        span_type_value = attributes_dict.get("span_type", "OpenTelemetry")
+        span_type = str(span_type_value)
+
+        # Create UiPathSpan from OpenTelemetry span
+        start_time = datetime.fromtimestamp(
+            (otel_span.start_time or 0) / 1e9
+        ).isoformat()
+
+        end_time_str = None
+        if otel_span.end_time is not None:
+            end_time_str = datetime.fromtimestamp(
+                (otel_span.end_time or 0) / 1e9
+            ).isoformat()
+        else:
+            end_time_str = datetime.now().isoformat()
+
+        return UiPathSpan(
+            id=span_id,
+            trace_id=trace_id,
+            parent_id=parent_id,
+            name=otel_span.name,
+            attributes=json.dumps(attributes_dict),
+            start_time=start_time,
+            end_time=end_time_str,
+            status=status,
+            span_type=span_type,
+        )
+
+    @staticmethod
+    def format_args_for_trace_json(
+        signature: inspect.Signature, *args: Any, **kwargs: Any
+    ) -> str:
+        """Return a JSON string of inputs from the function signature."""
+        result = _SpanUtils.format_args_for_trace(signature, *args, **kwargs)
+        return json.dumps(result, default=str)
+
+    @staticmethod
+    def format_args_for_trace(
+        signature: inspect.Signature, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
+        try:
+            """Return a dictionary of inputs from the function signature."""
+            # Create a parameter mapping by partially binding the arguments
+
+            parameter_binding = signature.bind_partial(*args, **kwargs)
+
+            # Fill in default values for any unspecified parameters
+            parameter_binding.apply_defaults()
+
+            # Extract the input parameters, skipping special Python parameters
+            result = {}
+            for name, value in parameter_binding.arguments.items():
+                # Skip class and instance references
+                if name in ("self", "cls"):
+                    continue
+
+                # Handle **kwargs parameters specially
+                param_info = signature.parameters.get(name)
+                if param_info and param_info.kind == inspect.Parameter.VAR_KEYWORD:
+                    # Flatten nested kwargs directly into the result
+                    if isinstance(value, dict):
+                        result.update(value)
+                else:
+                    # Regular parameter
+                    result[name] = value
+
+            return result
+        except Exception as e:
+            logger.warning(
+                f"Error formatting arguments for trace: {e}. Using args and kwargs directly."
+            )
+            return {"args": args, "kwargs": kwargs}

--- a/tests/tracing/test_span_utils.py
+++ b/tests/tracing/test_span_utils.py
@@ -1,0 +1,204 @@
+import inspect
+import json
+import os
+import uuid
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+from opentelemetry.sdk.trace import Span as OTelSpan
+from opentelemetry.trace import SpanContext, StatusCode
+
+from uipath.tracing._utils import UiPathSpan, _SpanUtils
+
+
+class TestUUIDMapper:
+    def test_trace_id_to_uuid4(self):
+        """Test that trace_id_to_uuid4 converts trace IDs to valid UUID4 format."""
+        trace_id = int("1234567890ABCDEF1234567890ABCDEF", 16)  # 128-bit trace ID
+
+        # Convert to UUID
+        uuid_obj = _SpanUtils.trace_id_to_uuid4(trace_id)
+
+        # Check that it's a valid UUID4
+        assert uuid_obj.version == 4
+        assert uuid_obj.variant == uuid.RFC_4122
+
+        # Check that the same trace_id always maps to the same UUID
+        uuid_obj2 = _SpanUtils.trace_id_to_uuid4(trace_id)
+        assert uuid_obj == uuid_obj2
+
+    def test_span_id_to_uuid4_deterministic(self):
+        """Test that span_id_to_uuid4 is deterministic for the same span_id."""
+        span_id = 0x1234567890ABCDEF  # 64-bit span ID
+
+        # Convert to UUID twice
+        uuid_obj1 = _SpanUtils.span_id_to_uuid4(span_id)
+        uuid_obj2 = _SpanUtils.span_id_to_uuid4(span_id)
+
+        # They should be the same
+        assert uuid_obj1 == uuid_obj2
+
+        # Check that it's a valid UUID4
+        assert uuid_obj1.version == 4
+        assert uuid_obj1.variant == uuid.RFC_4122
+
+    def test_span_id_to_uuid4_different_ids(self):
+        """Test that different span_ids map to different UUIDs."""
+        span_id1 = 0x1234567890ABCDEF  # 64-bit span ID
+        span_id2 = 0x2345678901BCDEF0  # Different 64-bit span ID
+
+        # Convert to UUIDs
+        uuid_obj1 = _SpanUtils.span_id_to_uuid4(span_id1)
+        uuid_obj2 = _SpanUtils.span_id_to_uuid4(span_id2)
+
+        # They should be different
+        assert uuid_obj1 != uuid_obj2
+
+        # But both should be valid UUID4
+        assert uuid_obj1.version == 4
+        assert uuid_obj1.variant == uuid.RFC_4122
+        assert uuid_obj2.version == 4
+        assert uuid_obj2.variant == uuid.RFC_4122
+
+
+class TestSpanUtils:
+    @patch.dict(
+        os.environ,
+        {
+            "UIPATH_ORGANIZATION_ID": "test-org",
+            "UIPATH_TENANT_ID": "test-tenant",
+            "UIPATH_FOLDER_KEY": "test-folder",
+            "UIPATH_PROCESS_UUID": "test-process",
+            "UIPATH_JOB_KEY": "test-job",
+        },
+    )
+    def test_otel_span_to_uipath_span(self):
+        # Create a mock OTel span
+        mock_span = Mock(spec=OTelSpan)
+
+        # Set span context
+        trace_id = 0x123456789ABCDEF0123456789ABCDEF0
+        span_id = 0x0123456789ABCDEF
+        mock_context = SpanContext(trace_id=trace_id, span_id=span_id, is_remote=False)
+        mock_span.get_span_context.return_value = mock_context
+
+        # Set span properties
+        mock_span.name = "test-span"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = {
+            "key1": "value1",
+            "key2": 123,
+            "span_type": "CustomSpanType",
+        }
+        mock_span.events = []
+        mock_span.links = []
+
+        # Set times
+        current_time_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = current_time_ns
+        mock_span.end_time = current_time_ns + 1000000  # 1ms later
+
+        # Convert to UiPath span
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+
+        # Verify the conversion
+        assert isinstance(uipath_span, UiPathSpan)
+        assert uipath_span.name == "test-span"
+        assert uipath_span.status == 1  # OK
+        assert uipath_span.span_type == "CustomSpanType"
+
+        # Verify attributes
+        attributes = json.loads(uipath_span.attributes)
+        assert attributes["key1"] == "value1"
+        assert attributes["key2"] == 123
+
+        # Test with error status
+        mock_span.status.status_code = StatusCode.ERROR
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        assert uipath_span.status == 2  # Error
+
+    @patch.dict(os.environ, {"UIPATH_TRACE_ID": "00000000-0000-4000-8000-000000000000"})
+    def test_otel_span_to_uipath_span_with_env_trace_id(self):
+        # Create a mock OTel span
+        mock_span = Mock(spec=OTelSpan)
+
+        # Set span context
+        trace_id = 0x123456789ABCDEF0123456789ABCDEF0
+        span_id = 0x0123456789ABCDEF
+        mock_context = SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=False,
+        )
+        mock_span.get_span_context.return_value = mock_context
+
+        # Set span properties
+        mock_span.name = "test-span"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = {}
+        mock_span.events = []
+        mock_span.links = []
+
+        # Set times
+        current_time_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = current_time_ns
+        mock_span.end_time = current_time_ns + 1000000  # 1ms later
+
+        # Convert to UiPath span
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+
+        # Verify the trace ID is taken from environment
+        assert str(uipath_span.trace_id) == "00000000-0000-4000-8000-000000000000"
+
+    def test_format_args_for_trace(self):
+        # Simple function signature
+        def func1(a, b, c=3):
+            pass
+
+        sig = inspect.signature(func1)
+        result = _SpanUtils.format_args_for_trace(sig, 1, 2)
+        assert result == {"a": 1, "b": 2, "c": 3}
+
+        # Test with kwargs
+        result = _SpanUtils.format_args_for_trace(sig, 1, c=4, b=5)
+        assert result == {"a": 1, "b": 5, "c": 4}
+
+        # Function with self parameter
+        class TestClass:
+            def method(self, x, y):
+                pass
+
+        sig = inspect.signature(TestClass.method)
+        result = _SpanUtils.format_args_for_trace(sig, TestClass(), 10, 20)
+        assert result == {"x": 10, "y": 20}
+
+        # Function with **kwargs
+        def func2(a, **kwargs):
+            pass
+
+        sig = inspect.signature(func2)
+        result = _SpanUtils.format_args_for_trace(sig, 1, b=2, c=3)
+        assert result == {"a": 1, "b": 2, "c": 3}
+
+    def test_format_args_for_trace_json(self):
+        def sample_func(a, b=None):
+            pass
+
+        sig = inspect.signature(sample_func)
+
+        # Test with simple args
+        json_result = _SpanUtils.format_args_for_trace_json(sig, 1, b="test")
+        parsed = json.loads(json_result)
+        assert parsed == {"a": 1, "b": "test"}
+
+        # Test with non-serializable object
+        class NonSerializable:
+            pass
+
+        json_result = _SpanUtils.format_args_for_trace_json(sig, 1, b=NonSerializable())
+        # Should not raise exception
+        parsed = json.loads(json_result)
+        assert parsed["a"] == 1
+        assert "b" in parsed  # The value will be a string representation

--- a/tests/tracing/test_traced.py
+++ b/tests/tracing/test_traced.py
@@ -1,0 +1,145 @@
+from asyncio import sleep
+from typing import List, Sequence
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+from uipath.tracing._traced import traced
+
+
+class InMemorySpanExporter(SpanExporter):
+    """An OpenTelemetry span exporter that stores spans in memory for testing."""
+
+    def __init__(self):
+        self.spans = []
+        self.is_shutdown = False
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        if self.is_shutdown:
+            return SpanExportResult.FAILURE
+
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def get_exported_spans(self) -> List[ReadableSpan]:
+        return self.spans
+
+    def clear_exported_spans(self) -> None:
+        self.spans = []
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return not self.is_shutdown
+
+    def shutdown(self) -> None:
+        self.is_shutdown = True
+
+
+@pytest.fixture
+def setup_tracer():
+    # Setup InMemorySpanExporter and TracerProvider
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    trace.set_tracer_provider(provider)
+    trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(exporter))  # type: ignore
+
+    yield exporter, provider
+
+
+def test_traced_sync_function(setup_tracer):
+    exporter, provider = setup_tracer
+
+    @traced()
+    def sample_function(x, y):
+        return x + y
+
+    result = sample_function(2, 3)
+    assert result == 5
+
+    provider.shutdown()  # Ensure spans are flushed
+    spans = exporter.get_exported_spans()
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "sample_function"
+    assert span.attributes["span_type"] == "function_call_sync"
+    assert "inputs" in span.attributes
+    assert "output" in span.attributes
+    assert span.attributes["output"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_traced_async_function(setup_tracer):
+    exporter, provider = setup_tracer
+
+    @traced()
+    async def sample_async_function(x, y):
+        return x * y
+
+    result = await sample_async_function(2, 3)
+    assert result == 6
+
+    provider.shutdown()  # Ensure spans are flushed
+
+    await sleep(1)
+    spans = exporter.get_exported_spans()
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "sample_async_function"
+    assert span.attributes["span_type"] == "function_call_async"
+    assert "inputs" in span.attributes
+    assert "output" in span.attributes
+    assert span.attributes["output"] == "6"
+
+
+def test_traced_generator_function(setup_tracer):
+    exporter, provider = setup_tracer
+
+    @traced()
+    def sample_generator_function(n):
+        for i in range(n):
+            yield i
+
+    results = list(sample_generator_function(3))
+    assert results == [0, 1, 2]
+
+    provider.shutdown()  # Ensure spans are flushed
+    spans = exporter.get_exported_spans()
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "sample_generator_function"
+    assert span.attributes["span_type"] == "function_call_generator_sync"
+    assert "inputs" in span.attributes
+    assert "output" in span.attributes
+    assert span.attributes["output"] == "[0, 1, 2]"
+
+
+@pytest.mark.asyncio
+async def test_traced_async_generator_function(setup_tracer):
+    exporter, provider = setup_tracer
+
+    @traced()
+    async def sample_async_generator_function(n):
+        for i in range(n):
+            yield i
+
+    results = [item async for item in sample_async_generator_function(3)]
+    assert results == [0, 1, 2]
+
+    provider.shutdown()  # Ensure spans are flushed
+    spans = exporter.get_exported_spans()
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "sample_async_generator_function"
+    assert span.attributes["span_type"] == "function_call_generator_async"
+    assert "inputs" in span.attributes
+    assert "output" in span.attributes
+    assert span.attributes["output"] == "[0, 1, 2]"

--- a/uv.lock
+++ b/uv.lock
@@ -436,6 +436,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998 },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -677,6 +689,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971 },
 ]
 
 [[package]]
@@ -1434,6 +1458,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/19/b8f0347090a649dce55a008ec54ac6abb50553a06508cdb5e7abb2813e99/openai-1.71.0.tar.gz", hash = "sha256:52b20bb990a1780f9b0b8ccebac93416343ebd3e4e714e3eff730336833ca207", size = 409926 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/f7/049e85faf6a000890e5ca0edca8e9183f8a43c9e7bba869cad871da0caba/openai-1.71.0-py3-none-any.whl", hash = "sha256:e1c643738f1fff1af52bce6ef06a7716c95d089281e7011777179614f32937aa", size = 598975 },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.32.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "importlib-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/40/2359245cd33641c2736a0136a50813352d72f3fc209de28fb226950db4a1/opentelemetry_api-1.32.1.tar.gz", hash = "sha256:a5be71591694a4d9195caf6776b055aa702e964d961051a0715d05f8632c32fb", size = 64138 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/f2/89ea3361a305466bc6460a532188830351220b5f0851a5fa133155c16eca/opentelemetry_api-1.32.1-py3-none-any.whl", hash = "sha256:bbd19f14ab9f15f0e85e43e6a958aa4cb1f36870ee62b7fd205783a112012724", size = 65287 },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.32.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/65/2069caef9257fae234ca0040d945c741aa7afbd83a7298ee70fc0bc6b6f4/opentelemetry_sdk-1.32.1.tar.gz", hash = "sha256:8ef373d490961848f525255a42b193430a0637e064dd132fd2a014d94792a092", size = 161044 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/00/d3976cdcb98027aaf16f1e980e54935eb820872792f0eaedd4fd7abb5964/opentelemetry_sdk-1.32.1-py3-none-any.whl", hash = "sha256:bba37b70a08038613247bc42beee5a81b0ddca422c7d7f1b097b32bf1c7e2f17", size = 118989 },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.53b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/b6/3c56e22e9b51bcb89edab30d54830958f049760bbd9ab0a759cece7bca88/opentelemetry_semantic_conventions-0.53b1.tar.gz", hash = "sha256:4c5a6fede9de61211b2e9fc1e02e8acacce882204cd770177342b6a3be682992", size = 114350 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6b/a8fb94760ef8da5ec283e488eb43235eac3ae7514385a51b6accf881e671/opentelemetry_semantic_conventions-0.53b1-py3-none-any.whl", hash = "sha256:21df3ed13f035f8f3ea42d07cbebae37020367a53b47f1ebee3b10a381a00208", size = 188443 },
 ]
 
 [[package]]
@@ -2325,6 +2389,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pytest-asyncio" },
     { name = "python-dotenv" },
@@ -2359,6 +2424,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.8" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.32.1" },
     { name = "pydantic", specifier = ">=2.11.1" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -2466,6 +2532,70 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/d1/1daec934997e8b160040c78d7b31789f19b122110a75eca3d4e8da0049e1/wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984", size = 53307 },
+    { url = "https://files.pythonhosted.org/packages/1b/7b/13369d42651b809389c1a7153baa01d9700430576c81a2f5c5e460df0ed9/wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22", size = 38486 },
+    { url = "https://files.pythonhosted.org/packages/62/bf/e0105016f907c30b4bd9e377867c48c34dc9c6c0c104556c9c9126bd89ed/wrapt-1.17.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80dd7db6a7cb57ffbc279c4394246414ec99537ae81ffd702443335a61dbf3a7", size = 38777 },
+    { url = "https://files.pythonhosted.org/packages/27/70/0f6e0679845cbf8b165e027d43402a55494779295c4b08414097b258ac87/wrapt-1.17.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a6e821770cf99cc586d33833b2ff32faebdbe886bd6322395606cf55153246c", size = 83314 },
+    { url = "https://files.pythonhosted.org/packages/0f/77/0576d841bf84af8579124a93d216f55d6f74374e4445264cb378a6ed33eb/wrapt-1.17.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b60fb58b90c6d63779cb0c0c54eeb38941bae3ecf7a73c764c52c88c2dcb9d72", size = 74947 },
+    { url = "https://files.pythonhosted.org/packages/90/ec/00759565518f268ed707dcc40f7eeec38637d46b098a1f5143bff488fe97/wrapt-1.17.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b870b5df5b71d8c3359d21be8f0d6c485fa0ebdb6477dda51a1ea54a9b558061", size = 82778 },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/7cffd26b1c607b0b0c8a9ca9d75757ad7620c9c0a9b4a25d3f8a1480fafc/wrapt-1.17.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4011d137b9955791f9084749cba9a367c68d50ab8d11d64c50ba1688c9b457f2", size = 81716 },
+    { url = "https://files.pythonhosted.org/packages/7e/09/dccf68fa98e862df7e6a60a61d43d644b7d095a5fc36dbb591bbd4a1c7b2/wrapt-1.17.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1473400e5b2733e58b396a04eb7f35f541e1fb976d0c0724d0223dd607e0f74c", size = 74548 },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/067021fa3c8814952c5e228d916963c1115b983e21393289de15128e867e/wrapt-1.17.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3cedbfa9c940fdad3e6e941db7138e26ce8aad38ab5fe9dcfadfed9db7a54e62", size = 81334 },
+    { url = "https://files.pythonhosted.org/packages/4b/0d/9d4b5219ae4393f718699ca1c05f5ebc0c40d076f7e65fd48f5f693294fb/wrapt-1.17.2-cp310-cp310-win32.whl", hash = "sha256:582530701bff1dec6779efa00c516496968edd851fba224fbd86e46cc6b73563", size = 36427 },
+    { url = "https://files.pythonhosted.org/packages/72/6a/c5a83e8f61aec1e1aeef939807602fb880e5872371e95df2137142f5c58e/wrapt-1.17.2-cp310-cp310-win_amd64.whl", hash = "sha256:58705da316756681ad3c9c73fd15499aa4d8c69f9fd38dc8a35e06c12468582f", size = 38774 },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/a2aab2cbc7a665efab072344a8949a71081eed1d2f451f7f7d2b966594a2/wrapt-1.17.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58", size = 53308 },
+    { url = "https://files.pythonhosted.org/packages/50/ff/149aba8365fdacef52b31a258c4dc1c57c79759c335eff0b3316a2664a64/wrapt-1.17.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda", size = 38488 },
+    { url = "https://files.pythonhosted.org/packages/65/46/5a917ce85b5c3b490d35c02bf71aedaa9f2f63f2d15d9949cc4ba56e8ba9/wrapt-1.17.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438", size = 38776 },
+    { url = "https://files.pythonhosted.org/packages/ca/74/336c918d2915a4943501c77566db41d1bd6e9f4dbc317f356b9a244dfe83/wrapt-1.17.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a", size = 83776 },
+    { url = "https://files.pythonhosted.org/packages/09/99/c0c844a5ccde0fe5761d4305485297f91d67cf2a1a824c5f282e661ec7ff/wrapt-1.17.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000", size = 75420 },
+    { url = "https://files.pythonhosted.org/packages/b4/b0/9fc566b0fe08b282c850063591a756057c3247b2362b9286429ec5bf1721/wrapt-1.17.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6", size = 83199 },
+    { url = "https://files.pythonhosted.org/packages/9d/4b/71996e62d543b0a0bd95dda485219856def3347e3e9380cc0d6cf10cfb2f/wrapt-1.17.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b", size = 82307 },
+    { url = "https://files.pythonhosted.org/packages/39/35/0282c0d8789c0dc9bcc738911776c762a701f95cfe113fb8f0b40e45c2b9/wrapt-1.17.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662", size = 75025 },
+    { url = "https://files.pythonhosted.org/packages/4f/6d/90c9fd2c3c6fee181feecb620d95105370198b6b98a0770cba090441a828/wrapt-1.17.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72", size = 81879 },
+    { url = "https://files.pythonhosted.org/packages/8f/fa/9fb6e594f2ce03ef03eddbdb5f4f90acb1452221a5351116c7c4708ac865/wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317", size = 36419 },
+    { url = "https://files.pythonhosted.org/packages/47/f8/fb1773491a253cbc123c5d5dc15c86041f746ed30416535f2a8df1f4a392/wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3", size = 38773 },
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799 },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821 },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919 },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721 },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899 },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222 },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707 },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685 },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567 },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672 },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865 },
+    { url = "https://files.pythonhosted.org/packages/ce/b9/0ffd557a92f3b11d4c5d5e0c5e4ad057bd9eb8586615cdaf901409920b14/wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125", size = 53800 },
+    { url = "https://files.pythonhosted.org/packages/c0/ef/8be90a0b7e73c32e550c73cfb2fa09db62234227ece47b0e80a05073b375/wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998", size = 38824 },
+    { url = "https://files.pythonhosted.org/packages/36/89/0aae34c10fe524cce30fe5fc433210376bce94cf74d05b0d68344c8ba46e/wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5", size = 38920 },
+    { url = "https://files.pythonhosted.org/packages/3b/24/11c4510de906d77e0cfb5197f1b1445d4fec42c9a39ea853d482698ac681/wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8", size = 88690 },
+    { url = "https://files.pythonhosted.org/packages/71/d7/cfcf842291267bf455b3e266c0c29dcb675b5540ee8b50ba1699abf3af45/wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6", size = 80861 },
+    { url = "https://files.pythonhosted.org/packages/d5/66/5d973e9f3e7370fd686fb47a9af3319418ed925c27d72ce16b791231576d/wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc", size = 89174 },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/8e17bb70f6ae25dabc1aaf990f86824e4fd98ee9cadf197054e068500d27/wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2", size = 86721 },
+    { url = "https://files.pythonhosted.org/packages/6f/54/f170dfb278fe1c30d0ff864513cff526d624ab8de3254b20abb9cffedc24/wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b", size = 79763 },
+    { url = "https://files.pythonhosted.org/packages/4a/98/de07243751f1c4a9b15c76019250210dd3486ce098c3d80d5f729cba029c/wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504", size = 87585 },
+    { url = "https://files.pythonhosted.org/packages/f9/f0/13925f4bd6548013038cdeb11ee2cbd4e37c30f8bfd5db9e5a2a370d6e20/wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a", size = 36676 },
+    { url = "https://files.pythonhosted.org/packages/bf/ae/743f16ef8c2e3628df3ddfd652b7d4c555d12c84b53f3d8218498f4ade9b/wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845", size = 38871 },
+    { url = "https://files.pythonhosted.org/packages/3d/bc/30f903f891a82d402ffb5fda27ec1d621cc97cb74c16fea0b6141f1d4e87/wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192", size = 56312 },
+    { url = "https://files.pythonhosted.org/packages/8a/04/c97273eb491b5f1c918857cd26f314b74fc9b29224521f5b83f872253725/wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b", size = 40062 },
+    { url = "https://files.pythonhosted.org/packages/4e/ca/3b7afa1eae3a9e7fefe499db9b96813f41828b9fdb016ee836c4c379dadb/wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0", size = 40155 },
+    { url = "https://files.pythonhosted.org/packages/89/be/7c1baed43290775cb9030c774bc53c860db140397047cc49aedaf0a15477/wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306", size = 113471 },
+    { url = "https://files.pythonhosted.org/packages/32/98/4ed894cf012b6d6aae5f5cc974006bdeb92f0241775addad3f8cd6ab71c8/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb", size = 101208 },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/0c30f2301ca94e655e5e057012e83284ce8c545df7661a78d8bfca2fac7a/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681", size = 109339 },
+    { url = "https://files.pythonhosted.org/packages/75/56/05d000de894c4cfcb84bcd6b1df6214297b8089a7bd324c21a4765e49b14/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6", size = 110232 },
+    { url = "https://files.pythonhosted.org/packages/53/f8/c3f6b2cf9b9277fb0813418e1503e68414cd036b3b099c823379c9575e6d/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6", size = 100476 },
+    { url = "https://files.pythonhosted.org/packages/a7/b1/0bb11e29aa5139d90b770ebbfa167267b1fc548d2302c30c8f7572851738/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f", size = 106377 },
+    { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986 },
+    { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750 },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594 },
+]
+
+[[package]]
 name = "yarl"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2545,6 +2675,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/4a/4833a134c76af987eff3ce8cb71e42932234120e6be061eb2555061e8844/yarl-1.19.0-cp313-cp313-win32.whl", hash = "sha256:24e4c367ad69988a2283dd45ea88172561ca24b2326b9781e164eb46eea68345", size = 85878 },
     { url = "https://files.pythonhosted.org/packages/32/e9/59327daab3af8f79221638a8f0d11474d20f6a8fbc41e9da80c5ef69e688/yarl-1.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:0110f91c57ab43d1538dfa92d61c45e33b84df9257bd08fcfcda90cce931cbc9", size = 92448 },
     { url = "https://files.pythonhosted.org/packages/a4/06/ae25a353e8f032322df6f30d6bb1fc329773ee48e1a80a2196ccb8d1206b/yarl-1.19.0-py3-none-any.whl", hash = "sha256:a727101eb27f66727576630d02985d8a065d09cd0b5fcbe38a5793f71b2a97ef", size = 45990 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630 },
 ]
 
 [[package]]


### PR DESCRIPTION
I incorporated an LlmOpsHttpExporter that's compatible with OpenTelemetry, and a @traced() attribute that uses OpenTelemetry. Also, I've added a TracedDecoratorRegistry that I'll use in UiPath-langchain to replace the Langchain tracer instead of OpenTelemetry. Consequently, all @traced() methods will behave differently.

Add open telemetry tracing



Example

```python
from time import sleep
from opentelemetry import trace
import os

from aio_tracer import traced, wait_for_tracer
import asyncio

tracer = trace.get_tracer(__name__)

@traced()
def print_env_vars():
    for key, value in os.environ.items():
        print(f"{key}={value}")


@traced()
def sync_function(x, y):
    sleep(1)
    return x + y

@traced()
async def async_function(x, y):
    await asyncio.sleep(1)
    return x * y

@traced()
def generator_function(n):
    for i in range(n):
        yield i ** 2

@traced()
async def async_generator_function(n):
    for i in range(n):
        await asyncio.sleep(0.5)
        yield i ** 3

def main():
    main_inner()
    wait_for_tracer()
    
@traced()
def main_inner():
    print_env_vars()

    print("Sync function result:", sync_function(3, 4))

    with tracer.start_as_current_span("foo") as span:
        with tracer.start_as_current_span("bar") as span2:
            print("Hello world!")
            for value in generator_function(5):
                print("Generator yielded:", value)
    

@traced()
async def async_demo():
    print("Async function result:", await async_function(2, 5))
    async for value in async_generator_function(3):
        print("Async generator yielded:", value)

if __name__ == "__main__":
    main()

```