### PR TITLE
cli: use http instead of https for cli auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.54"
+version = "2.0.55"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_auth/auth_config.json
+++ b/src/uipath/_cli/_auth/auth_config.json
@@ -1,6 +1,6 @@
 {
   "client_id": "36dea5b8-e8bb-423d-8e7b-c808df8f1c00",
-  "redirect_uri": "https://localhost:__PY_REPLACE_PORT__/oidc/login",
+  "redirect_uri": "http://localhost:__PY_REPLACE_PORT__/oidc/login",
   "scope": "offline_access OrchestratorApiUserAccess ConnectionService DataService DocumentUnderstanding EnterpriseContextService Directory JamJamApi LLMGateway LLMOps OMS RCS.FolderAuthorization",
   "port": 8104
 }

--- a/src/uipath/_cli/cli_auth.py
+++ b/src/uipath/_cli/cli_auth.py
@@ -8,7 +8,7 @@ import click
 from dotenv import load_dotenv
 
 from ..telemetry import track
-from ._auth._auth_server import HTTPSServer
+from ._auth._auth_server import HTTPServer
 from ._auth._oidc_utils import get_auth_config, get_auth_url
 from ._auth._portal_service import PortalService, select_tenant
 from ._auth._utils import update_auth_file, update_env_file
@@ -97,7 +97,7 @@ def auth(domain, force: None | bool = False):
             auth_url,
         )
 
-        server = HTTPSServer(port=auth_config["port"])
+        server = HTTPServer(port=auth_config["port"])
         token_data = server.start(state, code_verifier, domain)
 
         if token_data:


### PR DESCRIPTION
# Description

# Related
- https://github.com/UiPath/first-party-service-metadata/pull/2199

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-nightly==2.0.55.dev1003760342",

  # Any version from PR
  "uipath-nightly>=2.0.55.dev1003760000,<2.0.55.dev1003770000"
]
```