### PR TITLE
Fix connection tokenType query param

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.71"
+version = "2.0.72"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_services/connections_service.py
+++ b/src/uipath/_services/connections_service.py
@@ -122,5 +122,5 @@ class ConnectionsService(BaseService):
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(f"/connections_/api/v1/Connections/{key}/token"),
-            params={"type": "direct"},
+            params={"tokenType": "direct"},
         )

--- a/tests/sdk/services/test_connections_service.py
+++ b/tests/sdk/services/test_connections_service.py
@@ -119,7 +119,7 @@ class TestConnectionsService:
     ) -> None:
         connection_key = "test-connection"
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?type=direct",
+            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?tokenType=direct",
             status_code=200,
             json={
                 "accessToken": "test-token",
@@ -142,7 +142,7 @@ class TestConnectionsService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?type=direct"
+            == f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?tokenType=direct"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers
@@ -163,7 +163,7 @@ class TestConnectionsService:
     ) -> None:
         connection_key = "test-connection"
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?type=direct",
+            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?tokenType=direct",
             status_code=200,
             json={
                 "accessToken": "test-token",
@@ -186,7 +186,7 @@ class TestConnectionsService:
         assert sent_request.method == "GET"
         assert (
             sent_request.url
-            == f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?type=direct"
+            == f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}/token?tokenType=direct"
         )
 
         assert HEADER_USER_AGENT in sent_request.headers


### PR DESCRIPTION
Fix:

The query string param for the connection token endpoint should be 'tokenType=direct' so we get a vendor token instead of an uipath token.