### PR TITLE
fix: rollback to FoldersNavigation usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.67"
+version = "2.0.68"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/tests/sdk/services/test_context_grounding_service.py
+++ b/tests/sdk/services/test_context_grounding_service.py
@@ -38,12 +38,13 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -67,12 +68,13 @@ class TestContextGroundingService:
         )
 
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -130,12 +132,13 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -159,12 +162,13 @@ class TestContextGroundingService:
         )
 
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -221,12 +225,13 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
@@ -280,17 +285,17 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
         )
-
         httpx_mock.add_response(
             url=f"{base_url}{org}{tenant}/ecs_/v2/indexes?$filter=Name eq 'test-index'&$expand=dataSource",
             status_code=200,

--- a/tests/sdk/services/test_folder_service.py
+++ b/tests/sdk/services/test_folder_service.py
@@ -28,19 +28,20 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test_folder_path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
         )
 
         with pytest.warns(DeprecationWarning, match="Use retrieve_key instead"):
-            folder_key = service.retrieve_key_by_folder_path("test_folder_path")
+            folder_key = service.retrieve_key_by_folder_path("test-folder-path")
 
         assert folder_key == "test-folder-key"
 
@@ -51,7 +52,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test_folder_path%27&%24top=1&%24select=Key"
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -70,9 +71,9 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&skip=0&take=20",
             status_code=200,
-            json={},
+            json={"PageItems": []},
         )
 
         with pytest.warns(DeprecationWarning, match="Use retrieve_key instead"):
@@ -87,7 +88,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key"
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&skip=0&take=20"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -106,18 +107,19 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
             json={
-                "value": [
+                "PageItems": [
                     {
                         "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
                     }
                 ]
             },
         )
 
-        folder_key = service.retrieve_key_by_folder_path("test-folder-path")
+        folder_key = service.retrieve_key(folder_path="test-folder-path")
 
         assert folder_key == "test-folder-key"
 
@@ -128,7 +130,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27test-folder-path%27&%24top=1&%24select=Key"
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -147,12 +149,12 @@ class TestFolderService:
         version: str,
     ) -> None:
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key",
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&skip=0&take=20",
             status_code=200,
-            json={},
+            json={"PageItems": []},
         )
 
-        folder_key = service.retrieve_key_by_folder_path("non-existent-folder")
+        folder_key = service.retrieve_key(folder_path="non-existent-folder")
 
         assert folder_key is None
 
@@ -163,7 +165,7 @@ class TestFolderService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/orchestrator_/odata/Folders?%24filter=DisplayName+eq+%27non-existent-folder%27&%24top=1&%24select=Key"
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=non-existent-folder&skip=0&take=20"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -171,3 +173,198 @@ class TestFolderService:
             sent_request.headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.FolderService.retrieve_key/{version}"
         )
+
+    def test_retrieve_key_found_on_second_page(
+        self,
+        httpx_mock: HTTPXMock,
+        service: FolderService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        """Test that retrieve_key can find a folder on subsequent pages through pagination."""
+        # First page - folder not found
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=target-folder&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": f"folder-key-{i}",
+                        "FullyQualifiedName": f"other-folder-{i}",
+                    }
+                    for i in range(20)  # Full page of 20 items, none matching
+                ]
+            },
+        )
+
+        # Second page - folder found
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=target-folder&skip=20&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "target-folder-key",
+                        "FullyQualifiedName": "target-folder",
+                    },
+                    {
+                        "Key": "another-folder-key",
+                        "FullyQualifiedName": "another-folder",
+                    },
+                ]
+            },
+        )
+
+        folder_key = service.retrieve_key(folder_path="target-folder")
+
+        assert folder_key == "target-folder-key"
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+        assert requests[0].method == "GET"
+        assert (
+            requests[0].url
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=target-folder&skip=0&take=20"
+        )
+
+        assert requests[1].method == "GET"
+        assert (
+            requests[1].url
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=target-folder&skip=20&take=20"
+        )
+
+    def test_retrieve_key_not_found_after_pagination(
+        self,
+        httpx_mock: HTTPXMock,
+        service: FolderService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        """Test that retrieve_key returns None when folder is not found after paginating through all results."""
+        # First page - full page, no match
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=missing-folder&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": f"folder-key-{i}",
+                        "FullyQualifiedName": f"other-folder-{i}",
+                    }
+                    for i in range(20)  # Full page of 20 items
+                ]
+            },
+        )
+
+        # Second page - no match
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=missing-folder&skip=20&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "final-folder-key",
+                        "FullyQualifiedName": "final-folder",
+                    },
+                ]
+            },
+        )
+
+        folder_key = service.retrieve_key(folder_path="missing-folder")
+
+        assert folder_key is None
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+
+        assert requests[0].method == "GET"
+        assert (
+            requests[0].url
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=missing-folder&skip=0&take=20"
+        )
+
+        assert requests[1].method == "GET"
+        assert (
+            requests[1].url
+            == f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=missing-folder&skip=20&take=20"
+        )
+
+    def test_retrieve_key_found_on_third_page(
+        self,
+        httpx_mock: HTTPXMock,
+        service: FolderService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        """Test that retrieve_key can find a folder on the third page through multiple pagination requests."""
+        # First page
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=deep-folder&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": f"folder-key-{i}",
+                        "FullyQualifiedName": f"page1-folder-{i}",
+                    }
+                    for i in range(20)
+                ]
+            },
+        )
+
+        # Second page
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=deep-folder&skip=20&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": f"folder-key-{i}",
+                        "FullyQualifiedName": f"page2-folder-{i}",
+                    }
+                    for i in range(20)
+                ]
+            },
+        )
+
+        # Third page - folder found
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=deep-folder&skip=40&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "some-other-key",
+                        "FullyQualifiedName": "some-other-folder",
+                    },
+                    {
+                        "Key": "deep-folder-key",
+                        "FullyQualifiedName": "deep-folder",
+                    },
+                ]
+            },
+        )
+
+        folder_key = service.retrieve_key(folder_path="deep-folder")
+
+        assert folder_key == "deep-folder-key"
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 3
+
+        expected_urls = [
+            f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=deep-folder&skip=0&take=20",
+            f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=deep-folder&skip=20&take=20",
+            f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=deep-folder&skip=40&take=20",
+        ]
+
+        for i, request in enumerate(requests):
+            assert request.method == "GET"
+            assert request.url == expected_urls[i]

--- a/uv.lock
+++ b/uv.lock
@@ -3111,7 +3111,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.67"
+version = "2.0.68"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
this PR rollbacks the changes added here:
https://github.com/UiPath/uipath-python/pull/407

# Improvements:
- take 20 folders at a time
- pagination support on client side

The current implementation is subject to change, after new API is added in Orchestrator.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.68.dev1004080453",

  # Any version from PR
  "uipath>=2.0.68.dev1004080000,<2.0.68.dev1004090000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```