### PR TITLE
feat: filter app schemas by deployment name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.31"
+version = "2.2.32"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/platform/action_center/_tasks_service.py
+++ b/src/uipath/platform/action_center/_tasks_service.py
@@ -131,7 +131,7 @@ def _retrieve_app_key_spec(app_name: str) -> RequestSpec:
     return RequestSpec(
         method="GET",
         endpoint=Endpoint("/apps_/default/api/v1/default/deployed-action-apps-schemas"),
-        params={"search": app_name},
+        params={"search": app_name, "filterByDeploymentTitle": "true"},
         headers={HEADER_TENANT_ID: tenant_id},
     )
 

--- a/tests/resource_overrides/test_resource_overrides.py
+++ b/tests/resource_overrides/test_resource_overrides.py
@@ -84,7 +84,7 @@ class TestResourceOverrides:
         # Mock Actions API - need to mock app retrieval first
         # First mock the app schema retrieval
         httpx_mock.add_response(
-            url=f"{org_scoped_base_url}/apps_/default/api/v1/default/deployed-action-apps-schemas?search=Overwritten App Name",
+            url=f"{org_scoped_base_url}/apps_/default/api/v1/default/deployed-action-apps-schemas?search=Overwritten App Name&filterByDeploymentTitle=true",
             method="GET",
             json={
                 "deployed": [

--- a/tests/sdk/services/test_actions_service.py
+++ b/tests/sdk/services/test_actions_service.py
@@ -136,7 +136,7 @@ class TestTasksService:
         monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
 
         httpx_mock.add_response(
-            url=f"{base_url}{org}/apps_/default/api/v1/default/deployed-action-apps-schemas?search=test-app",
+            url=f"{base_url}{org}/apps_/default/api/v1/default/deployed-action-apps-schemas?search=test-app&filterByDeploymentTitle=true",
             status_code=200,
             json={
                 "deployed": [

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.31"
+version = "2.2.32"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
-  filter app schemas by deployment name

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.54.dev1003221149",

  # Any version from PR
  "uipath>=2.1.54.dev1003220000,<2.1.54.dev1003230000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.32.dev1003223412",

  # Any version from PR
  "uipath>=2.2.32.dev1003220000,<2.2.32.dev1003230000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.2.32.dev1003220000,<2.2.32.dev1003230000",
]
```
<!-- DEV_PACKAGE_END -->