### PR TITLE
improvement: enriched http error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.0.80"
+version = "2.0.81"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_services/processes_service.py
+++ b/src/uipath/_services/processes_service.py
@@ -71,7 +71,6 @@ class ProcessesService(FolderContext, BaseService):
             folder_key=folder_key,
             folder_path=folder_path,
         )
-
         response = self.request(
             spec.method,
             url=spec.endpoint,

--- a/src/uipath/models/exceptions.py
+++ b/src/uipath/models/exceptions.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from httpx import HTTPStatusError
+
 
 class IngestionInProgressException(Exception):
     """An exception that is triggered when a search is attempted on an index that is currently undergoing ingestion."""
@@ -11,3 +13,24 @@ class IngestionInProgressException(Exception):
         else:
             self.message = f"index '{index_name}' is currently queued for ingestion"
         super().__init__(self.message)
+
+
+class EnrichedException(Exception):
+    def __init__(self, error: HTTPStatusError) -> None:
+        # Extract the relevant details from the HTTPStatusError
+        status_code = error.response.status_code if error.response else "Unknown"
+        url = str(error.request.url) if error.request else "Unknown"
+        response_content = (
+            error.response.content.decode("utf-8")
+            if error.response and error.response.content
+            else "No content"
+        )
+
+        enriched_message = (
+            f"\nRequest URL: {url}"
+            f"\nStatus Code: {status_code}"
+            f"\nResponse Content: {response_content}"
+        )
+
+        # Initialize the parent Exception class with the formatted message
+        super().__init__(enriched_message)

--- a/uv.lock
+++ b/uv.lock
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.0.80"
+version = "2.0.81"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Include http response content in error messages.

Example error format after the changes:
```
    raise EnrichedException(e) from e
uipath.models.exceptions.EnrichedException:
Request URL: https://***
Status Code: 400
Response Content: {"message":"Folder does not exist or the user does not have access to the folder.","errorCode":1100,"traceId":"00-1b64de7918bddc499c641063f41781e4-b74eec3dd37247ac-01"}
```

Issue: https://github.com/UiPath/uipath-python/issues/454