### PR TITLE
fix(cli): Don't double include README.md in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/cli_pack.py
+++ b/src/uipath/_cli/cli_pack.py
@@ -347,7 +347,7 @@ def pack_fn(
                                     z.writestr(f"content/{rel_path}", f.read())
 
         # Handle optional files, conditionally including uv.lock
-        optional_files = ["pyproject.toml", "README.md"]
+        optional_files = ["pyproject.toml"]
         if include_uv_lock:
             optional_files.append("uv.lock")
 


### PR DESCRIPTION
Broken by https://github.com/UiPath/uipath-python/pull/469