### PR TITLE
fix: proper relative url parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.55"
+version = "2.0.56"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_utils/_url.py
+++ b/src/uipath/_utils/_url.py
@@ -80,6 +80,23 @@ class UiPathUrl:
         return org_name, tenant_name
 
     def _is_relative_url(self, url: str) -> bool:
+        # Empty URLs are considered relative
+        if not url:
+            return True
+
         parsed = urlparse(url)
 
-        return parsed.hostname is None and parsed.path == url
+        # Protocol-relative URLs (starting with //) are not relative
+        if url.startswith("//"):
+            return False
+
+        # URLs with schemes are not relative (http:, https:, mailto:, etc.)
+        if parsed.scheme:
+            return False
+
+        # URLs with network locations are not relative
+        if parsed.netloc:
+            return False
+
+        # If we've passed all the checks, it's a relative URL
+        return True


### PR DESCRIPTION
The previous implementation would not take query string params into consideration:

```python
def _is_relative_url(self, url: str) -> bool:
        parsed = urlparse(url)
        print(f"url: {url}")
        print(f"parsed: {parsed}")
        return parsed.hostname is None and parsed.path == url
```
```cmd
[2025-05-18 09:00:59,576][INFO] url: mcp/mcp/gmaps-hosted/runtime/abort?runtimeId=c370591f-a68e-4103-9e4b-d02341fa6a35
[2025-05-18 09:00:59,576][INFO] parsed: ParseResult(scheme='', netloc='', path='mcp_/mcp/gmaps-hosted/runtime/abort', params='', query='runtimeId=c370591f-a68e-4103-9e4b-d02341fa6a35', fragment='')
[2025-05-18 09:00:59,576][INFO] self._is_relative_url(url): self._is_relative_url(url)=False
```