### PR TITLE
Add detailed error logging for client credentials authentication

### DIFF
--- a/src/uipath/_cli/_auth/_client_credentials.py
+++ b/src/uipath/_cli/_auth/_client_credentials.py
@@ -106,11 +106,19 @@ class ClientCredentialsService:
                             "refresh_token": "",
                             "id_token": "",
                         }
+                    
                     case 400:
+                        
                         console.error(
                             "Invalid client credentials or request parameters."
                         )
+                        try:
+                            error_details = response.json()
+                            console.error(f"DEBUG: Error details: {error_details}")
+                        except:
+                            console.error(f"DEBUG: Raw error response: {response.text}")
                         return None
+                    
                     case 401:
                         console.error("Unauthorized: Invalid client credentials.")
                         return None

--- a/src/uipath/_cli/_auth/_client_credentials.py
+++ b/src/uipath/_cli/_auth/_client_credentials.py
@@ -108,15 +108,16 @@ class ClientCredentialsService:
                         }
                     
                     case 400:
+                        try:
+                            error_details = response.json()
+                            console.info(f"DEBUG: Error details: {error_details}")
+                        except:
+                            console.info(f"DEBUG: Raw error response: {response.text}")
                         
                         console.error(
                             "Invalid client credentials or request parameters."
                         )
-                        try:
-                            error_details = response.json()
-                            console.error(f"DEBUG: Error details: {error_details}")
-                        except:
-                            console.error(f"DEBUG: Raw error response: {response.text}")
+                        
                         return None
                     
                     case 401:

--- a/src/uipath/_cli/_auth/_client_credentials.py
+++ b/src/uipath/_cli/_auth/_client_credentials.py
@@ -111,7 +111,7 @@ class ClientCredentialsService:
                         try:
                             error_details = response.json()
                             console.info(f"DEBUG: Error details: {error_details}")
-                        except:
+                        except Exception:
                             console.info(f"DEBUG: Raw error response: {response.text}")
                         
                         console.error(

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -62,9 +62,13 @@ Usage: `uipath run <entrypoint_path> <input_arguments> [-f <input_json_file_path
     try:
 
         async def execute():
-            context = UiPathRuntimeContext.from_config(
-                env.get("UIPATH_CONFIG_PATH", "uipath.json")
-            )
+            config_path = env.get("UIPATH_CONFIG_PATH", "uipath.json")
+            console.info(f"[DEBUG] Using config path: {config_path}")
+            console.info(f"[DEBUG] Entrypoint argument: {entrypoint}")
+            console.info(f"[DEBUG] Entrypoint absolute path: {os.path.abspath(entrypoint) if entrypoint else None}")
+            console.info(f"[DEBUG] Entrypoint exists: {os.path.exists(entrypoint) if entrypoint else None}")
+            console.info(f"[DEBUG] Input: {input}")
+            context = UiPathRuntimeContext.from_config(config_path)
             context.entrypoint = entrypoint
             context.input = input
             context.resume = resume
@@ -93,6 +97,7 @@ Usage: `uipath run <entrypoint_path> <input_arguments> [-f <input_json_file_path
         return MiddlewareResult(should_continue=False)
 
     except UiPathRuntimeError as e:
+        console.info(f"[DEBUG][UiPathRuntimeError] {type(e).__name__}: {e}")
         return MiddlewareResult(
             should_continue=False,
             error_message=f"Error: {e.error_info.title} - {e.error_info.detail}",
@@ -100,6 +105,7 @@ Usage: `uipath run <entrypoint_path> <input_arguments> [-f <input_json_file_path
         )
     except Exception as e:
         # Handle unexpected errors
+        console.info(f"[DEBUG][Exception] {type(e).__name__}: {e}")
         return MiddlewareResult(
             should_continue=False,
             error_message=f"Error: Unexpected error occurred - {str(e)}",


### PR DESCRIPTION
Add debug error details logging for 400 status responses in client credentials authentication.

When client credentials authentication fails with 400 status, developers only received a generic error message without specific details about what went wrong.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.0.79.dev1004490598",

  # Any version from PR
  "uipath>=2.0.79.dev1004490000,<2.0.79.dev1004500000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```