### PR TITLE
feat: filter app schema by FQN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.14"
+version = "2.0.15"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2393,7 +2393,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.11"
+version = "2.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# Why? 
- when creating an action, we need to fetch from apps the `appId` given the `appName`
- apps API may return multiple app schemas from different folders current user (or robot) has access to
- if `app_folder_path` is provided -> use it to match the folder FQN
Note ❗ This should be a temporary fix until apps adds folder filtering support on `deployed-action-apps-schemas` API
[Apps ticket](https://uipath.atlassian.net/jira/software/c/projects/APPS/issues/APPS-28791?filter=reportedbyme&jql=project%20%3D%20%22APPS%22%20AND%20reporter%20IN%20%28currentUser%28%29%29%20ORDER%20BY%20created%20DESC) 