### PR TITLE
feat: add debug flag on run

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Attach",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      }
+    }
+  ]
+}

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -46,6 +46,27 @@ The `uipath init` command executes your `main.py` file to analyze its structure 
     :depth: 1
     :style: table
 
+/// tip
+For step-by-step debugging with breakpoints and variable inspection (supported from `2.0.66` onward):
+```console
+# Install debugpy package
+[uv] pip install debugpy
+# Run agent with debugging enabled
+uipath run [ENTRYPOINT] [INPUT] --debug
+```
+For vscode: add the [debug configuration](https://github.com/UiPath/uipath-python/blob/main/.vscode/launch.json) in your .vscode/launch.json file.
+Place breakpoints in your code where needed.
+Use the shortcut `F5`, or navigate to Run -> Start Debugging -> Python Debugger: Attach
+
+Upon starting the debugging process, one should see the following logs in terminal:
+```console
+🐛 Debug server started on port 5678
+📌 Waiting for debugger to attach...
+  - VS Code: Run -> Start Debugging -> Python Debugger: Attach
+✓  Debugger attached successfully!
+```
+///
+
 /// warning
 Depending on the shell you are using, it may be necessary to escape the input json:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.65"
+version = "2.0.66"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_utils/_debug.py
+++ b/src/uipath/_cli/_utils/_debug.py
@@ -1,0 +1,52 @@
+"""Debug utilities for UiPath CLI."""
+
+import os
+
+from ._console import ConsoleLogger
+
+console = ConsoleLogger()
+
+
+def setup_debugging(debug: bool, debug_port: int = 5678) -> bool:
+    """Setup debugging with debugpy if requested.
+
+    Args:
+        debug: Whether to enable debugging
+        debug_port: Port for the debug server (default: 5678)
+
+    Returns:
+        bool: True if debugging was setup successfully or not requested, False on error
+    """
+    if not debug:
+        return True
+
+    # Set environment variables to improve debugging
+    os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
+    os.environ["PYDEVD_USE_FRAME_EVAL"] = "NO"
+
+    # Try to import debugpy, log warning if not available
+    try:
+        import debugpy  # type: ignore[import-not-found]
+    except ImportError:
+        console.warning(
+            "debugpy not found, please install it and retry: '[uv] pip install debugpy'"
+        )
+        return False
+
+    # Configure debugpy for better breakpoint handling
+    try:
+        # Clear any existing listeners
+        debugpy.configure(subProcess=False)
+
+        debugpy.listen(debug_port)
+        console.info(f"🐛 Debug server started on port {debug_port}")
+        console.info("📌 Waiting for debugger to attach...")
+        console.info("  - VS Code: Run -> Start Debugging -> Python: Remote Attach")
+
+        debugpy.wait_for_client()
+        console.success("Debugger attached successfully!")
+
+        return True
+    except Exception as e:
+        console.error(f"Failed to start debug server on port {debug_port}: {str(e)}")
+        return False

--- a/uv.lock
+++ b/uv.lock
@@ -3111,7 +3111,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.65"
+version = "2.0.66"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
For step-by-step debugging with breakpoints and variable inspection (supported from `2.0.66` onward):
```console
# Install debugpy package
[uv] pip install debugpy
# Run agent with debugging enabled
uipath run [ENTRYPOINT] [INPUT] --debug
```
For vscode: add the [debug configuration](https://github.com/UiPath/uipath-python/blob/main/.vscode/launch.json) in your .vscode/launch.json file.
Place breakpoints in your code where needed.
Use the shortcut `F5`, or navigate to Run -> Start Debugging -> Python Debugger: Attach

Upon starting the debugging process, one should see the following logs in terminal:
```console
🐛 Debug server started on port 5678
📌 Waiting for debugger to attach...
  - VS Code: Run -> Start Debugging -> Python Debugger: Attach
✓  Debugger attached successfully!
```

## ToDo:

- ❌ add pycharm support `pydevd-pycharm` (delayed scope)