### PR TITLE
fix: console log middleware loading exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.2"
+version = "2.1.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/middlewares.py
+++ b/src/uipath/_cli/middlewares.py
@@ -126,9 +126,9 @@ class Middlewares:
                         register_func()
                         logger.info(f"Loaded middleware plugin: {entry_point.name}")
                     except Exception as e:
-                        logger.error(
+                        console.error(
                             f"Failed to load middleware plugin {entry_point.name}: {str(e)}",
-                            exc_info=True,
+                            include_traceback=True,
                         )
             else:
                 logger.info("No middleware plugins found")


### PR DESCRIPTION
## Summary

Surface exception and call stack when middleware fails to load. 

This exception happens when you try to use the latest `uipath-langchain` extension which is no longer compatible with `langgraph` version < 0.5.0.

<img width="2545" height="825" alt="image" src="https://github.com/user-attachments/assets/734df4b4-3311-4eb2-94ec-09cb411871be" />
