### PR TITLE
Attachments: support endpoints in sdk

### DIFF
--- a/docs/core/attachments.md
+++ b/docs/core/attachments.md
@@ -1,0 +1,86 @@
+# Attachments Service
+
+The `AttachmentsService` provides methods to upload, download, and delete attachments in UiPath Orchestrator. Attachments are files that can be associated with jobs, processes, or other entities, and are managed via the Orchestrator API.
+
+> **Reference:** [UiPath Orchestrator Attachments API](https://docs.uipath.com/orchestrator/reference/api-attachments)
+
+## Features
+- Upload files or in-memory content as attachments
+- Download attachments to local files
+- Delete attachments
+- Both synchronous and asynchronous methods
+
+## Usage
+
+### Instantiating the Service
+
+The `AttachmentsService` is available as a property on the main `UiPath` client:
+
+```python
+from uipath import UiPath
+
+client = UiPath()
+attachments = client.attachments
+```
+
+### Uploading an Attachment
+
+You can upload a file from disk or from memory:
+
+```python
+# Upload from file
+attachment_key = client.attachments.upload(
+    name="document.pdf",
+    source_path="/path/to/document.pdf",
+)
+
+# Upload from memory
+attachment_key = client.attachments.upload(
+    name="notes.txt",
+    content="Some text content",
+)
+```
+
+#### Async Example
+```python
+attachment_key = await client.attachments.upload_async(
+    name="notes.txt",
+    content="Some text content",
+)
+```
+
+### Downloading an Attachment
+
+```python
+attachment_name = client.attachments.download(
+    key=attachment_key,
+    destination_path="/path/to/save/document.pdf",
+)
+```
+
+#### Async Example
+```python
+attachment_name = await client.attachments.download_async(
+    key=attachment_key,
+    destination_path="/path/to/save/document.pdf",
+)
+```
+
+### Deleting an Attachment
+
+```python
+client.attachments.delete(key=attachment_key)
+```
+
+#### Async Example
+```python
+await client.attachments.delete_async(key=attachment_key)
+```
+
+## Error Handling
+
+All methods raise exceptions on failure. See the SDK error handling documentation for details.
+
+## See Also
+- [UiPath Orchestrator Attachments API](https://docs.uipath.com/orchestrator/reference/api-attachments)
+- [Jobs Service](./jobs.md) for listing attachments associated with jobs. 

--- a/src/uipath/_services/__init__.py
+++ b/src/uipath/_services/__init__.py
@@ -1,6 +1,7 @@
 from .actions_service import ActionsService
 from .api_client import ApiClient
 from .assets_service import AssetsService
+from .attachments_service import AttachmentsService
 from .buckets_service import BucketsService
 from .connections_service import ConnectionsService
 from .context_grounding_service import ContextGroundingService
@@ -13,6 +14,7 @@ from .queues_service import QueuesService
 __all__ = [
     "ActionsService",
     "AssetsService",
+    "AttachmentsService",
     "BucketsService",
     "ConnectionsService",
     "ContextGroundingService",

--- a/src/uipath/_services/attachments_service.py
+++ b/src/uipath/_services/attachments_service.py
@@ -1,0 +1,595 @@
+import uuid
+from typing import Any, Dict, Optional, Union, overload
+
+from httpx import request
+
+from .._config import Config
+from .._execution_context import ExecutionContext
+from .._folder_context import FolderContext
+from .._utils import Endpoint, RequestSpec, header_folder
+from ..tracing._traced import traced
+from ._base_service import BaseService
+
+
+def _upload_attachment_input_processor(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """Process attachment upload inputs to avoid logging large content."""
+    processed_inputs = inputs.copy()
+    if "source_path" in processed_inputs:
+        processed_inputs["source_path"] = f"<File at {processed_inputs['source_path']}>"
+    if "content" in processed_inputs:
+        if isinstance(processed_inputs["content"], str):
+            processed_inputs["content"] = "<Redacted String Content>"
+        else:
+            processed_inputs["content"] = "<Redacted Binary Content>"
+    return processed_inputs
+
+
+class AttachmentsService(FolderContext, BaseService):
+    """Service for managing UiPath attachments.
+
+    Attachments allow you to upload and download files to be used within UiPath
+    processes, actions, and other UiPath services.
+
+    Reference: https://docs.uipath.com/orchestrator/reference/api-attachments
+    """
+
+    def __init__(self, config: Config, execution_context: ExecutionContext) -> None:
+        super().__init__(config=config, execution_context=execution_context)
+
+    @traced(name="attachments_download", run_type="uipath")
+    def download(
+        self,
+        *,
+        key: uuid.UUID,
+        destination_path: str,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> str:
+        """Download an attachment.
+
+        This method downloads an attachment from UiPath to a local file.
+
+        Args:
+            key (uuid.UUID): The key of the attachment to download.
+            destination_path (str): The local path where the attachment will be saved.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Returns:
+            str: The name of the downloaded attachment.
+
+        Raises:
+            Exception: If the download fails.
+
+        Examples:
+            ```python
+            from uipath import UiPath
+
+            client = UiPath()
+
+            attachment_name = client.attachments.download(
+                key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000"),
+                destination_path="path/to/save/document.pdf"
+            )
+            print(f"Downloaded attachment: {attachment_name}")
+            ```
+        """
+        spec = self._retrieve_download_uri_spec(
+            key=key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        result = self.request(
+            spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            headers=spec.headers,
+        ).json()
+
+        # Get the attachment name
+        attachment_name = result["Name"]
+
+        download_uri = result["BlobFileAccess"]["Uri"]
+        headers = {
+            key: value
+            for key, value in zip(
+                result["BlobFileAccess"]["Headers"]["Keys"],
+                result["BlobFileAccess"]["Headers"]["Values"],
+                strict=False,
+            )
+        }
+
+        with open(destination_path, "wb") as file:
+            if result["BlobFileAccess"]["RequiresAuth"]:
+                file_content = self.request(
+                    "GET", download_uri, headers=headers
+                ).content
+            else:
+                file_content = request("GET", download_uri, headers=headers).content
+            file.write(file_content)
+
+        return attachment_name
+
+    @traced(name="attachments_download", run_type="uipath")
+    async def download_async(
+        self,
+        *,
+        key: uuid.UUID,
+        destination_path: str,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> str:
+        """Download an attachment asynchronously.
+
+        This method asynchronously downloads an attachment from UiPath to a local file.
+
+        Args:
+            key (uuid.UUID): The key of the attachment to download.
+            destination_path (str): The local path where the attachment will be saved.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Returns:
+            str: The name of the downloaded attachment.
+
+        Raises:
+            Exception: If the download fails.
+
+        Examples:
+            ```python
+            import asyncio
+            from uipath import UiPath
+
+            client = UiPath()
+
+            async def main():
+                attachment_name = await client.attachments.download_async(
+                    key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000"),
+                    destination_path="path/to/save/document.pdf"
+                )
+                print(f"Downloaded attachment: {attachment_name}")
+            ```
+        """
+        spec = self._retrieve_download_uri_spec(
+            key=key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        result = (
+            await self.request_async(
+                spec.method,
+                url=spec.endpoint,
+                params=spec.params,
+                headers=spec.headers,
+            )
+        ).json()
+
+        # Get the attachment name
+        attachment_name = result["Name"]
+
+        download_uri = result["BlobFileAccess"]["Uri"]
+        headers = {
+            key: value
+            for key, value in zip(
+                result["BlobFileAccess"]["Headers"]["Keys"],
+                result["BlobFileAccess"]["Headers"]["Values"],
+                strict=False,
+            )
+        }
+
+        with open(destination_path, "wb") as file:
+            if result["BlobFileAccess"]["RequiresAuth"]:
+                response = await self.request_async(
+                    "GET", download_uri, headers=headers
+                )
+                file.write(response.content)
+            else:
+                file.write(request("GET", download_uri, headers=headers).content)
+
+        return attachment_name
+
+    @overload
+    def upload(
+        self,
+        *,
+        name: str,
+        content: Union[str, bytes],
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> uuid.UUID: ...
+
+    @overload
+    def upload(
+        self,
+        *,
+        name: str,
+        source_path: str,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> uuid.UUID: ...
+
+    @traced(
+        name="attachments_upload",
+        run_type="uipath",
+        input_processor=_upload_attachment_input_processor,
+    )
+    def upload(
+        self,
+        *,
+        name: str,
+        content: Optional[Union[str, bytes]] = None,
+        source_path: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> uuid.UUID:
+        """Upload a file or content to UiPath as an attachment.
+
+        This method uploads content to UiPath and makes it available as an attachment.
+        You can either provide a file path or content in memory.
+
+        Args:
+            name (str): The name of the attachment file.
+            content (Optional[Union[str, bytes]]): The content to upload (string or bytes).
+            source_path (Optional[str]): The local path of the file to upload.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Returns:
+            uuid.UUID: The UUID of the created attachment.
+
+        Raises:
+            ValueError: If neither content nor source_path is provided, or if both are provided.
+            Exception: If the upload fails.
+
+        Examples:
+            ```python
+            from uipath import UiPath
+
+            client = UiPath()
+
+            # Upload a file from disk
+            attachment_key = client.attachments.upload(
+                name="my-document.pdf",
+                source_path="path/to/local/document.pdf",
+            )
+            print(f"Uploaded attachment with key: {attachment_key}")
+
+            # Upload content from memory
+            attachment_key = client.attachments.upload(
+                name="notes.txt",
+                content="This is a text file content",
+            )
+            print(f"Uploaded attachment with key: {attachment_key}")
+            ```
+        """
+        # Validate input parameters
+        if not (content or source_path):
+            raise ValueError("Content or source_path is required")
+        if content and source_path:
+            raise ValueError("Content and source_path are mutually exclusive")
+
+        spec = self._create_attachment_and_retrieve_upload_uri_spec(
+            name=name,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        result = self.request(
+            spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            headers=spec.headers,
+            json=spec.json,
+        ).json()
+
+        # Get the ID from the response and convert to UUID
+        attachment_key = uuid.UUID(result["Id"])
+
+        upload_uri = result["BlobFileAccess"]["Uri"]
+        headers = {
+            key: value
+            for key, value in zip(
+                result["BlobFileAccess"]["Headers"]["Keys"],
+                result["BlobFileAccess"]["Headers"]["Values"],
+                strict=False,
+            )
+        }
+
+        if source_path:
+            # Upload from file
+            with open(source_path, "rb") as file:
+                if result["BlobFileAccess"]["RequiresAuth"]:
+                    self.request(
+                        "PUT", upload_uri, headers=headers, files={"file": file}
+                    )
+                else:
+                    request("PUT", upload_uri, headers=headers, files={"file": file})
+        else:
+            # Upload from memory
+            # Convert string to bytes if needed
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+
+            if result["BlobFileAccess"]["RequiresAuth"]:
+                self.request("PUT", upload_uri, headers=headers, content=content)
+            else:
+                request("PUT", upload_uri, headers=headers, content=content)
+
+        return attachment_key
+
+    @overload
+    async def upload_async(
+        self,
+        *,
+        name: str,
+        content: Union[str, bytes],
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> uuid.UUID: ...
+
+    @overload
+    async def upload_async(
+        self,
+        *,
+        name: str,
+        source_path: str,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> uuid.UUID: ...
+
+    @traced(
+        name="attachments_upload",
+        run_type="uipath",
+        input_processor=_upload_attachment_input_processor,
+    )
+    async def upload_async(
+        self,
+        *,
+        name: str,
+        content: Optional[Union[str, bytes]] = None,
+        source_path: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> uuid.UUID:
+        """Upload a file or content to UiPath as an attachment asynchronously.
+
+        This method asynchronously uploads content to UiPath and makes it available as an attachment.
+        You can either provide a file path or content in memory.
+
+        Args:
+            name (str): The name of the attachment file.
+            content (Optional[Union[str, bytes]]): The content to upload (string or bytes).
+            source_path (Optional[str]): The local path of the file to upload.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Returns:
+            uuid.UUID: The UUID of the created attachment.
+
+        Raises:
+            ValueError: If neither content nor source_path is provided, or if both are provided.
+            Exception: If the upload fails.
+
+        Examples:
+            ```python
+            import asyncio
+            from uipath import UiPath
+
+            client = UiPath()
+
+            async def main():
+                # Upload a file from disk
+                attachment_key = await client.attachments.upload_async(
+                    name="my-document.pdf",
+                    source_path="path/to/local/document.pdf",
+                )
+                print(f"Uploaded attachment with key: {attachment_key}")
+
+                # Upload content from memory
+                attachment_key = await client.attachments.upload_async(
+                    name="notes.txt",
+                    content="This is a text file content",
+                )
+                print(f"Uploaded attachment with key: {attachment_key}")
+            ```
+        """
+        # Validate input parameters
+        if not (content or source_path):
+            raise ValueError("Content or source_path is required")
+        if content and source_path:
+            raise ValueError("Content and source_path are mutually exclusive")
+
+        spec = self._create_attachment_and_retrieve_upload_uri_spec(
+            name=name,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        result = (
+            await self.request_async(
+                spec.method,
+                url=spec.endpoint,
+                params=spec.params,
+                headers=spec.headers,
+                json=spec.json,
+            )
+        ).json()
+
+        # Get the ID from the response and convert to UUID
+        attachment_key = uuid.UUID(result["Id"])
+
+        upload_uri = result["BlobFileAccess"]["Uri"]
+        headers = {
+            key: value
+            for key, value in zip(
+                result["BlobFileAccess"]["Headers"]["Keys"],
+                result["BlobFileAccess"]["Headers"]["Values"],
+                strict=False,
+            )
+        }
+
+        if source_path:
+            # Upload from file
+            with open(source_path, "rb") as file:
+                if result["BlobFileAccess"]["RequiresAuth"]:
+                    await self.request_async(
+                        "PUT", upload_uri, headers=headers, files={"file": file}
+                    )
+                else:
+                    request("PUT", upload_uri, headers=headers, files={"file": file})
+        else:
+            # Upload from memory
+            # Convert string to bytes if needed
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+
+            if result["BlobFileAccess"]["RequiresAuth"]:
+                await self.request_async(
+                    "PUT", upload_uri, headers=headers, content=content
+                )
+            else:
+                request("PUT", upload_uri, headers=headers, content=content)
+
+        return attachment_key
+
+    @traced(name="attachments_delete", run_type="uipath")
+    def delete(
+        self,
+        *,
+        key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> None:
+        """Delete an attachment.
+
+        This method deletes an attachment from UiPath.
+
+        Args:
+            key (uuid.UUID): The key of the attachment to delete.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Raises:
+            Exception: If the deletion fails.
+
+        Examples:
+            ```python
+            from uipath import UiPath
+
+            client = UiPath()
+
+            client.attachments.delete(
+                key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
+            )
+            print("Attachment deleted successfully")
+            ```
+        """
+        spec = self._delete_attachment_spec(
+            key=key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        self.request(
+            spec.method,
+            url=spec.endpoint,
+            headers=spec.headers,
+        )
+
+    @traced(name="attachments_delete", run_type="uipath")
+    async def delete_async(
+        self,
+        *,
+        key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> None:
+        """Delete an attachment asynchronously.
+
+        This method asynchronously deletes an attachment from UiPath.
+
+        Args:
+            key (uuid.UUID): The key of the attachment to delete.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Raises:
+            Exception: If the deletion fails.
+
+        Examples:
+            ```python
+            import asyncio
+            from uipath import UiPath
+
+            client = UiPath()
+
+            async def main():
+                await client.attachments.delete_async(
+                    key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
+                )
+                print("Attachment deleted successfully")
+            ```
+        """
+        spec = self._delete_attachment_spec(
+            key=key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        await self.request_async(
+            spec.method,
+            url=spec.endpoint,
+            headers=spec.headers,
+        )
+
+    @property
+    def custom_headers(self) -> Dict[str, str]:
+        """Return custom headers for API requests."""
+        return self.folder_headers
+
+    def _create_attachment_and_retrieve_upload_uri_spec(
+        self,
+        name: str,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="POST",
+            endpoint=Endpoint("/orchestrator_/odata/Attachments"),
+            json={
+                "Name": name,
+            },
+            headers={
+                **header_folder(folder_key, folder_path),
+            },
+        )
+
+    def _retrieve_download_uri_spec(
+        self,
+        key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="GET",
+            endpoint=Endpoint(f"/orchestrator_/odata/Attachments({key})"),
+            headers={
+                **header_folder(folder_key, folder_path),
+            },
+        )
+
+    def _delete_attachment_spec(
+        self,
+        key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="DELETE",
+            endpoint=Endpoint(f"/orchestrator_/odata/Attachments({key})"),
+            headers={
+                **header_folder(folder_key, folder_path),
+            },
+        )

--- a/src/uipath/_services/jobs_service.py
+++ b/src/uipath/_services/jobs_service.py
@@ -1,10 +1,12 @@
 import json
-from typing import Any, Dict, Optional, overload
+import uuid
+from typing import Any, Dict, List, Optional, overload
 
 from .._config import Config
 from .._execution_context import ExecutionContext
 from .._folder_context import FolderContext
 from .._utils import Endpoint, RequestSpec, header_folder
+from ..models import Attachment
 from ..models.job import Job
 from ..tracing._traced import traced
 from ._base_service import BaseService
@@ -264,4 +266,256 @@ class JobsService(FolderContext, BaseService):
             endpoint=Endpoint(
                 f"/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.GetByKey(identifier={job_key})"
             ),
+        )
+
+    @traced(name="jobs_list_attachments", run_type="uipath")
+    def list_attachments(
+        self,
+        *,
+        job_key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> List[Attachment]:
+        """List attachments associated with a specific job.
+
+        This method retrieves all attachments linked to a job by its key.
+
+        Args:
+            job_key (uuid.UUID): The key of the job to retrieve attachments for.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Returns:
+            List[Attachment]: A list of attachment objects associated with the job.
+
+        Raises:
+            Exception: If the retrieval fails.
+
+        Examples:
+            ```python
+            from uipath import UiPath
+
+            client = UiPath()
+
+            attachments = client.jobs.list_attachments(
+                job_key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
+            )
+            for attachment in attachments:
+                print(f"Attachment: {attachment.Name}, Key: {attachment.Key}")
+            ```
+        """
+        spec = self._list_job_attachments_spec(
+            job_key=job_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        response = self.request(
+            spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            headers=spec.headers,
+        ).json()
+
+        return [Attachment.model_validate(item) for item in response]
+
+    @traced(name="jobs_list_attachments", run_type="uipath")
+    async def list_attachments_async(
+        self,
+        *,
+        job_key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> List[Attachment]:
+        """List attachments associated with a specific job asynchronously.
+
+        This method asynchronously retrieves all attachments linked to a job by its key.
+
+        Args:
+            job_key (uuid.UUID): The key of the job to retrieve attachments for.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Returns:
+            List[Attachment]: A list of attachment objects associated with the job.
+
+        Raises:
+            Exception: If the retrieval fails.
+
+        Examples:
+            ```python
+            import asyncio
+            from uipath import UiPath
+
+            client = UiPath()
+
+            async def main():
+                attachments = await client.jobs.list_attachments_async(
+                    job_key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
+                )
+                for attachment in attachments:
+                    print(f"Attachment: {attachment.Name}, Key: {attachment.Key}")
+            ```
+        """
+        spec = self._list_job_attachments_spec(
+            job_key=job_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        response = (
+            await self.request_async(
+                spec.method,
+                url=spec.endpoint,
+                params=spec.params,
+                headers=spec.headers,
+            )
+        ).json()
+
+        return [Attachment.model_validate(item) for item in response]
+
+    @traced(name="jobs_link_attachment", run_type="uipath")
+    def link_attachment(
+        self,
+        *,
+        attachment_key: uuid.UUID,
+        job_key: uuid.UUID,
+        category: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> None:
+        """Link an attachment to a job.
+
+        This method links an existing attachment to a specific job.
+
+        Args:
+            attachment_key (uuid.UUID): The key of the attachment to link.
+            job_key (uuid.UUID): The key of the job to link the attachment to.
+            category (Optional[str]): Optional category for the attachment in the context of this job.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Raises:
+            Exception: If the link operation fails.
+
+        Examples:
+            ```python
+            from uipath import UiPath
+
+            client = UiPath()
+
+            client.jobs.link_attachment(
+                attachment_key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000"),
+                job_key=uuid.UUID("123e4567-e89b-12d3-a456-426614174001"),
+                category="Result"
+            )
+            print("Attachment linked to job successfully")
+            ```
+        """
+        spec = self._link_job_attachment_spec(
+            attachment_key=attachment_key,
+            job_key=job_key,
+            category=category,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        return self.request(
+            spec.method,
+            url=spec.endpoint,
+            headers=spec.headers,
+            json=spec.json,
+        )
+
+    @traced(name="jobs_link_attachment", run_type="uipath")
+    async def link_attachment_async(
+        self,
+        *,
+        attachment_key: uuid.UUID,
+        job_key: uuid.UUID,
+        category: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> None:
+        """Link an attachment to a job asynchronously.
+
+        This method asynchronously links an existing attachment to a specific job.
+
+        Args:
+            attachment_key (uuid.UUID): The key of the attachment to link.
+            job_key (uuid.UUID): The key of the job to link the attachment to.
+            category (Optional[str]): Optional category for the attachment in the context of this job.
+            folder_key (Optional[str]): The key of the folder. Override the default one set in the SDK config.
+            folder_path (Optional[str]): The path of the folder. Override the default one set in the SDK config.
+
+        Raises:
+            Exception: If the link operation fails.
+
+        Examples:
+            ```python
+            import asyncio
+            from uipath import UiPath
+
+            client = UiPath()
+
+            async def main():
+                await client.jobs.link_attachment_async(
+                    attachment_key=uuid.UUID("123e4567-e89b-12d3-a456-426614174000"),
+                    job_key=uuid.UUID("123e4567-e89b-12d3-a456-426614174001"),
+                    category="Result"
+                )
+                print("Attachment linked to job successfully")
+            ```
+        """
+        spec = self._link_job_attachment_spec(
+            attachment_key=attachment_key,
+            job_key=job_key,
+            category=category,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
+
+        return await self.request_async(
+            spec.method,
+            url=spec.endpoint,
+            headers=spec.headers,
+            json=spec.json,
+        )
+
+    def _list_job_attachments_spec(
+        self,
+        job_key: uuid.UUID,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="GET",
+            endpoint=Endpoint("/orchestrator_/api/JobAttachments/GetByJobKey"),
+            params={
+                "jobKey": job_key,
+            },
+            headers={
+                **header_folder(folder_key, folder_path),
+            },
+        )
+
+    def _link_job_attachment_spec(
+        self,
+        attachment_key: uuid.UUID,
+        job_key: uuid.UUID,
+        category: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="POST",
+            endpoint=Endpoint("/orchestrator_/api/JobAttachments/Post"),
+            json={
+                "attachmentId": str(attachment_key),
+                "jobKey": str(job_key),
+                "category": category,
+            },
+            headers={
+                **header_folder(folder_key, folder_path),
+            },
         )

--- a/src/uipath/_uipath.py
+++ b/src/uipath/_uipath.py
@@ -10,6 +10,7 @@ from ._services import (
     ActionsService,
     ApiClient,
     AssetsService,
+    AttachmentsService,
     BucketsService,
     ConnectionsService,
     ContextGroundingService,
@@ -68,6 +69,10 @@ class UiPath:
     @property
     def assets(self) -> AssetsService:
         return AssetsService(self._config, self._execution_context)
+
+    @property
+    def attachments(self) -> AttachmentsService:
+        return AttachmentsService(self._config, self._execution_context)
 
     @property
     def processes(self) -> ProcessesService:

--- a/src/uipath/models/__init__.py
+++ b/src/uipath/models/__init__.py
@@ -1,6 +1,7 @@
 from .action_schema import ActionSchema
 from .actions import Action
 from .assets import Asset, UserAsset
+from .attachment import Attachment
 from .buckets import Bucket
 from .connections import Connection, ConnectionToken
 from .context_grounding import ContextGroundingQueryResponse
@@ -26,6 +27,7 @@ from .queues import (
 __all__ = [
     "Action",
     "Asset",
+    "Attachment",
     "UserAsset",
     "ContextGroundingQueryResponse",
     "ContextGroundingIndex",

--- a/src/uipath/models/attachment.py
+++ b/src/uipath/models/attachment.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+import uuid
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Attachment(BaseModel):
+    """Model representing an attachment in UiPath.
+
+    Attachments can be associated with jobs in UiPath and contain binary files or documents.
+    """
+
+    model_config = ConfigDict(
+        validate_by_name=True,
+        validate_by_alias=True,
+        use_enum_values=True,
+        arbitrary_types_allowed=True,
+        extra="allow",
+        json_encoders={datetime: lambda v: v.isoformat() if v else None},
+    )
+
+    name: str = Field(alias="Name")
+    creation_time: Optional[datetime] = Field(default=None, alias="CreationTime")
+    last_modification_time: Optional[datetime] = Field(default=None, alias="LastModificationTime")
+    key: uuid.UUID = Field(alias="Key")

--- a/tests/sdk/services/test_attachments_service.py
+++ b/tests/sdk/services/test_attachments_service.py
@@ -1,0 +1,527 @@
+import json
+import os
+import uuid
+from typing import TYPE_CHECKING, Any, Dict
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from uipath._config import Config
+from uipath._execution_context import ExecutionContext
+from uipath._services.attachments_service import AttachmentsService
+from uipath._utils.constants import HEADER_USER_AGENT
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.fixture
+def service(
+    config: Config,
+    execution_context: ExecutionContext,
+    monkeypatch: "MonkeyPatch",
+) -> AttachmentsService:
+    """Fixture that provides a configured AttachmentsService instance for testing.
+
+    Args:
+        config: The Config fixture with test configuration settings.
+        execution_context: The ExecutionContext fixture with test execution context.
+        monkeypatch: PyTest MonkeyPatch fixture for environment modification.
+
+    Returns:
+        AttachmentsService: A configured instance of AttachmentsService.
+    """
+    monkeypatch.setenv("UIPATH_FOLDER_PATH", "test-folder-path")
+    return AttachmentsService(config=config, execution_context=execution_context)
+
+
+@pytest.fixture
+def temp_file(tmp_path: Any) -> str:
+    """Creates a temporary file for testing file uploads and downloads.
+
+    Args:
+        tmp_path: PyTest fixture providing a temporary directory.
+
+    Returns:
+        str: Path to the temporary test file.
+    """
+    file_path = os.path.join(tmp_path, "test_file.txt")
+    with open(file_path, "w") as f:
+        f.write("Test content")
+    return file_path
+
+
+@pytest.fixture
+def blob_uri_response() -> Dict[str, Any]:
+    """Provides a mock response for blob access requests.
+
+    Returns:
+        Dict[str, Any]: A mock API response with blob storage access details.
+    """
+    return {
+        "Id": "12345678-1234-1234-1234-123456789012",
+        "Name": "test_file.txt",
+        "BlobFileAccess": {
+            "Uri": "https://test-storage.com/test-container/test-blob",
+            "Headers": {
+                "Keys": ["x-ms-blob-type", "Content-Type"],
+                "Values": ["BlockBlob", "application/octet-stream"],
+            },
+            "RequiresAuth": False,
+        },
+    }
+
+
+class TestAttachmentsService:
+    """Test suite for the AttachmentsService class."""
+
+    def test_upload_with_file_path(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+        temp_file: str,
+        blob_uri_response: Dict[str, Any],
+    ) -> None:
+        """Test uploading an attachment from a file path.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+            temp_file: Temporary file fixture.
+            blob_uri_response: Mock response fixture for blob operations.
+        """
+        # Arrange
+        file_name = os.path.basename(temp_file)
+
+        # Mock the create attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments",
+            method="POST",
+            status_code=200,
+            json=blob_uri_response,
+        )
+
+        # Mock the blob upload
+        httpx_mock.add_response(
+            url=blob_uri_response["BlobFileAccess"]["Uri"],
+            method="PUT",
+            status_code=201,
+        )
+
+        # Act
+        attachment_key = service.upload(
+            name=file_name,
+            source_path=temp_file,
+        )
+
+        # Assert
+        assert attachment_key == uuid.UUID(blob_uri_response["Id"])
+
+        # Verify the requests
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+        # Check the first request to create the attachment
+        create_request = requests[0]
+        assert create_request.method == "POST"
+        assert (
+            create_request.url
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments"
+        )
+        assert json.loads(create_request.content) == {"Name": file_name}
+        assert HEADER_USER_AGENT in create_request.headers
+        assert create_request.headers[HEADER_USER_AGENT].startswith(
+            f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.AttachmentsService.upload/{version}"
+        )
+
+        # Check the second request to upload the content
+        upload_request = requests[1]
+        assert upload_request.method == "PUT"
+        assert upload_request.url == blob_uri_response["BlobFileAccess"]["Uri"]
+        assert "x-ms-blob-type" in upload_request.headers
+        assert upload_request.headers["x-ms-blob-type"] == "BlockBlob"
+
+    def test_upload_with_content(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+        blob_uri_response: Dict[str, Any],
+    ) -> None:
+        """Test uploading an attachment with in-memory content.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+            blob_uri_response: Mock response fixture for blob operations.
+        """
+        # Arrange
+        content = "Test content in memory"
+        file_name = "text_content.txt"
+
+        # Mock the create attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments",
+            method="POST",
+            status_code=200,
+            json=blob_uri_response,
+        )
+
+        # Mock the blob upload
+        httpx_mock.add_response(
+            url=blob_uri_response["BlobFileAccess"]["Uri"],
+            method="PUT",
+            status_code=201,
+        )
+
+        # Act
+        attachment_key = service.upload(
+            name=file_name,
+            content=content,
+        )
+
+        # Assert
+        assert attachment_key == uuid.UUID(blob_uri_response["Id"])
+
+        # Verify the requests
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+        # Check the first request to create the attachment
+        create_request = requests[0]
+        assert create_request.method == "POST"
+        assert (
+            create_request.url
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments"
+        )
+        assert json.loads(create_request.content) == {"Name": file_name}
+        assert HEADER_USER_AGENT in create_request.headers
+
+        # Check the second request to upload the content
+        upload_request = requests[1]
+        assert upload_request.method == "PUT"
+        assert upload_request.url == blob_uri_response["BlobFileAccess"]["Uri"]
+        assert "x-ms-blob-type" in upload_request.headers
+        assert upload_request.headers["x-ms-blob-type"] == "BlockBlob"
+        assert upload_request.content == content.encode("utf-8")
+
+    def test_upload_validation_errors(
+        self,
+        service: AttachmentsService,
+    ) -> None:
+        """Test validation errors when uploading attachments.
+
+        Args:
+            service: AttachmentsService fixture.
+        """
+        # Test missing both content and source_path
+        with pytest.raises(ValueError, match="Content or source_path is required"):
+            service.upload(name="test.txt")
+
+        # Test providing both content and source_path
+        with pytest.raises(
+            ValueError, match="Content and source_path are mutually exclusive"
+        ):
+            service.upload(
+                name="test.txt", content="test content", source_path="/path/to/file.txt"
+            )
+
+    @pytest.mark.asyncio
+    async def test_upload_async_with_content(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+        blob_uri_response: Dict[str, Any],
+    ) -> None:
+        """Test asynchronously uploading an attachment with in-memory content.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+            blob_uri_response: Mock response fixture for blob operations.
+        """
+        # Arrange
+        content = "Test content in memory"
+        file_name = "text_content.txt"
+
+        # Mock the create attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments",
+            method="POST",
+            status_code=200,
+            json=blob_uri_response,
+        )
+
+        # Mock the blob upload
+        httpx_mock.add_response(
+            url=blob_uri_response["BlobFileAccess"]["Uri"],
+            method="PUT",
+            status_code=201,
+        )
+
+        # Act
+        attachment_key = await service.upload_async(
+            name=file_name,
+            content=content,
+        )
+
+        # Assert
+        assert attachment_key == uuid.UUID(blob_uri_response["Id"])
+
+        # Verify the requests
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+        # Check the first request to create the attachment
+        create_request = requests[0]
+        assert create_request.method == "POST"
+        assert (
+            create_request.url
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments"
+        )
+        assert HEADER_USER_AGENT in create_request.headers
+
+    def test_download(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+        tmp_path: Any,
+        blob_uri_response: Dict[str, Any],
+    ) -> None:
+        """Test downloading an attachment.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+            tmp_path: Temporary directory fixture.
+            blob_uri_response: Mock response fixture for blob operations.
+        """
+        # Arrange
+        attachment_key = uuid.UUID("12345678-1234-1234-1234-123456789012")
+        destination_path = os.path.join(tmp_path, "downloaded_file.txt")
+        file_content = b"Downloaded file content"
+        expected_name = blob_uri_response["Name"]
+
+        # Mock the get attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})",
+            method="GET",
+            status_code=200,
+            json=blob_uri_response,
+        )
+
+        # Mock the blob download
+        httpx_mock.add_response(
+            url=blob_uri_response["BlobFileAccess"]["Uri"],
+            method="GET",
+            status_code=200,
+            content=file_content,
+        )
+
+        # Act
+        result = service.download(
+            key=attachment_key,
+            destination_path=destination_path,
+        )
+
+        # Assert
+        assert result == expected_name
+        assert os.path.exists(destination_path)
+        with open(destination_path, "rb") as f:
+            assert f.read() == file_content
+
+        # Verify the requests
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+        # Check the first request to get the attachment metadata
+        get_request = requests[0]
+        assert get_request.method == "GET"
+        assert (
+            get_request.url
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})"
+        )
+        assert HEADER_USER_AGENT in get_request.headers
+
+        # Check the second request to download the content
+        download_request = requests[1]
+        assert download_request.method == "GET"
+        assert download_request.url == blob_uri_response["BlobFileAccess"]["Uri"]
+
+    @pytest.mark.asyncio
+    async def test_download_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+        tmp_path: Any,
+        blob_uri_response: Dict[str, Any],
+    ) -> None:
+        """Test asynchronously downloading an attachment.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+            tmp_path: Temporary directory fixture.
+            blob_uri_response: Mock response fixture for blob operations.
+        """
+        # Arrange
+        attachment_key = uuid.UUID("12345678-1234-1234-1234-123456789012")
+        destination_path = os.path.join(tmp_path, "downloaded_file_async.txt")
+        file_content = b"Downloaded file content async"
+        expected_name = blob_uri_response["Name"]
+
+        # Mock the get attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})",
+            method="GET",
+            status_code=200,
+            json=blob_uri_response,
+        )
+
+        # Mock the blob download
+        httpx_mock.add_response(
+            url=blob_uri_response["BlobFileAccess"]["Uri"],
+            method="GET",
+            status_code=200,
+            content=file_content,
+        )
+
+        # Act
+        result = await service.download_async(
+            key=attachment_key,
+            destination_path=destination_path,
+        )
+
+        # Assert
+        assert result == expected_name
+        assert os.path.exists(destination_path)
+        with open(destination_path, "rb") as f:
+            assert f.read() == file_content
+
+    def test_delete(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        """Test deleting an attachment.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+        """
+        # Arrange
+        attachment_key = uuid.UUID("12345678-1234-1234-1234-123456789012")
+
+        # Mock the delete attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})",
+            method="DELETE",
+            status_code=204,
+        )
+
+        # Act
+        service.delete(key=attachment_key)
+
+        # Verify the request
+        request = httpx_mock.get_request()
+        assert request.method == "DELETE"
+        assert (
+            request.url
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})"
+        )
+        assert HEADER_USER_AGENT in request.headers
+        assert request.headers[HEADER_USER_AGENT].startswith(
+            f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.AttachmentsService.delete/{version}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: AttachmentsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        """Test asynchronously deleting an attachment.
+
+        Args:
+            httpx_mock: HTTPXMock fixture for mocking HTTP requests.
+            service: AttachmentsService fixture.
+            base_url: Base URL fixture for the API endpoint.
+            org: Organization fixture for the API path.
+            tenant: Tenant fixture for the API path.
+            version: Version fixture for the user agent header.
+        """
+        # Arrange
+        attachment_key = uuid.UUID("12345678-1234-1234-1234-123456789012")
+
+        # Mock the delete attachment endpoint
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})",
+            method="DELETE",
+            status_code=204,
+        )
+
+        # Act
+        await service.delete_async(key=attachment_key)
+
+        # Verify the request
+        request = httpx_mock.get_request()
+        assert request.method == "DELETE"
+        assert (
+            request.url
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Attachments({attachment_key})"
+        )
+        assert HEADER_USER_AGENT in request.headers
+        assert request.headers[HEADER_USER_AGENT].startswith(
+            f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.AttachmentsService.delete_async/{version}"
+        )


### PR DESCRIPTION
These endpoints were tensted and work fine. 

```
[2025-05-12 18:38:12,677][INFO] Attachment uploaded, key: 28f884a3-9cab-4ccd-c85f-08dd9164ced1
[2025-05-12 18:38:13,324][INFO] Downloaded attachment: ticket-classification-attachment_2
[2025-05-12 18:38:13,662][INFO] Attachments after upload: [Attachment(name='ticket-classification-attachment_2', organization_unit_id=1, tenant_id=1, creation_time=datetime.datetime(2025, 5, 12, 15, 38, 12, 530000, tzinfo=TzInfo(UTC)), last_modification_time=None, key=UUID('28f884a3-9cab-4ccd-c85f-08dd9164ced1'), LastModifierUserId=None, CreatorUserId=3405220, BlobFileAccess=None)]
[2025-05-12 18:38:14,491][INFO] Delete attachment result: None
[2025-05-12 18:38:14,835][INFO] Attachments after deletion: []
[2025-05-12 18:38:14,836][INFO] Attachment operations completed
```

TODO: 
1. Add endpoints to manually link job to attachments.  ✔️ 