### PR TITLE
feat: add packed files settings to uipath.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.16"
+version = "2.0.17"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2392,7 +2392,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.16"
+version = "2.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Configurable files & file extensions inclusion lists for `uipath pack`:

`uipath.json`:

```json
{
    "settings":{
      "filesIncluded": [
        "github-mcp-server"
      ],
      "fileExtensionsIncluded": [
        "go"
      ]
    }
}
```