### PR TITLE
fix: add binary file extensions to prevent corruption during pack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.76"
+version = "2.0.77"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_utils/_constants.py
+++ b/src/uipath/_cli/_utils/_constants.py
@@ -1,1 +1,58 @@
 BINDINGS_VERSION = "2.2"
+
+# Binary file extension categories
+IMAGE_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".bmp",
+    ".ico",
+    ".tiff",
+    ".webp",
+    ".svg",
+}
+
+DOCUMENT_EXTENSIONS = {".pdf", ".docx", ".pptx", ".xlsx", ".xls"}
+
+ARCHIVE_EXTENSIONS = {".zip", ".tar", ".gz", ".rar", ".7z", ".bz2", ".xz"}
+
+MEDIA_EXTENSIONS = {
+    ".mp3",
+    ".wav",
+    ".flac",
+    ".aac",
+    ".mp4",
+    ".avi",
+    ".mov",
+    ".mkv",
+    ".wmv",
+}
+
+FONT_EXTENSIONS = {".woff", ".woff2", ".ttf", ".otf", ".eot"}
+
+EXECUTABLE_EXTENSIONS = {".exe", ".dll", ".so", ".dylib", ".bin"}
+
+DATABASE_EXTENSIONS = {".db", ".sqlite", ".sqlite3"}
+
+PYTHON_BINARY_EXTENSIONS = {".pickle", ".pkl"}
+
+SPECIAL_EXTENSIONS = {""}  # Extensionless binary files
+
+# Pre-compute the union for optimal performance
+BINARY_EXTENSIONS = (
+    IMAGE_EXTENSIONS
+    | DOCUMENT_EXTENSIONS
+    | ARCHIVE_EXTENSIONS
+    | MEDIA_EXTENSIONS
+    | FONT_EXTENSIONS
+    | EXECUTABLE_EXTENSIONS
+    | DATABASE_EXTENSIONS
+    | PYTHON_BINARY_EXTENSIONS
+    | SPECIAL_EXTENSIONS
+)
+
+
+def is_binary_file(file_extension: str) -> bool:
+    """Determine if a file should be treated as binary."""
+    return file_extension.lower() in BINARY_EXTENSIONS

--- a/src/uipath/_cli/cli_pack.py
+++ b/src/uipath/_cli/cli_pack.py
@@ -17,6 +17,7 @@ except ImportError:
 
 from ..telemetry import track
 from ._utils._console import ConsoleLogger
+from ._utils._constants import is_binary_file
 
 console = ConsoleLogger()
 
@@ -265,8 +266,6 @@ def pack_fn(
     # Define the allowlist of file extensions to include
     file_extensions_included = [".py", ".mermaid", ".json", ".yaml", ".yml"]
     files_included = []
-    # Binary files that should be read in binary mode
-    binary_extensions = [".exe", "", ".xlsx", ".xls"]
 
     with open(config_path, "r") as f:
         config_data = json.load(f)
@@ -328,7 +327,7 @@ def pack_fn(
                 if file_extension in file_extensions_included or file in files_included:
                     file_path = os.path.join(root, file)
                     rel_path = os.path.relpath(file_path, directory)
-                    if file_extension in binary_extensions:
+                    if is_binary_file(file_extension):
                         # Read binary files in binary mode
                         with open(file_path, "rb") as f:
                             z.writestr(f"content/{rel_path}", f.read())


### PR DESCRIPTION
## Summary

This PR centralizes binary file extension logic, updates the pack command to use the new utility, and bumps the package version.

- Added `is_binary_file` and grouped binary extensions in a constants module.
- Refactored `cli_pack.pack_fn` to replace its inline `binary_extensions` list with `is_binary_file`.
- Incremented project version to `2.0.77`.

In some near future, we probably need to read all files in binary mode by default and have a special treatment for new line sensitive files, eg:
```python
line_ending_sensitive_files = {'.json', '.xml', '.yaml', '.yml', '.toml'}
```