### PR TITLE
feat(build): move nightly to testpy

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -51,7 +51,6 @@ jobs:
 
           $PROJECT_NAME    = ($pyprojcontent | Select-String -Pattern '(?m)^\[(project|tool\.poetry)\][^\[]*?name\s*=\s*"([^"]*)"' -AllMatches).Matches[0].Groups[2].Value
           $CURRENT_VERSION = ($pyprojcontent | Select-String -Pattern '(?m)^\[(project|tool\.poetry)\][^\[]*?version\s*=\s*"([^"]*)"' -AllMatches).Matches[0].Groups[2].Value
-          $NIGHTLY_NAME = "$PROJECT_NAME-nightly"
 
 
           # Get PR number and run number with proper padding
@@ -70,10 +69,6 @@ jobs:
           # Update version in pyproject.toml
           (Get-Content pyproject.toml) -replace "version = `"$CURRENT_VERSION`"", "version = `"$DEV_VERSION`"" | Set-Content pyproject.toml
 
-          # Update project name in pyproject.toml
-          (Get-Content pyproject.toml) -replace "name = `"$PROJECT_NAME`"", "name = `"$NIGHTLY_NAME`"" | Set-Content pyproject.toml
-
-
           Write-Output "Package version set to $DEV_VERSION"
 
           $dependencyMessage = @"
@@ -85,11 +80,20 @@ jobs:
           [project]
           dependencies = [
             # Exact version:
-            "$NIGHTLY_NAME==$DEV_VERSION",
+            "$PROJECT_NAME==$DEV_VERSION",
 
             # Any version from PR
-            "$NIGHTLY_NAME>=$MIN_VERSION,<$MAX_VERSION"
+            "$PROJECT_NAME>=$MIN_VERSION,<$MAX_VERSION"
           ]
+
+          [[tool.uv.index]]
+          name = "testpypi"
+          url = "https://test.pypi.org/simple/"
+          publish-url = "https://test.pypi.org/legacy/"
+          explicit = true
+
+          [tool.uv.sources]
+          $PROJECT_NAME = { index = "testpypi" }
           ``````
           "@
 
@@ -130,6 +134,7 @@ jobs:
         run: uv build
 
       - name: Publish
-        run: uv publish
+        run: uv publish --index testpypi
         env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,9 @@ show_missing = true
 
 [tool.coverage.run]
 source = ["src"]
+
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true


### PR DESCRIPTION
# Description
move nightly to testpy

see results here https://test.pypi.org/project/uipath/#history

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.62.dev1003970405",

  # Any version from PR
  "uipath>=2.0.62.dev1003970000,<2.0.62.dev1003980000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```