### PR TITLE
feat: CLI add pull command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.6"
+version = "2.1.7"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -10,6 +10,7 @@ from .cli_invoke import invoke as invoke  # type: ignore
 from .cli_new import new as new  # type: ignore
 from .cli_pack import pack as pack  # type: ignore
 from .cli_publish import publish as publish  # type: ignore
+from .cli_pull import pull as pull  # type: ignore
 from .cli_push import push as push  # type: ignore
 from .cli_run import run as run  # type: ignore
 
@@ -65,3 +66,4 @@ cli.add_command(deploy)
 cli.add_command(auth)
 cli.add_command(invoke)
 cli.add_command(push)
+cli.add_command(pull)

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+from urllib.parse import urlparse
 
 import click
 
@@ -29,7 +30,7 @@ def environment_options(function):
     return function
 
 
-def get_env_vars(spinner: Optional[Spinner] = None) -> list[str | None]:
+def get_env_vars(spinner: Optional[Spinner] = None) -> list[str]:
     base_url = os.environ.get("UIPATH_URL")
     token = os.environ.get("UIPATH_ACCESS_TOKEN")
 
@@ -42,7 +43,8 @@ def get_env_vars(spinner: Optional[Spinner] = None) -> list[str | None]:
         click.echo("UIPATH_URL, UIPATH_ACCESS_TOKEN")
         click.get_current_context().exit(1)
 
-    return [base_url, token]
+    # at this step we know for sure that both base_url and token exist. type checking can be disabled
+    return [base_url, token]  # type: ignore
 
 
 def serialize_object(obj):
@@ -69,3 +71,18 @@ def serialize_object(obj):
     # Return primitive types as is
     else:
         return obj
+
+
+def get_org_scoped_url(base_url: str) -> str:
+    """Get organization scoped URL from base URL.
+
+    Args:
+        base_url: The base URL to scope
+
+    Returns:
+        str: The organization scoped URL
+    """
+    parsed = urlparse(base_url)
+    org_name, *_ = parsed.path.strip("/").split("/")
+    org_scoped_url = f"{parsed.scheme}://{parsed.netloc}/{org_name}"
+    return org_scoped_url

--- a/src/uipath/_cli/cli_pack.py
+++ b/src/uipath/_cli/cli_pack.py
@@ -276,7 +276,9 @@ def display_project_info(config):
 
 
 @click.command()
-@click.argument("root", type=str, default="./")
+@click.argument(
+    "root", type=click.Path(exists=True, file_okay=False, dir_okay=True), default="."
+)
 @click.option(
     "--nolock",
     is_flag=True,

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -1,0 +1,216 @@
+# type: ignore
+"""CLI command for pulling remote project files from UiPath StudioWeb solution.
+
+This module provides functionality to pull remote project files from a UiPath StudioWeb solution.
+It handles:
+- File downloads from source_code and evals folders
+- Maintaining folder structure locally
+- File comparison using hashes
+- Interactive confirmation for overwriting files
+"""
+
+# type: ignore
+import hashlib
+import json
+import os
+from typing import Dict, Set
+
+import click
+import httpx
+from dotenv import load_dotenv
+
+from .._utils._ssl_context import get_httpx_client_kwargs
+from .._utils._url import UiPathUrl
+from ..telemetry import track
+from ._utils._common import get_env_vars
+from ._utils._console import ConsoleLogger
+from ._utils._studio_project import (
+    ProjectFile,
+    ProjectFolder,
+    download_file,
+    get_folder_by_name,
+    get_project_structure,
+)
+
+console = ConsoleLogger()
+load_dotenv(override=True)
+
+
+def compute_normalized_hash(content: str) -> str:
+    """Compute hash of normalized content.
+
+    Args:
+        content: Content to hash
+
+    Returns:
+        str: SHA256 hash of the normalized content
+    """
+    try:
+        # Try to parse as JSON to handle formatting
+        json_content = json.loads(content)
+        normalized = json.dumps(json_content, indent=2)
+    except json.JSONDecodeError:
+        # Not JSON, normalize line endings
+        normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def collect_files_from_folder(
+    folder: ProjectFolder, base_path: str, files_dict: Dict[str, ProjectFile]
+) -> None:
+    """Recursively collect all files from a folder and its subfolders.
+
+    Args:
+        folder: The folder to collect files from
+        base_path: Base path for file paths
+        files_dict: Dictionary to store collected files
+    """
+    # Add files from current folder
+    for file in folder.files:
+        file_path = os.path.join(base_path, file.name)
+        files_dict[file_path] = file
+
+    # Recursively process subfolders
+    for subfolder in folder.folders:
+        subfolder_path = os.path.join(base_path, subfolder.name)
+        collect_files_from_folder(subfolder, subfolder_path, files_dict)
+
+
+def download_folder_files(
+    folder: ProjectFolder,
+    base_path: str,
+    base_url: str,
+    token: str,
+    client: httpx.Client,
+    processed_files: Set[str],
+) -> None:
+    """Download files from a folder recursively.
+
+    Args:
+        folder: The folder to download files from
+        base_path: Base path for local file storage
+        base_url: Base URL for API requests
+        token: Authentication token
+        client: HTTP client
+        processed_files: Set to track processed files
+    """
+    files_dict: Dict[str, ProjectFile] = {}
+    collect_files_from_folder(folder, "", files_dict)
+
+    for file_path, remote_file in files_dict.items():
+        local_path = os.path.join(base_path, file_path)
+        local_dir = os.path.dirname(local_path)
+
+        # Create directory if it doesn't exist
+        if not os.path.exists(local_dir):
+            os.makedirs(local_dir)
+
+        # Download remote file
+        response = download_file(base_url, remote_file.id, client, token)
+        remote_content = response.read().decode("utf-8")
+        remote_hash = compute_normalized_hash(remote_content)
+
+        if os.path.exists(local_path):
+            # Read and hash local file
+            with open(local_path, "r", encoding="utf-8") as f:
+                local_content = f.read()
+                local_hash = compute_normalized_hash(local_content)
+
+            # Compare hashes
+            if local_hash != remote_hash:
+                styled_path = click.style(str(file_path), fg="cyan")
+                console.warning(f"File {styled_path}" + " differs from remote version.")
+                response = click.prompt("Do you want to override it? (y/n)", type=str)
+                if response.lower() == "y":
+                    with open(local_path, "w", encoding="utf-8", newline="\n") as f:
+                        f.write(remote_content)
+                    console.success(f"Updated {click.style(str(file_path), fg='cyan')}")
+                else:
+                    console.info(f"Skipped {click.style(str(file_path), fg='cyan')}")
+            else:
+                console.info(
+                    f"File {click.style(str(file_path), fg='cyan')} is up to date"
+                )
+        else:
+            # File doesn't exist locally, create it
+            with open(local_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(remote_content)
+            console.success(f"Downloaded {click.style(str(file_path), fg='cyan')}")
+
+        processed_files.add(file_path)
+
+
+@click.command()
+@click.argument("root", type=str, default="./")
+@track
+def pull(root: str) -> None:
+    """Pull remote project files from Studio Web Project.
+
+    This command pulls the remote project files from a UiPath Studio Web project.
+    It downloads files from the source_code and evals folders, maintaining the
+    folder structure locally. Files are compared using hashes before overwriting,
+    and user confirmation is required for differing files.
+
+    Args:
+        root: The root directory to pull files into
+
+    Environment Variables:
+        UIPATH_PROJECT_ID: Required. The ID of the UiPath Studio Web project
+
+    Example:
+        $ uipath pull
+        $ uipath pull /path/to/project
+    """
+    if not os.getenv("UIPATH_PROJECT_ID", False):
+        console.error("UIPATH_PROJECT_ID environment variable not found.")
+
+    [base_url, token] = get_env_vars()
+    uipath_url = UiPathUrl(base_url)
+    org_scoped_base_url = uipath_url.scope_url("org")
+    base_api_url = f"{org_scoped_base_url}/studio_/backend/api/Project/{os.getenv('UIPATH_PROJECT_ID')}/FileOperations"
+
+    with console.spinner("Pulling UiPath project files..."):
+        try:
+            with httpx.Client(**get_httpx_client_kwargs()) as client:
+                # Get project structure
+                structure = get_project_structure(
+                    os.getenv("UIPATH_PROJECT_ID"),  # type: ignore
+                    org_scoped_base_url,
+                    token,
+                    client,
+                )
+
+                processed_files: Set[str] = set()
+
+                # Process source_code folder
+                source_code_folder = get_folder_by_name(structure, "source_code")
+                if source_code_folder:
+                    download_folder_files(
+                        source_code_folder,
+                        root,
+                        base_api_url,
+                        token,
+                        client,
+                        processed_files,
+                    )
+                else:
+                    console.warning("No source_code folder found in remote project")
+
+                # Process evals folder
+                evals_folder = get_folder_by_name(structure, "evals")
+                if evals_folder:
+                    evals_path = os.path.join(root, "evals")
+                    download_folder_files(
+                        evals_folder,
+                        evals_path,
+                        base_api_url,
+                        token,
+                        client,
+                        processed_files,
+                    )
+                else:
+                    console.warning("No evals folder found in remote project")
+
+        except Exception as e:
+            console.error(f"Failed to pull UiPath project: {str(e)}")

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -492,7 +492,9 @@ def upload_source_files_to_project(
 
 
 @click.command()
-@click.argument("root", type=str, default="./")
+@click.argument(
+    "root", type=click.Path(exists=True, file_okay=False, dir_okay=True), default="."
+)
 @click.option(
     "--nolock",
     is_flag=True,

--- a/tests/cli/test_pull.py
+++ b/tests/cli/test_pull.py
@@ -1,0 +1,399 @@
+# type: ignore
+import json
+import os
+from typing import Any, Dict
+
+from click.testing import CliRunner
+from pytest_httpx import HTTPXMock
+from utils.project_details import ProjectDetails
+from utils.uipath_json import UiPathJson
+
+from tests.cli.utils.common import configure_env_vars
+from uipath._cli.cli_pull import pull
+
+
+class TestPull:
+    """Test pull command."""
+
+    def test_pull_without_project_id(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        uipath_json: UiPathJson,
+    ) -> None:
+        """Test pull when UIPATH_PROJECT_ID is missing."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            result = runner.invoke(pull, ["./"])
+            assert result.exit_code == 1
+            assert "UIPATH_PROJECT_ID environment variable not found." in result.output
+
+    def test_successful_pull(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        uipath_json: UiPathJson,
+        mock_env_vars: Dict[str, str],
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test successful project pull with various file operations."""
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        # Mock the project structure response
+        mock_structure = {
+            "id": "root",
+            "name": "root",
+            "folders": [
+                {
+                    "id": "414af585-7e88-4774-ad94-cf6bd48f6c2d",
+                    "name": "source_code",
+                    "files": [
+                        {
+                            "id": "123",
+                            "name": "main.py",
+                            "isMain": True,
+                            "fileType": "1",
+                            "isEntryPoint": True,
+                            "ignoredFromPublish": False,
+                        },
+                        {
+                            "id": "456",
+                            "name": "pyproject.toml",
+                            "isMain": False,
+                            "fileType": "1",
+                            "isEntryPoint": False,
+                            "ignoredFromPublish": False,
+                        },
+                        {
+                            "id": "789",
+                            "name": "uipath.json",
+                            "isMain": False,
+                            "fileType": "1",
+                            "isEntryPoint": False,
+                            "ignoredFromPublish": False,
+                        },
+                    ],
+                },
+                {
+                    "id": "evals-folder-id",
+                    "name": "evals",
+                    "folders": [
+                        {
+                            "id": "eval-sets-id",
+                            "name": "eval-sets",
+                            "files": [
+                                {
+                                    "id": "eval-sets-file-id",
+                                    "name": "test-set.json",
+                                    "isMain": False,
+                                    "fileType": "1",
+                                    "isEntryPoint": False,
+                                    "ignoredFromPublish": False,
+                                }
+                            ],
+                            "folders": [],
+                        },
+                        {
+                            "id": "evaluators-id",
+                            "name": "evaluators",
+                            "files": [
+                                {
+                                    "id": "evaluators-file-id",
+                                    "name": "test-evaluator.json",
+                                    "isMain": False,
+                                    "fileType": "1",
+                                    "isEntryPoint": False,
+                                    "ignoredFromPublish": False,
+                                }
+                            ],
+                            "folders": [],
+                        },
+                    ],
+                    "files": [],
+                },
+            ],
+            "files": [],
+            "folderType": "0",
+        }
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        # Mock file download responses
+        # For main.py
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/123",
+            content=b"print('Hello World')",
+        )
+
+        # For pyproject.toml
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/456",
+            content=project_details.to_toml().encode(),
+        )
+
+        # For uipath.json
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/789",
+            content=uipath_json.to_json().encode(),
+        )
+
+        # For eval-sets/test-set.json
+        test_set_content = {
+            "id": "02424d08-f482-4777-ac4d-233add24ee06",
+            "fileName": "evaluation-set-1752568767335.json",
+            "evaluatorRefs": [
+                "429d73a2-a748-4554-83d7-e32dec345931",
+                "bdb9f7c9-2d9e-4595-81c8-ef2a60216cb9",
+            ],
+            "evaluations": [],
+            "name": "Evaluation Set 2",
+            "batchSize": 10,
+            "timeoutMinutes": 20,
+            "modelSettings": [],
+            "createdAt": "2025-07-15T08:39:27.335Z",
+            "updatedAt": "2025-07-15T08:39:27.335Z",
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/eval-sets-file-id",
+            content=json.dumps(test_set_content, indent=2).encode(),
+        )
+
+        # For evaluators/test-evaluator.json
+        test_evaluator_content = {
+            "fileName": "evaluator-1752568815245.json",
+            "id": "52b716b1-c8ef-4da8-af31-fb218d0d5499",
+            "name": "Evaluator 3",
+            "description": "An evaluator that judges the agent based on its run history and expected behavior",
+            "type": 7,
+            "category": 3,
+            "prompt": "As an expert evaluator, determine how well the agent did on a scale of 0-100. Focus on if the simulation was successful and if the agent behaved according to the expected output accounting for alternative valid expressions, and reasonable variations in language while maintaining high standards for accuracy and completeness. Provide your score with a justification, explaining briefly and concisely why you gave that score.\n----\nUserOrSyntheticInputGivenToAgent:\n{{UserOrSyntheticInput}}\n----\nSimulationInstructions:\n{{SimulationInstructions}}\n----\nExpectedAgentBehavior:\n{{ExpectedAgentBehavior}}\n----\nAgentRunHistory:\n{{AgentRunHistory}}\n",
+            "targetOutputKey": "*",
+            "createdAt": "2025-07-15T08:40:15.245Z",
+            "updatedAt": "2025-07-15T08:40:15.245Z",
+        }
+
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/evaluators-file-id",
+            content=json.dumps(test_evaluator_content, indent=2).encode(),
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            # Set environment variables
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            # Run pull
+            result = runner.invoke(pull, ["./"])
+            assert result.exit_code == 0
+
+            # Verify source code files
+            assert "Downloaded main.py" in result.output
+            assert "Downloaded pyproject.toml" in result.output
+            assert "Downloaded uipath.json" in result.output
+
+            # Verify source code file contents
+            with open("main.py", "r") as f:
+                assert f.read() == "print('Hello World')"
+            with open("pyproject.toml", "r") as f:
+                assert f.read() == project_details.to_toml()
+            with open("uipath.json", "r") as f:
+                assert f.read() == uipath_json.to_json()
+
+            # Verify evals folder structure exists
+            assert os.path.isdir("evals")
+            assert os.path.isdir("evals/eval-sets")
+            assert os.path.isdir("evals/evaluators")
+
+            # Verify eval files exist and have correct content
+            with open("evals/eval-sets/test-set.json", "r") as f:
+                assert json.load(f) == test_set_content
+            with open("evals/evaluators/test-evaluator.json", "r") as f:
+                assert json.load(f) == test_evaluator_content
+
+    def test_pull_with_existing_files(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        uipath_json: UiPathJson,
+        mock_env_vars: Dict[str, str],
+        httpx_mock: HTTPXMock,
+        monkeypatch: Any,
+    ) -> None:
+        """Test pull when local files exist and differ from remote."""
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        # Mock the project structure response
+        mock_structure = {
+            "id": "root",
+            "name": "root",
+            "folders": [
+                {
+                    "id": "414af585-7e88-4774-ad94-cf6bd48f6c2d",
+                    "name": "source_code",
+                    "files": [
+                        {
+                            "id": "123",
+                            "name": "main.py",
+                            "isMain": True,
+                            "fileType": "1",
+                            "isEntryPoint": True,
+                            "ignoredFromPublish": False,
+                        }
+                    ],
+                }
+            ],
+            "files": [],
+            "folderType": "0",
+        }
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        # Mock file download response
+        remote_content = "print('Remote version')"
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/123",
+            content=remote_content.encode(),
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            # Create local file with different content
+            local_content = "print('Local version')"
+            with open("main.py", "w") as f:
+                f.write(local_content)
+
+            # Set environment variables
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            # Mock user input to confirm override
+            monkeypatch.setattr("click.prompt", lambda *args, **kwargs: "y")
+
+            # Run pull
+            result = runner.invoke(pull, ["./"])
+            assert result.exit_code == 0
+            assert "differs from remote version" in result.output
+            assert "Updated main.py" in result.output
+
+            # Verify file was updated
+            with open("main.py", "r") as f:
+                assert f.read() == remote_content
+
+    def test_pull_skip_override(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        uipath_json: UiPathJson,
+        mock_env_vars: Dict[str, str],
+        httpx_mock: HTTPXMock,
+        monkeypatch: Any,
+    ) -> None:
+        """Test pull when user chooses not to override local files."""
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        # Mock the project structure response
+        mock_structure = {
+            "id": "root",
+            "name": "root",
+            "folders": [
+                {
+                    "id": "414af585-7e88-4774-ad94-cf6bd48f6c2d",
+                    "name": "source_code",
+                    "files": [
+                        {
+                            "id": "123",
+                            "name": "main.py",
+                            "isMain": True,
+                            "fileType": "1",
+                            "isEntryPoint": True,
+                            "ignoredFromPublish": False,
+                        }
+                    ],
+                }
+            ],
+            "files": [],
+            "folderType": "0",
+        }
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        # Mock file download response
+        remote_content = "print('Remote version')"
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/File/123",
+            content=remote_content.encode(),
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            # Create local file with different content
+            local_content = "print('Local version')"
+            with open("main.py", "w") as f:
+                f.write(local_content)
+
+            # Set environment variables
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            # Mock user input to reject override
+            monkeypatch.setattr("click.prompt", lambda *args, **kwargs: "n")
+
+            # Run pull
+            result = runner.invoke(pull, ["./"])
+            assert result.exit_code == 0
+            assert "differs from remote version" in result.output
+            assert "Skipped main.py" in result.output
+
+            # Verify file was not updated
+            with open("main.py", "r") as f:
+                assert f.read() == local_content
+
+    def test_pull_with_api_error(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        uipath_json: UiPathJson,
+        mock_env_vars: Dict[str, str],
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test pull when API request fails."""
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        # Mock API error response
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            status_code=401,
+            json={"message": "Unauthorized"},
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            # Set environment variables
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            result = runner.invoke(pull, ["./"])
+            assert result.exit_code == 1
+            assert "Failed to pull UiPath project" in result.output
+            assert "401 Unauthorized" in result.output

--- a/tests/cli/test_push.py
+++ b/tests/cli/test_push.py
@@ -10,6 +10,7 @@ from pytest_httpx import HTTPXMock
 from utils.project_details import ProjectDetails
 from utils.uipath_json import UiPathJson
 
+from tests.cli.utils.common import configure_env_vars
 from uipath._cli.cli_push import push
 
 
@@ -46,10 +47,16 @@ class TestPush:
     """Test push command."""
 
     def test_push_without_uipath_json(
-        self, runner: CliRunner, temp_dir: str, project_details: ProjectDetails
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        mock_env_vars: Dict[str, str],
     ) -> None:
         """Test push when uipath.json is missing."""
         with runner.isolated_filesystem(temp_dir=temp_dir):
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = "123"
             with open("pyproject.toml", "w") as f:
                 f.write(project_details.to_toml())
             result = runner.invoke(push, ["./"])
@@ -65,9 +72,11 @@ class TestPush:
         temp_dir: str,
         project_details: ProjectDetails,
         uipath_json: UiPathJson,
+        mock_env_vars: Dict[str, str],
     ) -> None:
         """Test push when UIPATH_PROJECT_ID is missing."""
         with runner.isolated_filesystem(temp_dir=temp_dir):
+            configure_env_vars(mock_env_vars)
             with open("uipath.json", "w") as f:
                 f.write(uipath_json.to_json())
             with open("pyproject.toml", "w") as f:
@@ -203,7 +212,7 @@ class TestPush:
                 f.write('version = 1 \n requires-python = ">=3.11"')
 
             # Set environment variables
-            os.environ.update(mock_env_vars)
+            configure_env_vars(mock_env_vars)
             os.environ["UIPATH_PROJECT_ID"] = project_id
 
             # Run push
@@ -320,7 +329,7 @@ class TestPush:
                 f.write('version = 1 \n requires-python = ">=3.11"')
 
             # Set environment variables
-            os.environ.update(mock_env_vars)
+            configure_env_vars(mock_env_vars)
             os.environ["UIPATH_PROJECT_ID"] = project_id
 
             # Run push
@@ -399,7 +408,7 @@ class TestPush:
                 f.write("")
 
             # Set environment variables
-            os.environ.update(mock_env_vars)
+            configure_env_vars(mock_env_vars)
             os.environ["UIPATH_PROJECT_ID"] = project_id
 
             result = runner.invoke(push, ["./"])
@@ -499,7 +508,7 @@ class TestPush:
             with open("uv.lock", "w") as f:
                 f.write("")
             # Set environment variables
-            os.environ.update(mock_env_vars)
+            configure_env_vars(mock_env_vars)
             os.environ["UIPATH_PROJECT_ID"] = project_id
 
             # Run push with --nolock flag

--- a/tests/cli/utils/common.py
+++ b/tests/cli/utils/common.py
@@ -1,0 +1,7 @@
+import os
+from typing import Dict
+
+
+def configure_env_vars(env_vars: Dict[str, str]):
+    os.environ.clear()
+    os.environ.update(env_vars)

--- a/uv.lock
+++ b/uv.lock
@@ -2028,7 +2028,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.5"
+version = "2.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
# Add New CLI Pull Command for Studio Web Projects

## Overview
This PR introduces a new `pull` command to the UiPath CLI, enabling pulling remote project files from a Studio Web solution to the local environment. This complements the existing `push` command to provide full bidirectional sync capabilities.

## Key Features

### New CLI Command
- Added `uipath pull` command
- Automatically syncs remote files to local project
- Handles file downloads and updates
- Maintains project structure integrity

### File Operations
- Downloads new files that don't exist locally
- Updates existing files with remote changes (with user confirmation)
- Preserves local files that match remote content
- Handles JSON formatting and line ending normalization
- Supports special folders like `evals` with subfolders:
  - `eval-sets`: Evaluation set configurations
  - `evaluators`: Evaluator definitions

### Project Structure Management
- Recursively processes remote folder structure
- Creates missing local directories as needed
- Maintains file hierarchy and relationships
- Provides interactive file override confirmation
- Handles both source code and evaluation assets

### Content Handling
- Normalizes line endings across platforms
- Pretty-prints JSON files with consistent formatting
- Uses SHA256 hashing for efficient file comparison
- Provides clear console feedback with colored output

## Code Organization

### File Management
- Efficient file comparison using content hashing
- Structured handling of different file types
- Clear separation of download and comparison logic
- Consistent error handling and user feedback

## Testing
- Comprehensive test suite covering:
  - Successful pull operations
  - File comparison and override scenarios
  - API error handling
  - JSON formatting verification
  - Evaluation assets handling
  - Project structure creation
  - User interaction simulation

## Usage
```bash
# Pull all project files
$ uipath pull

# Files that differ from remote versions will prompt for confirmation
# before overwriting local changes
```

## Example Output
```
⠴ Pulling UiPath project files...
File agent.mermaid is up to date
File uv.lock is up to date
File pyproject.toml is up to date
File langgraph.json is up to date
File uipath.json is up to date
⚠️ File main.py differs from remote version.
Do you want to override it? (y/n): y
✓  Updated main.py
✓  Downloaded eval-sets\evaluation-set-1752568767335.json
✓  Downloaded eval-sets\evaluation-set-default.json
✓  Downloaded evaluators\evaluator-default.json
✓  Downloaded evaluators\evaluator-1752568815245.json
✓  Downloaded evaluators\evaluator-default-trajectory.json
```