### PR TITLE
Fix: Prevent multipart form data corruption in binary file uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.62"
+version = "2.0.63"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_services/attachments_service.py
+++ b/src/uipath/_services/attachments_service.py
@@ -384,13 +384,14 @@ class AttachmentsService(FolderContext, BaseService):
         if source_path:
             # Upload from file
             with open(source_path, "rb") as file:
+                file_content = file.read()
                 if result["BlobFileAccess"]["RequiresAuth"]:
                     self.request(
-                        "PUT", upload_uri, headers=headers, files={"file": file}
+                        "PUT", upload_uri, headers=headers, content=file_content
                     )
                 else:
                     with httpx.Client() as client:
-                        client.put(upload_uri, headers=headers, files={"file": file})
+                        client.put(upload_uri, headers=headers, content=file_content)
         else:
             # Upload from memory
             # Convert string to bytes if needed
@@ -519,13 +520,14 @@ class AttachmentsService(FolderContext, BaseService):
         if source_path:
             # Upload from file
             with open(source_path, "rb") as file:
+                file_content = file.read()
                 if result["BlobFileAccess"]["RequiresAuth"]:
                     await self.request_async(
-                        "PUT", upload_uri, headers=headers, files={"file": file}
+                        "PUT", upload_uri, headers=headers, content=file_content
                     )
                 else:
                     with httpx.Client() as client:
-                        client.put(upload_uri, headers=headers, files={"file": file})
+                        client.put(upload_uri, headers=headers, content=file_content)
         else:
             # Upload from memory
             # Convert string to bytes if needed


### PR DESCRIPTION
## Problem
Binary files (PNG, PDF, etc.) uploaded via `AttachmentsService.upload()` and `upload_async()` were being corrupted with HTTP multipart form data headers embedded in the file content.
### Example of corruption:
```
Content-Disposition: form-data; name="file"; filename="image.png"
Content-Type: image/png

‰PNG
[actual PNG data...]
```
This made uploaded images and other binary files unusable.
## Root Cause
The upload methods were using `files={"file": file}` parameter with `httpx`, which automatically wraps the file content in `multipart/form-data` encoding. UiPath's blob storage was incorrectly storing the entire multipart payload instead of extracting just the file content.
## Solution
Replace files=`{"file": file}` with `content=file_content` to send raw binary data without multipart wrapping.
### Changes Made

- `upload()`: Read file content into memory and use `content=` parameter
- `upload_async()`: Read file content into memory and use `content=` parameter