### PR TITLE
fix: use odata api for folder search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.66"
+version = "2.0.67"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_services/context_grounding_service.py
+++ b/src/uipath/_services/context_grounding_service.py
@@ -673,7 +673,7 @@ class ContextGroundingService(FolderContext, BaseService):
             )
 
         if folder_key is None:
-            raise ValueError("Folder key or folder path is required")
+            raise ValueError("ContextGrounding: Failed to resolve folder key")
 
         return folder_key
 
@@ -681,4 +681,6 @@ class ContextGroundingService(FolderContext, BaseService):
         try:
             return index.data_source.bucketName, index.data_source.folder  # type: ignore
         except AttributeError as e:
-            raise Exception("Cannot extract bucket data from index") from e
+            raise Exception(
+                "ContextGrounding: Cannot extract bucket data from index"
+            ) from e

--- a/src/uipath/_services/folder_service.py
+++ b/src/uipath/_services/folder_service.py
@@ -34,25 +34,19 @@ class FolderService(BaseService):
             url=spec.endpoint,
             params=spec.params,
         ).json()
-
-        return next(
-            (
-                item["Key"]
-                for item in response["PageItems"]
-                if item["FullyQualifiedName"] == folder_path
-            ),
-            None,
-        )
+        try:
+            return response["value"][0]["Key"]
+        except KeyError:
+            return None
 
     def _retrieve_spec(self, folder_path: str) -> RequestSpec:
         folder_name = folder_path.split("/")[-1]
         return RequestSpec(
             method="GET",
-            endpoint=Endpoint(
-                "orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser"
-            ),
+            endpoint=Endpoint("orchestrator_/odata/Folders"),
             params={
-                "searchText": folder_name,
-                "take": 1,
+                "$filter": f"DisplayName eq '{folder_name}'",
+                "$top": 1,
+                "$select": "Key",
             },
         )

--- a/tests/sdk/services/test_context_grounding_service.py
+++ b/tests/sdk/services/test_context_grounding_service.py
@@ -38,13 +38,12 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -68,13 +67,12 @@ class TestContextGroundingService:
         )
 
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -132,13 +130,12 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -162,13 +159,12 @@ class TestContextGroundingService:
         )
 
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -225,13 +221,12 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -285,13 +280,12 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },

--- a/tests/sdk/services/test_folder_service.py
+++ b/tests/sdk/services/test_folder_service.py
@@ -28,20 +28,19 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test_folder_path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
         )
 
         with pytest.warns(DeprecationWarning, match="Use retrieve_key instead"):
-            folder_key = service.retrieve_key_by_folder_path("test-folder-path")
+            folder_key = service.retrieve_key_by_folder_path("test_folder_path")
 
         assert folder_key == "test-folder-key"
 
@@ -52,7 +51,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1"
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test_folder_path%27&%24top=1&%24select=Key"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -71,9 +70,9 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key",
             status_code=200,
-            json={"PageItems": []},
+            json={},
         )
 
         with pytest.warns(DeprecationWarning, match="Use retrieve_key instead"):
@@ -88,7 +87,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&take=1"
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -107,13 +106,12 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
             status_code=200,
             json={
-                "PageItems": [
+                "value": [
                     {
                         "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -130,7 +128,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&take=1"
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -149,9 +147,9 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&take=1",
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key",
             status_code=200,
-            json={"PageItems": []},
+            json={},
         )
 
         folder_key = service.retrieve_key_by_folder_path("non-existent-folder")
@@ -165,7 +163,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&take=1"
+            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers

--- a/uv.lock
+++ b/uv.lock
@@ -3111,7 +3111,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.66"
+version = "2.0.67"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- use `odata/Folders` api instead of `FoldersNavigation` to compare exact equality between folder names
- update tests to use new api

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.67.dev1004070452",

  # Any version from PR
  "uipath>=2.0.67.dev1004070000,<2.0.67.dev1004080000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```