### PR TITLE
feat: pack uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.71"
+version = "2.0.72"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/cli_pack.py
+++ b/src/uipath/_cli/cli_pack.py
@@ -304,7 +304,7 @@ def pack_fn(projectName, description, entryPoints, version, authors, directory):
                                 with open(file_path, "r", encoding="latin-1") as f:
                                     z.writestr(f"content/{rel_path}", f.read())
 
-        optional_files = ["pyproject.toml", "README.md"]
+        optional_files = ["pyproject.toml", "README.md", "uv.lock"]
         for file in optional_files:
             file_path = os.path.join(directory, file)
             if os.path.exists(file_path):


### PR DESCRIPTION
Include the `uv.lock` file inside the `.nupkg` for faster dependencies resolve

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.72.dev1004140485",

  # Any version from PR
  "uipath>=2.0.72.dev1004140000,<2.0.72.dev1004150000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```