### PR TITLE
fix(tracer): lazy load tracer for traced

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.63"
+version = "2.0.64"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
# Description

- Lazy load tracer for traced
- add `register_current_span_provider` for custom trace context

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.64.dev1004020435",

  # Any version from PR
  "uipath>=2.0.64.dev1004020000,<2.0.64.dev1004030000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```