### PR TITLE
feat: add auth network options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.73"
+version = "2.0.74"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_auth/_client_credentials.py
+++ b/src/uipath/_cli/_auth/_client_credentials.py
@@ -5,7 +5,7 @@ import httpx
 
 from .._utils._console import ConsoleLogger
 from ._models import TokenData
-from ._utils import parse_access_token, update_env_file
+from ._utils import get_httpx_client_kwargs, parse_access_token, update_env_file
 
 console = ConsoleLogger()
 
@@ -13,8 +13,17 @@ console = ConsoleLogger()
 class ClientCredentialsService:
     """Service for client credentials authentication flow."""
 
-    def __init__(self, domain: str):
+    def __init__(
+        self,
+        domain: str,
+        verify_ssl: bool = True,
+        cert: Optional[str] = None,
+        proxy: Optional[str] = None,
+    ):
         self.domain = domain
+        self.verify_ssl = verify_ssl
+        self.cert = cert
+        self.proxy = proxy
 
     def get_token_url(self) -> str:
         """Get the token URL for the specified domain."""
@@ -91,13 +100,13 @@ class ClientCredentialsService:
         }
 
         try:
-            with httpx.Client(timeout=30.0) as client:
+            with httpx.Client(
+                **get_httpx_client_kwargs(self.verify_ssl, self.cert, self.proxy)
+            ) as client:
                 response = client.post(token_url, data=data)
-
                 match response.status_code:
                     case 200:
                         token_data = response.json()
-                        # Convert to our TokenData format
                         return {
                             "access_token": token_data["access_token"],
                             "token_type": token_data.get("token_type", "Bearer"),

--- a/src/uipath/_cli/_auth/_portal_service.py
+++ b/src/uipath/_cli/_auth/_portal_service.py
@@ -10,13 +10,13 @@ from ._models import TenantsAndOrganizationInfoResponse, TokenData
 from ._oidc_utils import get_auth_config
 from ._utils import (
     get_auth_data,
+    get_httpx_client_kwargs,
     get_parsed_token_data,
     update_auth_file,
     update_env_file,
 )
 
 console = ConsoleLogger()
-client = httpx.Client(follow_redirects=True, timeout=30.0)
 
 
 class PortalService:
@@ -27,6 +27,8 @@ class PortalService:
     domain: Optional[str] = None
     selected_tenant: Optional[str] = None
 
+    _client: Optional[httpx.Client] = None
+
     _tenants_and_organizations: Optional[TenantsAndOrganizationInfoResponse] = None
 
     def __init__(
@@ -34,18 +36,40 @@ class PortalService:
         domain: str,
         access_token: Optional[str] = None,
         prt_id: Optional[str] = None,
+        verify_ssl: bool = True,
+        cert: Optional[str] = None,
+        proxy: Optional[str] = None,
     ):
         self.domain = domain
         self.access_token = access_token
         self.prt_id = prt_id
+
+        self._client = httpx.Client(**get_httpx_client_kwargs(verify_ssl, cert, proxy))
+
+    def close(self):
+        """Explicitly close the HTTP client."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self):
+        """Enter the runtime context related to this object."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the runtime context and close the HTTP client."""
+        self.close()
 
     def update_token_data(self, token_data: TokenData):
         self.access_token = token_data["access_token"]
         self.prt_id = get_parsed_token_data(token_data).get("prt_id")
 
     def get_tenants_and_organizations(self) -> TenantsAndOrganizationInfoResponse:
+        if self._client is None:
+            raise RuntimeError("HTTP client is not initialized")
+
         url = f"https://{self.domain}.uipath.com/{self.prt_id}/portal_/api/filtering/leftnav/tenantsAndOrganizationInfo"
-        response = client.get(
+        response = self._client.get(
             url, headers={"Authorization": f"Bearer {self.access_token}"}
         )
         if response.status_code < 400:
@@ -72,6 +96,9 @@ class PortalService:
         return f"https://{self.domain}.uipath.com/{account_name}/{self.selected_tenant}/orchestrator_"
 
     def post_refresh_token_request(self, refresh_token: str) -> TokenData:
+        if self._client is None:
+            raise RuntimeError("HTTP client is not initialized")
+
         url = f"https://{self.domain}.uipath.com/identity_/connect/token"
         client_id = get_auth_config().get("client_id")
 
@@ -83,7 +110,7 @@ class PortalService:
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-        response = client.post(url, data=data, headers=headers)
+        response = self._client.post(url, data=data, headers=headers)
         if response.status_code < 400:
             return response.json()
         elif response.status_code == 401:
@@ -137,6 +164,9 @@ class PortalService:
         update_env_file(updated_env_contents)
 
     def post_auth(self, base_url: str) -> None:
+        if self._client is None:
+            raise RuntimeError("HTTP client is not initialized")
+
         or_base_url = (
             f"{base_url}/orchestrator_"
             if base_url
@@ -148,7 +178,7 @@ class PortalService:
 
         try:
             [try_enable_first_run_response, acquire_license_response] = [
-                client.post(
+                self._client.post(
                     url,
                     headers={"Authorization": f"Bearer {self.access_token}"},
                 )

--- a/src/uipath/_cli/_auth/_utils.py
+++ b/src/uipath/_cli/_auth/_utils.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from ._models import AccessTokenData, TokenData
 
@@ -49,3 +49,47 @@ def update_env_file(env_contents):
     lines = [f"{key}={value}\n" for key, value in env_contents.items()]
     with open(env_path, "w") as f:
         f.writelines(lines)
+
+
+def normalize_cert_path(cert_path: Optional[str]) -> Optional[str]:
+    """Normalize certificate path for cross-platform compatibility."""
+    if not cert_path:
+        return None
+
+    # Expand user home directory (~)
+    cert_path = os.path.expanduser(cert_path)
+
+    # Expand environment variables ($VAR, %VAR%)
+    cert_path = os.path.expandvars(cert_path)
+
+    # Convert to absolute path
+    cert_path = os.path.abspath(cert_path)
+
+    # Check if file exists
+    if not os.path.exists(cert_path):
+        raise FileNotFoundError(f"Certificate file not found: {cert_path}")
+
+    if not os.path.isfile(cert_path):
+        raise ValueError(f"Certificate path is not a file: {cert_path}")
+
+    return cert_path
+
+
+def get_httpx_client_kwargs(
+    verify_ssl: bool = True,
+    cert: Optional[str] = None,
+    proxy: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get standardized httpx client configuration."""
+    client_kwargs: Dict[str, Any] = {"follow_redirects": True, "timeout": 30.0}
+
+    if not verify_ssl:
+        client_kwargs["verify"] = False
+    elif cert:
+        normalized_cert = normalize_cert_path(cert)
+        client_kwargs["verify"] = normalized_cert
+
+    if proxy:
+        client_kwargs["proxies"] = proxy
+
+    return client_kwargs

--- a/src/uipath/_cli/cli_auth.py
+++ b/src/uipath/_cli/cli_auth.py
@@ -80,6 +80,23 @@ def set_port():
     required=False,
     help="Base URL for the UiPath tenant instance (required for client credentials)",
 )
+@click.option(
+    "--no-verify-ssl",
+    "--insecure",
+    is_flag=True,
+    required=False,
+    help="Disable SSL certificate verification (not recommended for production)",
+)
+@click.option(
+    "--cert",
+    required=False,
+    help="Path to custom CA certificate bundle file (for corporate certificates)",
+)
+@click.option(
+    "--proxy",
+    required=False,
+    help="Proxy URL in format: http://proxy:port or https://proxy:port",
+)
 @track
 def auth(
     domain,
@@ -87,11 +104,20 @@ def auth(
     client_id: str = None,
     client_secret: str = None,
     base_url: str = None,
+    no_verify_ssl: bool = False,
+    cert: str = None,
+    proxy: str = None,
 ):
     """Authenticate with UiPath Cloud Platform.
 
     Interactive mode (default): Opens browser for OAuth authentication.
     Unattended mode: Use --client-id, --client-secret and --base-url for client credentials flow.
+
+    Network options:
+    - Use --cert to specify custom CA certificates for corporate environments
+    - Use --no-verify-ssl to disable SSL verification (not recommended)
+    - Use --proxy to configure proxy settings (e.g., --proxy http://proxy:8080)
+    - Set HTTP_PROXY/HTTPS_PROXY environment variables for proxy configuration
     """
     # Check if client credentials are provided for unattended authentication
     if client_id and client_secret:
@@ -102,8 +128,9 @@ def auth(
             return
 
         with console.spinner("Authenticating with client credentials ..."):
-            # Create service instance
-            credentials_service = ClientCredentialsService(domain)
+            credentials_service = ClientCredentialsService(
+                domain, verify_ssl=not no_verify_ssl, cert=cert, proxy=proxy
+            )
 
             # If base_url is provided, extract domain from it to override the CLI domain parameter
             if base_url:
@@ -127,56 +154,59 @@ def auth(
 
     # Interactive authentication flow (existing logic)
     with console.spinner("Authenticating with UiPath ..."):
-        portal_service = PortalService(domain)
+        with PortalService(
+            domain, verify_ssl=not no_verify_ssl, cert=cert, proxy=proxy
+        ) as portal_service:
+            if not force:
+                if (
+                    os.getenv("UIPATH_URL")
+                    and os.getenv("UIPATH_TENANT_ID")
+                    and os.getenv("UIPATH_ORGANIZATION_ID")
+                ):
+                    try:
+                        portal_service.ensure_valid_token()
+                        console.success(
+                            "Authentication successful.",
+                        )
+                        return
+                    except Exception:
+                        console.info(
+                            "Authentication token is invalid. Please reauthenticate.",
+                        )
 
-        if not force:
-            if (
-                os.getenv("UIPATH_URL")
-                and os.getenv("UIPATH_TENANT_ID")
-                and os.getenv("UIPATH_ORGANIZATION_ID")
-            ):
+            auth_url, code_verifier, state = get_auth_url(domain)
+
+            webbrowser.open(auth_url, 1)
+            auth_config = get_auth_config()
+
+            console.link(
+                "If a browser window did not open, please open the following URL in your browser:",
+                auth_url,
+            )
+
+            server = HTTPServer(port=auth_config["port"])
+            token_data = server.start(state, code_verifier, domain)
+
+            if token_data:
+                portal_service.update_token_data(token_data)
+                update_auth_file(token_data)
+                access_token = token_data["access_token"]
+                update_env_file({"UIPATH_ACCESS_TOKEN": access_token})
+
+                tenants_and_organizations = (
+                    portal_service.get_tenants_and_organizations()
+                )
+                base_url = select_tenant(domain, tenants_and_organizations)
                 try:
-                    portal_service.ensure_valid_token()
+                    portal_service.post_auth(base_url)
                     console.success(
                         "Authentication successful.",
                     )
-                    return
                 except Exception:
-                    console.info(
-                        "Authentication token is invalid. Please reauthenticate.",
+                    console.error(
+                        "Could not prepare the environment. Please try again.",
                     )
-
-        auth_url, code_verifier, state = get_auth_url(domain)
-
-        webbrowser.open(auth_url, 1)
-        auth_config = get_auth_config()
-
-        console.link(
-            "If a browser window did not open, please open the following URL in your browser:",
-            auth_url,
-        )
-
-        server = HTTPServer(port=auth_config["port"])
-        token_data = server.start(state, code_verifier, domain)
-
-        if token_data:
-            portal_service.update_token_data(token_data)
-            update_auth_file(token_data)
-            access_token = token_data["access_token"]
-            update_env_file({"UIPATH_ACCESS_TOKEN": access_token})
-
-            tenants_and_organizations = portal_service.get_tenants_and_organizations()
-            base_url = select_tenant(domain, tenants_and_organizations)
-            try:
-                portal_service.post_auth(base_url)
-                console.success(
-                    "Authentication successful.",
-                )
-            except Exception:
+            else:
                 console.error(
-                    "Could not prepare the environment. Please try again.",
+                    "Authentication failed. Please try again.",
                 )
-        else:
-            console.error(
-                "Authentication failed. Please try again.",
-            )


### PR DESCRIPTION
## Pull Request Overview
Adds configurable network options to the authentication CLI and propagates those settings into underlying HTTP clients.

- Introduce `--no-verify-ssl`, `--cert`, and `--proxy` flags to the auth command
- Extend `ClientCredentialsService` and `PortalService` constructors to apply SSL verification and proxy settings
- Replace shared global HTTP client with per-instance `httpx.Client` (with proper cleanup) and bump package version

## Example Usage

```
# Custom CA certificate 
uipath auth --cert /path/to/corporate-ca-bundle.pem

# With proxy
uipath auth --cert /path/to/corp-ca.pem --proxy http://proxy:8080

# Client credentials with CA 
uipath auth \
  --client-id "your-id" \
  --client-secret "your-secret" \
  --base-url "https://tenant.uipath.com" \
  --cert /path/to/corp-ca.pem

# Disable SSL verification (last resort)
uipath auth --no-verify-ssl
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.74.dev1004350527",

  # Any version from PR
  "uipath>=2.0.74.dev1004350000,<2.0.74.dev1004360000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```