### PR TITLE
fix: add identity auth scope

### DIFF
--- a/src/uipath/_cli/_auth/auth_config.json
+++ b/src/uipath/_cli/_auth/auth_config.json
@@ -1,6 +1,6 @@
 {
   "client_id": "36dea5b8-e8bb-423d-8e7b-c808df8f1c00",
   "redirect_uri": "http://localhost:__PY_REPLACE_PORT__/oidc/login",
-  "scope": "offline_access OrchestratorApiUserAccess ConnectionService DataService DocumentUnderstanding EnterpriseContextService Directory JamJamApi LLMGateway LLMOps OMS RCS.FolderAuthorization",
+  "scope": "offline_access OrchestratorApiUserAccess IdentityServerApi ConnectionService DataService DocumentUnderstanding EnterpriseContextService Directory JamJamApi LLMGateway LLMOps OMS RCS.FolderAuthorization",
   "port": 8104
 }


### PR DESCRIPTION
### Summary

Adds `IdentityServerApi` scope to avoid token delegation and RCS API failures.



## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.72.dev1004000500",

  # Any version from PR
  "uipath>=2.0.72.dev1004000000,<2.0.72.dev1004010000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```