### PR TITLE
feat: api call fixes for eval command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,13 +103,13 @@ line-ending = "auto"
 plugins = ["pydantic.mypy"]
 exclude = ["samples/.*"]
 
-
 follow_imports = "silent"
 warn_redundant_casts = true
 warn_unused_ignores = true
 disallow_any_generics = true
 check_untyped_defs = true
 no_implicit_reexport = true
+disable_error_code = ["empty-body"]
 
 disallow_untyped_defs = false
 

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -5,6 +5,7 @@ import click
 
 from .cli_auth import auth as auth  # type: ignore
 from .cli_deploy import deploy as deploy  # type: ignore
+from .cli_eval import eval as eval  # type: ignore
 from .cli_init import init as init  # type: ignore
 from .cli_invoke import invoke as invoke  # type: ignore
 from .cli_new import new as new  # type: ignore
@@ -67,3 +68,4 @@ cli.add_command(auth)
 cli.add_command(invoke)
 cli.add_command(push)
 cli.add_command(pull)
+cli.add_command(eval)

--- a/src/uipath/_cli/_evals/_evaluators/__init__.py
+++ b/src/uipath/_cli/_evals/_evaluators/__init__.py
@@ -1,0 +1,20 @@
+"""Evaluators package for the evaluation system.
+
+This package contains all evaluator types and the factory for creating them.
+"""
+
+from ._agent_scorer_evaluator import AgentScorerEvaluator
+from ._deterministic_evaluator import DeterministicEvaluator
+from ._evaluator_base import EvaluatorBase
+from ._evaluator_factory import EvaluatorFactory
+from ._llm_as_judge_evaluator import LlmAsAJudgeEvaluator
+from ._trajectory_evaluator import TrajectoryEvaluator
+
+__all__ = [
+    "EvaluatorBase",
+    "EvaluatorFactory",
+    "DeterministicEvaluator",
+    "LlmAsAJudgeEvaluator",
+    "AgentScorerEvaluator",
+    "TrajectoryEvaluator",
+]

--- a/src/uipath/_cli/_evals/_evaluators/_agent_scorer_evaluator.py
+++ b/src/uipath/_cli/_evals/_evaluators/_agent_scorer_evaluator.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+from .._models import EvaluationResult
+from ._evaluator_base import EvaluatorBase
+
+
+class AgentScorerEvaluator(EvaluatorBase):
+    """Evaluator that uses an agent to score outputs."""
+
+    def __init__(
+        self,
+        agent_config: Dict[str, Any],
+        scoring_criteria: Dict[str, Any],
+        target_output_key: str = "*",
+    ):
+        """Initialize the agent scorer evaluator.
+
+        Args:
+            agent_config: Configuration for the scoring agent
+            scoring_criteria: Criteria used for scoring
+            target_output_key: Key in output to evaluate ("*" for entire output)
+        """
+        super().__init__()
+        self.agent_config = agent_config or {}
+        self.scoring_criteria = scoring_criteria or {}
+        self.target_output_key = target_output_key
+
+    async def evaluate(
+        self,
+        evaluation_id: str,
+        evaluation_name: str,
+        input_data: Dict[str, Any],
+        expected_output: Dict[str, Any],
+        actual_output: Dict[str, Any],
+    ) -> EvaluationResult:
+        """Evaluate using an agent scorer.
+
+        Args:
+            evaluation_id: The ID of the evaluation being processed
+            evaluation_name: The name of the evaluation
+            input_data: The input data for the evaluation
+            expected_output: The expected output
+            actual_output: The actual output from the agent
+
+        Returns:
+            EvaluationResult containing the score and details
+        """
+        # TODO: Implement this
+
+        return EvaluationResult(
+            evaluation_id=evaluation_id,
+            evaluation_name=evaluation_name,
+            evaluator_id=self.id,  # type: ignore
+            evaluator_name="AgentScorer",
+            score=0.5,  # Placeholder score
+            input=input_data,
+            expected_output=expected_output,
+            actual_output=actual_output,
+            details="Agent scorer evaluation not yet implemented",
+        )

--- a/src/uipath/_cli/_evals/_evaluators/_deterministic_evaluator.py
+++ b/src/uipath/_cli/_evals/_evaluators/_deterministic_evaluator.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict
+
+from .._models import EvaluationResult
+from ._evaluator_base import EvaluatorBase
+
+
+class DeterministicEvaluator(EvaluatorBase):
+    """Evaluator for deterministic/rule-based evaluations."""
+
+    def __init__(self, rule_config: Dict[str, Any], target_output_key: str = "*"):
+        """Initialize the deterministic evaluator.
+
+        Args:
+            rule_config: Configuration for the rule (expected_value, regex_pattern, etc.)
+            target_output_key: Key in output to evaluate ("*" for entire output)
+        """
+        super().__init__()
+        self.rule_config = rule_config or {}
+        self.target_output_key = target_output_key
+
+    async def evaluate(
+        self,
+        evaluation_id: str,
+        evaluation_name: str,
+        input_data: Dict[str, Any],
+        expected_output: Dict[str, Any],
+        actual_output: Dict[str, Any],
+    ) -> EvaluationResult:
+        """Evaluate using deterministic rules.
+
+        Args:
+            evaluation_id: The ID of the evaluation being processed
+            evaluation_name: The name of the evaluation
+            input_data: The input data for the evaluation
+            expected_output: The expected output
+            actual_output: The actual output from the agent
+
+        Returns:
+            EvaluationResult containing the score and details
+        """
+        # TODO: implement this
+
+        return EvaluationResult(
+            evaluation_id=evaluation_id,
+            evaluation_name=evaluation_name,
+            evaluator_id=self.id,  # type: ignore
+            evaluator_name=self.name,  # type: ignore
+            score=0.5,
+            input=input_data,
+            expected_output=expected_output,
+            actual_output=actual_output,
+            details="details",
+        )

--- a/src/uipath/_cli/_evals/_evaluators/_evaluator_base.py
+++ b/src/uipath/_cli/_evals/_evaluators/_evaluator_base.py
@@ -1,0 +1,88 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from uipath._cli._evals._models import (
+    EvaluationResult,
+    EvaluatorCategory,
+    EvaluatorType,
+)
+
+
+@dataclass
+class EvaluatorBaseParams:
+    """Parameters for initializing the base evaluator."""
+
+    evaluator_id: str
+    category: EvaluatorCategory
+    evaluator_type: EvaluatorType
+    name: str
+    description: str
+    created_at: str
+    updated_at: str
+    target_output_key: str
+
+
+class EvaluatorBase(ABC):
+    """Abstract base class for all evaluators."""
+
+    def __init__(self):
+        # initialization done via 'from_params' function
+        self.id = None
+        self.name = None
+        self.description = None
+        self.created_at = None
+        self.updated_at = None
+        self.category = None
+        self.type = None
+        self.target_output_key = None
+        pass
+
+    @classmethod
+    def from_params(cls, params: EvaluatorBaseParams, **kwargs):
+        """Initialize the base evaluator from parameters.
+
+        Args:
+            params: EvaluatorBaseParams containing base configuration
+            **kwargs: Additional specific parameters for concrete evaluators
+
+        Returns:
+            Initialized evaluator instance
+        """
+        instance = cls(**kwargs)
+        instance.id = params.evaluator_id
+        instance.category = params.category
+        instance.type = params.evaluator_type
+        instance.name = params.name
+        instance.description = params.description
+        instance.created_at = params.created_at
+        instance.updated_at = params.updated_at
+        instance.target_output_key = params.target_output_key
+        return instance
+
+    @abstractmethod
+    async def evaluate(
+        self,
+        evaluation_id: str,
+        evaluation_name: str,
+        input_data: Dict[str, Any],
+        expected_output: Dict[str, Any],
+        actual_output: Dict[str, Any],
+    ) -> EvaluationResult:
+        """Evaluate the given data and return a result.
+
+        Args:
+            evaluation_id: The ID of the evaluation being processed
+            evaluation_name: The name of the evaluation
+            input_data: The input data for the evaluation
+            expected_output: The expected output
+            actual_output: The actual output from the agent
+
+        Returns:
+            EvaluationResult containing the score and details
+        """
+        pass
+
+    def __repr__(self) -> str:
+        """String representation of the evaluator."""
+        return f"{self.__class__.__name__}(id='{self.id}', name='{self.name}', category={self.category.name})"  # type: ignore

--- a/src/uipath/_cli/_evals/_evaluators/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluators/_evaluator_factory.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict
+
+from .._models import EvaluatorCategory, EvaluatorType
+from ._agent_scorer_evaluator import AgentScorerEvaluator
+from ._deterministic_evaluator import DeterministicEvaluator
+from ._evaluator_base import EvaluatorBase, EvaluatorBaseParams
+from ._llm_as_judge_evaluator import LlmAsAJudgeEvaluator
+from ._trajectory_evaluator import TrajectoryEvaluator
+
+
+class EvaluatorFactory:
+    """Factory class for creating evaluator instances based on configuration."""
+
+    @staticmethod
+    def create_evaluator(data: Dict[str, Any]) -> EvaluatorBase:
+        """Create an evaluator instance from configuration data.
+
+        Args:
+            data: Dictionary containing evaluator configuration from JSON file
+
+        Returns:
+            Appropriate evaluator instance based on category
+
+        Raises:
+            ValueError: If category is unknown or required fields are missing
+        """
+        # Extract common fields
+        evaluator_id = data.get("id")
+        if not evaluator_id:
+            raise ValueError("Evaluator configuration must include 'id' field")
+
+        category = EvaluatorCategory.from_int(data.get("category"))
+        evaluator_type = EvaluatorType.from_int(data.get("type", EvaluatorType.Unknown))
+        name = data.get("name", "")
+        description = data.get("description", "")
+        created_at = data.get("createdAt", "")
+        updated_at = data.get("updatedAt", "")
+        target_output_key = data.get("targetOutputKey", "")
+
+        # Create base parameters
+        base_params = EvaluatorBaseParams(
+            evaluator_id=evaluator_id,
+            category=category,
+            evaluator_type=evaluator_type,
+            name=name,
+            description=description,
+            created_at=created_at,
+            updated_at=updated_at,
+            target_output_key=target_output_key,
+        )
+
+        # Create evaluator based on category
+        if category == EvaluatorCategory.Deterministic:
+            return EvaluatorFactory._create_deterministic_evaluator(base_params, data)
+        elif category == EvaluatorCategory.LlmAsAJudge:
+            return EvaluatorFactory._create_llm_as_judge_evaluator(base_params, data)
+        elif category == EvaluatorCategory.AgentScorer:
+            return EvaluatorFactory._create_agent_scorer_evaluator(base_params, data)
+        elif category == EvaluatorCategory.Trajectory:
+            return EvaluatorFactory._create_trajectory_evaluator(base_params, data)
+        else:
+            raise ValueError(f"Unknown evaluator category: {category}")
+
+    @staticmethod
+    def _create_deterministic_evaluator(
+        base_params: EvaluatorBaseParams, data: Dict[str, Any]
+    ) -> DeterministicEvaluator:
+        """Create a deterministic evaluator."""
+        # TODO: implement this
+        pass
+
+    @staticmethod
+    def _create_llm_as_judge_evaluator(
+        base_params: EvaluatorBaseParams, data: Dict[str, Any]
+    ) -> LlmAsAJudgeEvaluator:
+        """Create an LLM-as-a-judge evaluator."""
+        prompt = data.get("prompt", "")
+        if not prompt:
+            raise ValueError("LLM evaluator must include 'prompt' field")
+
+        model = data.get("model", "")
+        if not model:
+            raise ValueError("LLM evaluator must include 'model' field")
+
+        return LlmAsAJudgeEvaluator.from_params(
+            base_params,
+            prompt=prompt,
+            model=model,
+            target_output_key=data.get("targetOutputKey", "*"),
+        )
+
+    @staticmethod
+    def _create_agent_scorer_evaluator(
+        base_params: EvaluatorBaseParams, data: Dict[str, Any]
+    ) -> AgentScorerEvaluator:
+        """Create an agent scorer evaluator."""
+        # TODO: implement this
+        pass
+
+    @staticmethod
+    def _create_trajectory_evaluator(
+        base_params: EvaluatorBaseParams, data: Dict[str, Any]
+    ) -> TrajectoryEvaluator:
+        """Create a trajectory evaluator."""
+        # TODO: implement this
+        pass

--- a/src/uipath/_cli/_evals/_evaluators/_llm_as_judge_evaluator.py
+++ b/src/uipath/_cli/_evals/_evaluators/_llm_as_judge_evaluator.py
@@ -1,0 +1,181 @@
+import json
+from typing import Any, Dict
+
+from ...._config import Config
+from ...._execution_context import ExecutionContext
+from ...._services.llm_gateway_service import UiPathLlmChatService
+from ...._utils.constants import (
+    COMMUNITY_AGENTS_SUFFIX,
+    ENV_BASE_URL,
+    ENV_UIPATH_ACCESS_TOKEN,
+    ENV_UNATTENDED_USER_ACCESS_TOKEN,
+)
+from .._models import EvaluationResult, LLMResponse
+from ._evaluator_base import EvaluatorBase
+
+
+class LlmAsAJudgeEvaluator(EvaluatorBase):
+    """Evaluator that uses an LLM to judge the quality of outputs."""
+
+    def __init__(self, prompt: str = "", model: str = "", target_output_key: str = "*"):
+        """Initialize the LLM-as-a-judge evaluator.
+
+        Args:
+            prompt: The prompt template for the LLM
+            model: The model to use for evaluation
+            target_output_key: Key in output to evaluate ("*" for entire output)
+        """
+        super().__init__()
+        self.actual_output_placeholder = "{{ActualOutput}}"
+        self.expected_output_placeholder = "{{ExpectedOutput}}"
+        self._initialize_llm()
+        self.prompt = prompt
+        self.model = model
+        self.target_output_key: str = target_output_key
+
+    def _initialize_llm(self):
+        """Initialize the LLM used for evaluation."""
+        import os
+
+        base_url_value = os.getenv(ENV_BASE_URL)
+        secret_value = os.getenv(ENV_UNATTENDED_USER_ACCESS_TOKEN) or os.getenv(
+            ENV_UIPATH_ACCESS_TOKEN
+        )
+        config = Config(
+            base_url=base_url_value,  # type: ignore
+            secret=secret_value,  # type: ignore
+        )
+        self.llm = UiPathLlmChatService(config, ExecutionContext())
+
+    async def evaluate(
+        self,
+        evaluation_id: str,
+        evaluation_name: str,
+        input_data: Dict[str, Any],
+        expected_output: Dict[str, Any],
+        actual_output: Dict[str, Any],
+    ) -> EvaluationResult:
+        """Evaluate using an LLM as a judge.
+
+        Args:
+            evaluation_id: The ID of the evaluation being processed
+            evaluation_name: The name of the evaluation
+            input_data: The input data for the evaluation
+            expected_output: The expected output
+            actual_output: The actual output from the agent
+
+        Returns:
+            EvaluationResult containing the score and details
+        """
+        # Extract the target value to evaluate
+        target_value = self._extract_target_value(actual_output)
+        expected_value = self._extract_target_value(expected_output)
+
+        # Create the evaluation prompt
+        evaluation_prompt = self._create_evaluation_prompt(expected_value, target_value)
+
+        llm_response = await self._get_llm_response(evaluation_prompt)
+
+        return EvaluationResult(
+            evaluation_id=evaluation_id,
+            evaluation_name=evaluation_name,
+            evaluator_id=self.id,  # type: ignore
+            evaluator_name=self.name,  # type: ignore
+            score=llm_response.score,
+            input=input_data,
+            expected_output=expected_output,
+            actual_output=actual_output,
+            details=llm_response.justification,
+        )
+
+    def _extract_target_value(self, output: Dict[str, Any]) -> Any:
+        """Extract the target value from output based on target_output_key."""
+        if self.target_output_key == "*":
+            return output
+
+        # Handle nested keys
+        keys = self.target_output_key.split(".")
+        value = output
+
+        try:
+            for key in keys:
+                if isinstance(value, dict):
+                    value = value[key]
+                else:
+                    return None
+            return value
+        except (KeyError, TypeError):
+            return None
+
+    def _create_evaluation_prompt(
+        self, expected_output: Dict[str, Any], actual_output: Dict[str, Any]
+    ) -> str:
+        """Create the evaluation prompt for the LLM."""
+        # Convert complex objects to JSON strings for the prompt
+        # Use the template prompt and substitute variables
+        formatted_prompt = self.prompt.replace(
+            self.actual_output_placeholder, json.dumps(actual_output, indent=2)
+        )
+        formatted_prompt = formatted_prompt.replace(
+            self.expected_output_placeholder, json.dumps(expected_output, indent=2)
+        )
+
+        return formatted_prompt
+
+    async def _get_llm_response(self, evaluation_prompt: str) -> LLMResponse:
+        """Get response from the LLM.
+
+        Args:
+            prompt: The formatted prompt to send to the LLM
+
+        Returns:
+            LLMResponse with score and justification
+        """
+        try:
+            # remove community-agents suffix from llm model name
+            model = self.model
+            if model.endswith(COMMUNITY_AGENTS_SUFFIX):
+                model = model.replace(COMMUNITY_AGENTS_SUFFIX, "")
+
+            # Prepare the request
+            request_data = {
+                "model": model,
+                "messages": [{"role": "user", "content": evaluation_prompt}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "evaluation_response",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "score": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 100,
+                                    "description": "Score between 0 and 100",
+                                },
+                                "justification": {
+                                    "type": "string",
+                                    "description": "Explanation for the score",
+                                },
+                            },
+                            "required": ["score", "justification"],
+                        },
+                    },
+                },
+            }
+
+            response = await self.llm.chat_completions(**request_data)
+
+            try:
+                return LLMResponse(**json.loads(response.choices[-1].message.content))
+            except (json.JSONDecodeError, ValueError) as e:
+                return LLMResponse(
+                    score=0.0, justification=f"Error parsing LLM response: {str(e)}"
+                )
+
+        except Exception as e:
+            # Fallback in case of any errors
+            return LLMResponse(
+                score=0.0, justification=f"Error during LLM evaluation: {str(e)}"
+            )

--- a/src/uipath/_cli/_evals/_evaluators/_trajectory_evaluator.py
+++ b/src/uipath/_cli/_evals/_evaluators/_trajectory_evaluator.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+from .._models import EvaluationResult
+from ._evaluator_base import EvaluatorBase
+
+
+class TrajectoryEvaluator(EvaluatorBase):
+    """Evaluator that analyzes the trajectory/path taken to reach outputs."""
+
+    def __init__(
+        self,
+        trajectory_config: Dict[str, Any],
+        step_weights: Dict[str, float],
+        target_output_key: str = "*",
+    ):
+        """Initialize the trajectory evaluator.
+
+        Args:
+            trajectory_config: Configuration for trajectory analysis
+            step_weights: Weights for different steps in the trajectory
+            target_output_key: Key in output to evaluate ("*" for entire output)
+        """
+        super().__init__()
+        self.trajectory_config = trajectory_config or {}
+        self.step_weights = step_weights or {}
+        self.target_output_key = target_output_key
+
+    async def evaluate(
+        self,
+        evaluation_id: str,
+        evaluation_name: str,
+        input_data: Dict[str, Any],
+        expected_output: Dict[str, Any],
+        actual_output: Dict[str, Any],
+    ) -> EvaluationResult:
+        """Evaluate using trajectory analysis.
+
+        Args:
+            evaluation_id: The ID of the evaluation being processed
+            evaluation_name: The name of the evaluation
+            input_data: The input data for the evaluation
+            expected_output: The expected output
+            actual_output: The actual output from the agent
+
+        Returns:
+            EvaluationResult containing the score and details
+        """
+        # TODO: Implement this
+
+        return EvaluationResult(
+            evaluation_id=evaluation_id,
+            evaluation_name=evaluation_name,
+            evaluator_id=self.id,  # type: ignore
+            evaluator_name=self.name,  # type: ignore
+            score=0.7,
+            input=input_data,
+            expected_output=expected_output,
+            actual_output=actual_output,
+            details="Trajectory evaluation not yet implemented",
+        )

--- a/src/uipath/_cli/_evals/_models/__init__.py
+++ b/src/uipath/_cli/_evals/_models/__init__.py
@@ -1,0 +1,18 @@
+from uipath._cli._evals._models._evaluation_set import EvaluationItem, EvaluationSet
+from uipath._cli._evals._models._evaluators import (
+    EvaluationResult,
+    EvaluationSetResult,
+    EvaluatorCategory,
+    EvaluatorType,
+    LLMResponse,
+)
+
+__all__ = [
+    "LLMResponse",
+    "EvaluatorCategory",
+    "EvaluatorType",
+    "EvaluationResult",
+    "EvaluationSetResult",
+    "EvaluationItem",
+    "EvaluationSet",
+]

--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -1,0 +1,43 @@
+from enum import IntEnum
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class EvaluationItem(BaseModel):
+    """Individual evaluation item within an evaluation set."""
+
+    id: str
+    name: str
+    inputs: Dict[str, Any]
+    expectedOutput: Dict[str, Any]
+    expectedAgentBehavior: str = ""
+    simulationInstructions: str = ""
+    simulateInput: bool = False
+    inputGenerationInstructions: str = ""
+    simulateTools: bool = False
+    toolsToSimulate: List[str] = Field(default_factory=list)
+    evalSetId: str
+    createdAt: str
+    updatedAt: str
+
+
+class EvaluationSet(BaseModel):
+    """Complete evaluation set model."""
+
+    id: str
+    fileName: str
+    evaluatorRefs: List[str] = Field(default_factory=list)
+    evaluations: List[EvaluationItem] = Field(default_factory=list)
+    name: str
+    batchSize: int = 10
+    timeoutMinutes: int = 20
+    modelSettings: List[Dict[str, Any]] = Field(default_factory=list)
+    createdAt: str
+    updatedAt: str
+
+
+class EvaluationStatus(IntEnum):
+    PENDING = 0
+    IN_PROGRESS = 1
+    COMPLETED = 2

--- a/src/uipath/_cli/_evals/_models/_evaluators.py
+++ b/src/uipath/_cli/_evals/_models/_evaluators.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from enum import IntEnum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LLMResponse(BaseModel):
+    score: float
+    justification: str
+
+
+class EvaluatorCategory(IntEnum):
+    """Types of evaluators."""
+
+    Deterministic = 0
+    LlmAsAJudge = 1
+    AgentScorer = 2
+    Trajectory = 3
+
+    @classmethod
+    def from_int(cls, value):
+        """Construct EvaluatorCategory from an int value."""
+        if value in cls._value2member_map_:
+            return cls(value)
+        else:
+            raise ValueError(f"{value} is not a valid EvaluatorCategory value")
+
+
+class EvaluatorType(IntEnum):
+    """Subtypes of evaluators."""
+
+    Unknown = 0
+    Equals = 1
+    Contains = 2
+    Regex = 3
+    Factuality = 4
+    Custom = 5
+    JsonSimilarity = 6
+    Trajectory = 7
+    ContextPrecision = 8
+    Faithfulness = 9
+
+    @classmethod
+    def from_int(cls, value):
+        """Construct EvaluatorCategory from an int value."""
+        if value in cls._value2member_map_:
+            return cls(value)
+        else:
+            raise ValueError(f"{value} is not a valid EvaluatorType value")
+
+
+class EvaluationResult(BaseModel):
+    """Result of a single evaluation."""
+
+    evaluation_id: str
+    evaluation_name: str
+    evaluator_id: str
+    evaluator_name: str
+    score: float
+    input: Dict[str, Any]
+    expected_output: Dict[str, Any]
+    actual_output: Dict[str, Any]
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    details: Optional[str] = None
+
+
+class EvaluationSetResult(BaseModel):
+    """Result of a complete evaluation set."""
+
+    eval_set_id: str
+    eval_set_name: str
+    results: List[EvaluationResult]
+    average_score: float
+
+
+class EvaluatorStatus(IntEnum):
+    BOOLEAN = 0
+    NUMERICAL = 1
+    ERROR = 2

--- a/src/uipath/_cli/_evals/evaluation_service.py
+++ b/src/uipath/_cli/_evals/evaluation_service.py
@@ -1,0 +1,474 @@
+"""Evaluation service for running and managing evaluation sets."""
+
+import asyncio
+import json
+import os
+import tempfile
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import click
+
+from uipath._cli._utils._console import ConsoleLogger
+
+from ..cli_run import run_core  # type: ignore
+from ._evaluators._evaluator_base import EvaluatorBase
+from ._evaluators._evaluator_factory import EvaluatorFactory
+from ._models import (
+    EvaluationSet,
+    EvaluationSetResult,
+)
+from .progress_reporter import ProgressReporter
+
+console = ConsoleLogger()
+
+
+class EvaluationService:
+    """Service for running evaluations."""
+
+    def __init__(
+        self,
+        entrypoint: str,
+        eval_set_path: str | Path,
+        workers: int,
+        report_progress: bool,
+    ):
+        """Initialize the evaluation service.
+
+        Args:
+            entrypoint: Path to the agent script to evaluate
+            eval_set_path: Path to the evaluation set file (can be string or Path)
+            workers: Number of parallel workers for running evaluations
+            report_progress: Whether to report progress to StudioWeb
+        """
+        self.entrypoint = entrypoint
+        self.eval_set_path = Path(eval_set_path)
+        self.eval_set = self._load_eval_set()
+        self._evaluators = self._load_evaluators()
+        self.num_workers = workers
+        self.results_lock = asyncio.Lock()
+        self._progress_manager: Optional[Any] = None
+        self._report_progress = report_progress
+        self._progress_reporter: Optional[ProgressReporter] = None
+        self._initialize_results()
+
+    def _initialize_results(self) -> None:
+        """Initialize the results file and directory."""
+        self._create_and_initialize_results_file()
+        # Initialize progress reporter if needed
+        if self._report_progress:
+            agent_snapshot = self._extract_agent_snapshot()
+            self._progress_reporter = ProgressReporter(
+                eval_set_id=self.eval_set.id,
+                agent_snapshot=agent_snapshot,
+                no_of_evals=len(self.eval_set.evaluations),
+                evaluators=self._evaluators,
+            )
+
+    def _extract_agent_snapshot(self) -> str:
+        """Extract agent snapshot from uipath.json file.
+
+        Returns:
+            JSON string containing the agent snapshot with input and output schemas
+        """
+        config_file = "uipath.json"
+        if not os.path.isfile(config_file):
+            console.error(f"File '{config_file}' not found. Please run 'uipath init'")
+
+        with open(config_file, "r", encoding="utf-8") as f:
+            file_content = f.read()
+        uipath_config = json.loads(file_content)
+
+        entry_point = None
+        for ep in uipath_config.get("entryPoints", []):
+            if ep.get("filePath") == self.entrypoint:
+                entry_point = ep
+                break
+
+        if not entry_point:
+            console.error(
+                f"No entry point found with filePath '{self.entrypoint}' in uipath.json"
+            )
+
+        input_schema = entry_point.get("input", {})  # type: ignore
+        output_schema = entry_point.get("output", {})  # type: ignore
+
+        # Format as agent snapshot
+        agent_snapshot = {"inputSchema": input_schema, "outputSchema": output_schema}
+
+        return json.dumps(agent_snapshot)
+
+    def _create_and_initialize_results_file(self):
+        # Create results directory if it doesn't exist
+        results_dir = self.eval_set_path.parent.parent / "results"
+        results_dir.mkdir(exist_ok=True)
+
+        # Create results file
+        timestamp = datetime.now(timezone.utc).strftime("%M-%H-%d-%m-%Y")
+        eval_set_name = self.eval_set.name
+        self.result_file = results_dir / f"eval-{eval_set_name}-{timestamp}.json"
+
+        initial_results = EvaluationSetResult(
+            eval_set_id=self.eval_set.id,
+            eval_set_name=self.eval_set.name,
+            results=[],
+            average_score=0.0,
+        )
+
+        with open(self.result_file, "w", encoding="utf-8") as f:
+            f.write(initial_results.model_dump_json(indent=2))
+
+    def _load_eval_set(self) -> EvaluationSet:
+        """Load the evaluation set from file.
+
+        Returns:
+            The loaded evaluation set as EvaluationSet model
+        """
+        with open(self.eval_set_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return EvaluationSet(**data)
+
+    def _load_evaluators(self) -> List[EvaluatorBase]:
+        """Load evaluators referenced by the evaluation set."""
+        evaluators = []
+        evaluators_dir = self.eval_set_path.parent.parent / "evaluators"
+        evaluator_refs = set(self.eval_set.evaluatorRefs)
+        found_evaluator_ids = set()
+
+        # Load evaluators from JSON files
+        for file in evaluators_dir.glob("*.json"):
+            with open(file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                evaluator_id = data.get("id")
+
+                if evaluator_id in evaluator_refs:
+                    try:
+                        evaluator = EvaluatorFactory.create_evaluator(data)
+                        evaluators.append(evaluator)
+                        found_evaluator_ids.add(evaluator_id)
+                    except Exception as e:
+                        console.warning(
+                            f"Failed to create evaluator {evaluator_id}: {str(e)}"
+                        )
+
+        # Check if all referenced evaluators were found
+        missing_evaluators = evaluator_refs - found_evaluator_ids
+        if missing_evaluators:
+            raise ValueError(
+                f"Could not find evaluators with IDs: {missing_evaluators}"
+            )
+
+        return evaluators
+
+    async def _write_results(self, results: List[Any]) -> None:
+        """Write evaluation results to file with async lock.
+
+        Args:
+            results: List of evaluation results to write
+        """
+        async with self.results_lock:
+            # Read current results
+            with open(self.result_file, "r", encoding="utf-8") as f:
+                current_results = EvaluationSetResult.model_validate_json(f.read())
+
+            # Add new results
+            current_results.results.extend(results)
+
+            if current_results.results:
+                current_results.average_score = sum(
+                    r.score for r in current_results.results
+                ) / len(current_results.results)
+
+            # Write updated results
+            with open(self.result_file, "w", encoding="utf-8") as f:
+                f.write(current_results.model_dump_json(indent=2))
+
+    async def _results_queue_consumer(self, results_queue: asyncio.Queue[Any]) -> None:
+        """Consumer task for the results queue that writes to local file.
+
+        Args:
+            results_queue: Queue containing evaluation results to write to file
+        """
+        while True:
+            results = await results_queue.get()
+            if results is None:
+                # Sentinel value - consumer should stop
+                results_queue.task_done()
+                return
+
+            try:
+                await self._write_results(results)
+                results_queue.task_done()
+            except Exception as e:
+                console.warning(f"Error writing results to file: {str(e)}")
+                results_queue.task_done()
+
+    async def _sw_progress_reporter_queue_consumer(
+        self, sw_progress_reporter_queue: asyncio.Queue[Any]
+    ) -> None:
+        """Consumer task for the SW progress reporter.
+
+        Args:
+            sw_progress_reporter_queue: Queue containing evaluation results to report to StudioWeb
+        """
+        while True:
+            queue_item = await sw_progress_reporter_queue.get()
+            if queue_item is None:
+                # Sentinel value - consumer should stop
+                sw_progress_reporter_queue.task_done()
+                return
+
+            eval_run_id, eval_results, actual_output, success = queue_item
+
+            try:
+                if self._progress_reporter:
+                    await self._progress_reporter.update_eval_run(
+                        eval_results, eval_run_id, actual_output, success
+                    )
+                sw_progress_reporter_queue.task_done()
+            except Exception as e:
+                console.warning(f"Error reporting progress to StudioWeb: {str(e)}")
+                sw_progress_reporter_queue.task_done()
+
+    def _run_agent(
+        self, input_json: str, eval_item: dict[str, Any]
+    ) -> tuple[Dict[str, Any], bool]:
+        """Run the agent with the given input.
+
+        Args:
+            input_json: JSON string containing input data
+
+        Returns:
+            Agent output as dictionary and success status
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                output_file = Path(tmpdir) / "output.json"
+                logs_file = Path(tmpdir) / "execution.log"
+
+                # Suppress LangChain deprecation warnings during agent execution
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", category=UserWarning, module="langchain"
+                    )
+                    # Note: Progress reporting is handled outside this method since it's async
+
+                    success, error_message, info_message = run_core(
+                        entrypoint=self.entrypoint,
+                        input=input_json,
+                        resume=False,
+                        input_file=None,
+                        execution_output_file=output_file,
+                        logs_file=logs_file,
+                        runtime_dir=tmpdir,
+                        eval_run=True,
+                    )
+                if not success:
+                    console.warning(error_message)
+                    return {}, False
+                else:
+                    # Read the output file
+                    with open(output_file, "r", encoding="utf-8") as f:
+                        result = json.load(f)
+
+                    # uncomment the following lines to have access to the execution.logs (needed for some types of evals)
+                    # with open(logs_file, "r", encoding="utf-8") as f:
+                    #     logs = f.read()
+                    if isinstance(result, str):
+                        try:
+                            return json.loads(result), True
+                        except json.JSONDecodeError as e:
+                            raise Exception(f"Error parsing output: {e}") from e
+                return result, True
+
+            except Exception as e:
+                console.warning(f"Error running agent: {str(e)}")
+                return {"error": str(e)}, False
+
+    async def _process_evaluation(
+        self,
+        eval_item: Dict[str, Any],
+        worker_id: int,
+        results_queue: asyncio.Queue[Any],
+        sw_progress_reporter_queue: asyncio.Queue[Any],
+    ) -> None:
+        """Process a single evaluation item.
+
+        Args:
+            eval_item: The evaluation item to process
+            worker_id: ID of the worker processing this evaluation
+            results_queue: Queue for local file results
+            sw_progress_reporter_queue: Queue for StudioWeb progress reporting
+        """
+        eval_id = eval_item["id"]
+        eval_run_id: Optional[str] = None
+
+        if self._progress_manager:
+            self._progress_manager.start_evaluation(eval_id, worker_id)
+
+        try:
+            input_json = json.dumps(eval_item["inputs"])
+
+            if self._report_progress and self._progress_reporter:
+                eval_run_id = await self._progress_reporter.create_eval_run(eval_item)
+
+            loop = asyncio.get_running_loop()
+            actual_output, success = await loop.run_in_executor(
+                None, self._run_agent, input_json, eval_item
+            )
+
+            if success:
+                # Run each evaluator
+                eval_results = {}
+                for evaluator in self._evaluators:
+                    result = await evaluator.evaluate(
+                        evaluation_id=eval_item["id"],
+                        evaluation_name=eval_item["name"],
+                        input_data=eval_item["inputs"],
+                        expected_output=eval_item["expectedOutput"],
+                        actual_output=actual_output,
+                    )
+                    eval_results[evaluator.id] = result
+
+                await results_queue.put(
+                    [eval_result for eval_result in eval_results.values()]
+                )
+
+                if self._report_progress:
+                    # TODO: modify this, here we are only reporting for success
+                    await sw_progress_reporter_queue.put(
+                        (eval_run_id, eval_results, actual_output, success)
+                    )
+
+                # Update progress to completed
+                if self._progress_manager:
+                    self._progress_manager.complete_evaluation(eval_id)
+            else:
+                # Mark as failed if agent execution failed
+                if self._progress_manager:
+                    self._progress_manager.fail_evaluation(
+                        eval_id, "Agent execution failed"
+                    )
+
+        except Exception as e:
+            # Mark as failed with error message
+            if self._progress_manager:
+                self._progress_manager.fail_evaluation(eval_id, str(e))
+            raise
+
+    async def _producer_task(self, task_queue: asyncio.Queue[Any]) -> None:
+        """Producer task that adds all evaluations to the queue.
+
+        Args:
+            task_queue: The asyncio queue to add tasks to
+        """
+        for eval_item in self.eval_set.evaluations:
+            await task_queue.put(eval_item.model_dump())
+
+        # Add sentinel values to signal workers to stop
+        for _ in range(self.num_workers):
+            await task_queue.put(None)
+
+    async def _consumer_task(
+        self,
+        task_queue: asyncio.Queue[Any],
+        worker_id: int,
+        results_queue: asyncio.Queue[Any],
+        sw_progress_reporter_queue: asyncio.Queue[Any],
+    ) -> None:
+        """Consumer task that processes evaluations from the queue.
+
+        Args:
+            task_queue: The asyncio queue to get tasks from
+            worker_id: ID of this worker for logging
+            results_queue: Queue for local file results
+            sw_progress_reporter_queue: Queue for StudioWeb progress reporting
+        """
+        while True:
+            eval_item = await task_queue.get()
+            if eval_item is None:
+                # Sentinel value - worker should stop
+                task_queue.task_done()
+                return
+
+            try:
+                await self._process_evaluation(
+                    eval_item, worker_id, results_queue, sw_progress_reporter_queue
+                )
+                task_queue.task_done()
+            except Exception as e:
+                # Log error and continue to next item
+                task_queue.task_done()
+                console.warning(
+                    f"Evaluation {eval_item.get('name', 'Unknown')} failed: {str(e)}"
+                )
+
+    async def run_evaluation(self) -> None:
+        """Run the evaluation set using multiple worker tasks."""
+        console.info(
+            f"Starting evaluating {click.style(self.eval_set.name, fg='cyan')} evaluation set..."
+        )
+
+        if self._report_progress and self._progress_reporter:
+            await self._progress_reporter.create_eval_set_run()
+
+        # Prepare items for progress tracker
+        progress_items = [
+            {"id": eval_item.id, "name": eval_item.name}
+            for eval_item in self.eval_set.evaluations
+        ]
+
+        with console.evaluation_progress(progress_items) as progress_manager:
+            self._progress_manager = progress_manager
+
+            task_queue: asyncio.Queue[Any] = asyncio.Queue()
+            results_queue: asyncio.Queue[Any] = asyncio.Queue()
+            sw_progress_reporter_queue: asyncio.Queue[Any] = asyncio.Queue()
+
+            producer = asyncio.create_task(self._producer_task(task_queue))
+
+            consumers = []
+            for worker_id in range(self.num_workers):
+                consumer = asyncio.create_task(
+                    self._consumer_task(
+                        task_queue, worker_id, results_queue, sw_progress_reporter_queue
+                    )
+                )
+                consumers.append(consumer)
+
+            # Create results queue consumer
+            results_consumer = asyncio.create_task(
+                self._results_queue_consumer(results_queue)
+            )
+
+            # Create SW progress reporter queue consumer
+            sw_progress_consumer = None
+            if self._report_progress:
+                sw_progress_consumer = asyncio.create_task(
+                    self._sw_progress_reporter_queue_consumer(
+                        sw_progress_reporter_queue
+                    )
+                )
+
+            # Wait for producer to finish
+            await producer
+            await task_queue.join()
+
+            # Wait for all consumers to finish
+            await asyncio.gather(*consumers)
+
+            # Signal queue consumers to stop by sending sentinel values
+            await results_queue.put(None)
+            if self._report_progress:
+                await sw_progress_reporter_queue.put(None)
+
+            await results_consumer
+            if sw_progress_consumer:
+                await sw_progress_consumer
+
+            if self._progress_reporter:
+                await self._progress_reporter.update_eval_set_run()
+
+        console.info(f"Results saved to {click.style(self.result_file, fg='cyan')}")

--- a/src/uipath/_cli/_evals/evaluation_service.py
+++ b/src/uipath/_cli/_evals/evaluation_service.py
@@ -323,6 +323,8 @@ class EvaluationService:
                 # Run each evaluator
                 eval_results = {}
                 for evaluator in self._evaluators:
+                    if evaluator is None:  ##TODO: Remove this if condition (this is due to _create_trajectory_evaluator in _evaluator_factory.py)
+                        continue
                     result = await evaluator.evaluate(
                         evaluation_id=eval_item["id"],
                         evaluation_name=eval_item["name"],

--- a/src/uipath/_cli/_evals/progress_reporter.py
+++ b/src/uipath/_cli/_evals/progress_reporter.py
@@ -1,0 +1,265 @@
+"""Progress reporter for sending evaluation updates to StudioWeb."""
+
+import json
+import logging
+import os
+from typing import Any, List
+
+from uipath import UiPath
+from uipath._cli._evals._evaluators import EvaluatorBase
+from uipath._cli._evals._models import EvaluationResult
+from uipath._cli._evals._models._evaluation_set import EvaluationStatus
+from uipath._cli._evals._models._evaluators import EvaluatorStatus
+from uipath._cli._utils._console import ConsoleLogger
+from uipath._utils import Endpoint, RequestSpec
+from uipath._utils.constants import ENV_TENANT_ID, HEADER_INTERNAL_TENANT_ID
+
+
+class ProgressReporter:
+    """Handles reporting evaluation progress to StudioWeb via API calls."""
+
+    def __init__(
+        self,
+        eval_set_id: str,
+        agent_snapshot: str,
+        no_of_evals: int,
+        evaluators: List[EvaluatorBase],
+    ):
+        """Initialize the progress reporter.
+
+        Args:
+            eval_set_id: ID of the evaluation set
+            agent_snapshot: JSON snapshot of the agent configuration
+            no_of_evals: Number of evaluations in the set
+            evaluators: List of evaluator instances
+        """
+        self._eval_set_id = eval_set_id
+        self.agent_snapshot = agent_snapshot
+        self._no_of_evals = no_of_evals
+        self._evaluators = evaluators
+
+        # Disable middleware logging and use the same console as ConsoleLogger
+        logging.getLogger("uipath._cli.middlewares").setLevel(logging.CRITICAL)
+
+        console_logger = ConsoleLogger.get_instance()
+
+        uipath = UiPath()
+
+        self._eval_set_run_id = None
+        self._client = uipath.api_client
+        self._console = console_logger
+        self._project_id = os.getenv("UIPATH_PROJECT_ID", None)
+        if not self._project_id:
+            self._console.warning(
+                "Cannot report data to StudioWeb. Please set UIPATH_PROJECT_ID."
+            )
+
+    async def create_eval_run(self, eval_snapshot: dict[str, Any]):
+        """Create a new evaluation run in StudioWeb.
+
+        Args:
+            eval_snapshot: Dictionary containing evaluation data
+
+        Returns:
+            The ID of the created evaluation run
+        """
+        spec = self._create_eval_run_spec(eval_snapshot)
+        response = await self._client.request_async(
+            method=spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            content=spec.content,
+            headers=spec.headers,
+            scoped="org",
+        )
+
+        return json.loads(response.content)["id"]
+
+    async def update_eval_run(
+        self,
+        eval_results: dict[str, EvaluationResult],
+        eval_run_id: str,
+        actual_output: dict[str, Any],
+        success: bool,
+    ):
+        """Update an evaluation run with results.
+
+        Args:
+            eval_results: Dictionary mapping evaluator IDs to evaluation results
+            eval_run_id: ID of the evaluation run to update
+            actual_output: The actual output from the agent
+            success: Whether the evaluation was successful
+        """
+        spec = self._update_eval_run_spec(
+            eval_results, eval_run_id, actual_output, success
+        )
+        await self._client.request_async(
+            method=spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            content=spec.content,
+            headers=spec.headers,
+            scoped="org",
+        )
+
+    async def create_eval_set_run(self):
+        """Create a new evaluation set run in StudioWeb."""
+        spec = self._create_eval_set_run_spec()
+        response = await self._client.request_async(
+            method=spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            content=spec.content,
+            headers=spec.headers,
+            scoped="org",
+        )
+
+        self._eval_set_run_id = json.loads(response.content)["id"]
+
+    async def update_eval_set_run(self):
+        """Update the evaluation set run status to completed."""
+        spec = self._update_eval_set_run_spec()
+        await self._client.request_async(
+            method=spec.method,
+            url=spec.endpoint,
+            params=spec.params,
+            content=spec.content,
+            headers=spec.headers,
+            scoped="org",
+        )
+
+    def _update_eval_run_spec(
+        self,
+        eval_results: dict[str, EvaluationResult],
+        eval_run_id: str,
+        actual_output: dict[str, Any],
+        success: bool,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="PUT",
+            endpoint=Endpoint(
+                f"agents_/api/execution/agents/{self._project_id}/evalRun"
+            ),
+            content=json.dumps(
+                {
+                    "evalRunId": eval_run_id,
+                    "status": EvaluationStatus.COMPLETED.value,
+                    "result": {
+                        "output": {
+                            **actual_output,
+                        }
+                    },
+                    "evaluatorScores": [
+                        {
+                            # TODO: here we should extract the exact value type (0 = boolean, 1 = numerical, 2 = error)
+                            "type": EvaluatorStatus.NUMERICAL.value
+                            if success
+                            else EvaluatorStatus.ERROR.value,
+                            "value": eval_results[evaluator.id].score,  # type: ignore
+                            "justification": eval_results[evaluator.id].details,  # type: ignore
+                            "evaluatorId": evaluator.id,
+                        }
+                        for evaluator in self._evaluators
+                    ],
+                    "completionMetrics": None,
+                    "assertionRuns": [],
+                }
+            ),
+            headers=self._tenant_header(),
+        )
+
+    def _create_eval_run_spec(self, eval_snapshot: dict[str, Any]) -> RequestSpec:
+        return RequestSpec(
+            method="POST",
+            endpoint=Endpoint(
+                f"agents_/api/execution/agents/{self._project_id}/evalRun"
+            ),
+            content=json.dumps(
+                {
+                    "evalSetRunId": self._eval_set_run_id,
+                    "evalSnapshot": eval_snapshot,
+                    "status": EvaluationStatus.IN_PROGRESS.value,
+                    "assertionRuns": [
+                        {
+                            "assertionSnapshot": {
+                                "id": evaluator.id,
+                                "assertionType": evaluator.type.name,  # type: ignore
+                                "targetOutputKey": evaluator.target_output_key,
+                            },
+                            "status": 1,
+                            "evaluatorId": evaluator.id,
+                        }
+                        for evaluator in self._evaluators
+                    ],
+                }
+            ),
+            headers=self._tenant_header(),
+        )
+
+    def _create_eval_set_run_spec(
+        self,
+    ) -> RequestSpec:
+        self._add_defaults_to_agent_snapshot()
+        # Parse the agent_snapshot JSON string back to a dict for the API call
+        agent_snapshot_dict = json.loads(self.agent_snapshot)
+
+        return RequestSpec(
+            method="POST",
+            endpoint=Endpoint(
+                f"agents_/api/execution/agents/{self._project_id}/evalSetRun"
+            ),
+            content=json.dumps(
+                {
+                    "agentId": self._project_id,
+                    "evalSetId": self._eval_set_id,
+                    "agentSnapshot": agent_snapshot_dict,
+                    "status": EvaluationStatus.IN_PROGRESS.value,
+                    "numberOfEvalsExecuted": self._no_of_evals,
+                }
+            ),
+            headers=self._tenant_header(),
+        )
+
+    def _update_eval_set_run_spec(
+        self,
+    ) -> RequestSpec:
+        return RequestSpec(
+            method="PUT",
+            endpoint=Endpoint(
+                f"agents_/api/execution/agents/{self._project_id}/evalSetRun"
+            ),
+            content=json.dumps(
+                {
+                    ## TODO: send the actual data here (do we need to send those again? isn't it redundant?)
+                    "evalSetRunId": self._eval_set_run_id,
+                    "score": 0,
+                    "status": EvaluationStatus.COMPLETED.value,
+                    "evaluatorScores": [],
+                }
+            ),
+            headers=self._tenant_header(),
+        )
+
+    def _add_defaults_to_agent_snapshot(self):
+        ## TODO: remove this after properties are marked as optional at api level
+        agent_snapshot_dict = json.loads(self.agent_snapshot)
+        agent_snapshot_dict["tools"] = []
+        agent_snapshot_dict["contexts"] = []
+        agent_snapshot_dict["escalations"] = []
+        agent_snapshot_dict["systemPrompt"] = "unknown"
+        agent_snapshot_dict["userPrompt"] = "unknown"
+        agent_snapshot_dict["settings"] = {
+            "model": "unknown",
+            "maxTokens": 0,
+            "temperature": 0,
+            "engine": "unknown",
+        }
+        self.agent_snapshot = json.dumps(agent_snapshot_dict)
+
+    def _tenant_header(self) -> dict[str, str]:
+        tenant_id = os.getenv(ENV_TENANT_ID, None)
+        if not tenant_id:
+            self._console.error(
+                f"{ENV_TENANT_ID} env var is not set. Please run 'uipath auth'."
+            )
+        return {HEADER_INTERNAL_TENANT_ID: tenant_id}  # type: ignore

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -158,15 +158,17 @@ class UiPathRuntimeContext(BaseModel):
     result: Optional[UiPathRuntimeResult] = None
     execution_output_file: Optional[str] = None
     input_file: Optional[str] = None
+    eval_run: bool = False
 
     model_config = {"arbitrary_types_allowed": True}
 
     @classmethod
-    def from_config(cls, config_path=None):
+    def from_config(cls, config_path=None, **kwargs) -> "UiPathRuntimeContext":
         """Load configuration from uipath.json file.
 
         Args:
             config_path: Path to the configuration file. If None, uses the default "uipath.json"
+            **kwargs: Additional keyword arguments to use as fallback for configuration values
 
         Returns:
             An instance of the class with fields populated from the config file
@@ -184,19 +186,28 @@ class UiPathRuntimeContext(BaseModel):
 
         instance = cls()
 
+        mapping = {
+            "dir": "runtime_dir",
+            "outputFile": "output_file",
+            "stateFile": "state_file",
+            "logsFile": "logs_file",
+        }
+
+        attributes_set = set()
+        # set values from config file if available
         if "runtime" in config:
             runtime_config = config["runtime"]
-
-            mapping = {
-                "dir": "runtime_dir",
-                "outputFile": "output_file",
-                "stateFile": "state_file",
-                "logsFile": "logs_file",
-            }
-
             for config_key, attr_name in mapping.items():
                 if config_key in runtime_config and hasattr(instance, attr_name):
+                    attributes_set.add(attr_name)
                     setattr(instance, attr_name, runtime_config[config_key])
+
+        # fallback to kwargs for any values not set from config file
+        for _, attr_name in mapping.items():
+            if attr_name in kwargs and hasattr(instance, attr_name):
+                # Only set from kwargs if not already set from config file
+                if attr_name not in attributes_set:
+                    setattr(instance, attr_name, kwargs[attr_name])
 
         return instance
 
@@ -310,12 +321,13 @@ class UiPathBaseRuntime(ABC):
             with open(self.context.input_file) as f:
                 self.context.input = f.read()
 
-        # Intercept all stdout/stderr/logs and write them to a file (runtime), stdout (debug)
+        # Intercept all stdout/stderr/logs and write them to a file (runtime/evals), stdout (debug)
         self.logs_interceptor = LogsInterceptor(
             min_level=self.context.logs_min_level,
             dir=self.context.runtime_dir,
             file=self.context.logs_file,
             job_id=self.context.job_id,
+            eval_run=self.context.eval_run,
         )
         self.logs_interceptor.setup()
 

--- a/src/uipath/_cli/_utils/_console.py
+++ b/src/uipath/_cli/_utils/_console.py
@@ -1,10 +1,17 @@
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, Iterator, List, Optional, Type, TypeVar
+from typing import Any, Dict, Iterator, List, Optional, Type, TypeVar
 
 import click
 from rich.console import Console
 from rich.live import Live
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+)
 from rich.spinner import Spinner as RichSpinner
 from rich.text import Text
 
@@ -50,6 +57,8 @@ class ConsoleLogger:
             self._console = Console()
             self._spinner_live: Optional[Live] = None
             self._spinner = RichSpinner("dots")
+            self._progress: Optional[Progress] = None
+            self._progress_tasks: Dict[str, TaskID] = {}
             self._initialized = True
 
     def _stop_spinner_if_active(self) -> None:
@@ -57,6 +66,13 @@ class ConsoleLogger:
         if self._spinner_live and self._spinner_live.is_started:
             self._spinner_live.stop()
             self._spinner_live = None
+
+    def _stop_progress_if_active(self) -> None:
+        """Internal method to stop the progress if it's active."""
+        if self._progress:
+            self._progress.stop()
+            self._progress = None
+            self._progress_tasks.clear()
 
     def log(
         self, message: str, level: LogLevel = LogLevel.INFO, fg: Optional[str] = None
@@ -203,6 +219,44 @@ class ConsoleLogger:
         if self._spinner_live and self._spinner_live.is_started:
             self._spinner.text = Text(message)
 
+    @contextmanager
+    def evaluation_progress(
+        self, evaluations: List[Dict[str, str]]
+    ) -> Iterator["EvaluationProgressManager"]:
+        """Context manager for evaluation progress tracking.
+
+        Args:
+            evaluations: List of evaluation items with 'id' and 'name' keys
+
+        Yields:
+            EvaluationProgressManager instance
+        """
+        try:
+            # Stop any existing progress or spinner
+            self._stop_spinner_if_active()
+            self._stop_progress_if_active()
+
+            # Create progress with custom columns
+            self._progress = Progress(
+                SpinnerColumn(),
+                TextColumn("[bold blue]{task.description}"),
+                TimeElapsedColumn(),
+                console=self._console,
+                transient=False,
+            )
+
+            # Add tasks for each evaluation
+            for eval_item in evaluations:
+                task_id = self._progress.add_task(eval_item["name"], total=1)
+                self._progress_tasks[eval_item["id"]] = task_id
+
+            self._progress.start()
+
+            yield EvaluationProgressManager(self._progress, self._progress_tasks)
+
+        finally:
+            self._stop_progress_if_active()
+
     @classmethod
     def get_instance(cls) -> "ConsoleLogger":
         """Get the singleton instance of ConsoleLogger.
@@ -213,3 +267,63 @@ class ConsoleLogger:
         if cls._instance is None:
             return cls()
         return cls._instance
+
+
+class EvaluationProgressManager:
+    """Manager for evaluation progress updates."""
+
+    def __init__(self, progress: Progress, tasks: Dict[str, TaskID]):
+        """Initialize the progress manager.
+
+        Args:
+            progress: The Rich Progress instance
+            tasks: Mapping of evaluation IDs to task IDs
+        """
+        self.progress = progress
+        self.tasks = tasks
+
+    def start_evaluation(self, eval_id: str, worker_id: int) -> None:
+        """Mark an evaluation as started.
+
+        Args:
+            eval_id: The evaluation ID
+            worker_id: The worker ID processing this evaluation
+        """
+        # No need to update anything - spinner and timer will show it's running
+        pass
+
+    def complete_evaluation(self, eval_id: str) -> None:
+        """Mark an evaluation as completed.
+
+        Args:
+            eval_id: The evaluation ID
+        """
+        if eval_id in self.tasks:
+            task_id = self.tasks[eval_id]
+            # Update description to show completion
+            current_desc = self.progress.tasks[task_id].description
+            self.progress.update(
+                task_id,
+                completed=1,
+                description=f"[green]✅ {current_desc}[/green]",
+            )
+
+    def fail_evaluation(self, eval_id: str, error_message: str) -> None:
+        """Mark an evaluation as failed.
+
+        Args:
+            eval_id: The evaluation ID
+            error_message: The error message
+        """
+        if eval_id in self.tasks:
+            task_id = self.tasks[eval_id]
+            # Truncate error message if too long
+            short_error = (
+                error_message[:40] + "..." if len(error_message) > 40 else error_message
+            )
+            # Update the description to show failure
+            current_desc = self.progress.tasks[task_id].description
+            self.progress.update(
+                task_id,
+                description=f"[red]❌ {current_desc} - {short_error}[/red]",
+            )

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -1,0 +1,94 @@
+# type: ignore
+import asyncio
+import os
+from pathlib import Path
+from typing import Optional, Tuple
+
+import click
+from dotenv import load_dotenv
+
+from .._utils.constants import ENV_JOB_ID
+from ..telemetry import track
+from ._evals.evaluation_service import EvaluationService
+from ._utils._console import ConsoleLogger
+
+console = ConsoleLogger()
+load_dotenv(override=True)
+
+
+def eval_agent(
+    entrypoint: str, eval_set: str, workers: int = 8, no_report: bool = False, **kwargs
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Core evaluation logic that can be called programmatically.
+
+    Args:
+        entrypoint: Path to the agent script to evaluate
+        eval_set: Path to the evaluation set JSON file
+        workers: Number of parallel workers for running evaluations
+        no_report: Do not report the evaluation results
+        **kwargs: Additional arguments for future extensibility
+
+    Returns:
+        Tuple containing:
+            - success: True if evaluation was successful
+            - error_message: Error message if any
+            - info_message: Info message if any
+    """
+    try:
+        eval_path = Path(eval_set)
+        if not eval_path.is_file() or eval_path.suffix != ".json":
+            return False, "Evaluation set must be a JSON file", None
+
+        if workers < 1:
+            return False, "Number of workers must be at least 1", None
+
+        service = EvaluationService(
+            entrypoint, eval_set, workers, report_progress=not no_report
+        )
+        asyncio.run(service.run_evaluation())
+
+        return True, None, "Evaluation completed successfully"
+
+    except Exception as e:
+        return False, f"Error running evaluation: {str(e)}", None
+
+
+@click.command()
+@click.argument("entrypoint", required=True)
+@click.argument("eval_set", required=True, type=click.Path(exists=True))
+@click.option(
+    "--no-report",
+    is_flag=True,
+    help="Do not report the evaluation results",
+    default=False,
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=8,
+    help="Number of parallel workers for running evaluations (default: 8)",
+)
+@track(when=lambda *_a, **_kw: os.getenv(ENV_JOB_ID) is None)
+def eval(entrypoint: str, eval_set: str, no_report: bool, workers: int) -> None:
+    """Run an evaluation set against the agent.
+
+    Args:
+        entrypoint: Path to the agent script to evaluate
+        eval_set: Path to the evaluation set JSON file
+        workers: Number of parallel workers for running evaluations
+        no_report: Do not report the evaluation results
+    """
+    success, error_message, info_message = eval_agent(
+        entrypoint=entrypoint, eval_set=eval_set, workers=workers, no_report=no_report
+    )
+
+    if error_message:
+        console.error(error_message)
+        click.get_current_context().exit(1)
+
+    if info_message:
+        console.success(info_message)
+
+
+if __name__ == "__main__":
+    eval()

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 import traceback
 from os import environ as env
-from typing import Optional
+from typing import Optional, Tuple
 from uuid import uuid4
 
 import click
@@ -64,7 +64,7 @@ Usage: `uipath run <entrypoint_path> <input_arguments> [-f <input_json_file_path
 
         async def execute():
             context = UiPathRuntimeContext.from_config(
-                env.get("UIPATH_CONFIG_PATH", "uipath.json")
+                env.get("UIPATH_CONFIG_PATH", "uipath.json"), **kwargs
             )
             context.entrypoint = entrypoint
             context.input = input
@@ -73,6 +73,7 @@ Usage: `uipath run <entrypoint_path> <input_arguments> [-f <input_json_file_path
             context.trace_id = env.get("UIPATH_TRACE_ID")
             context.input_file = kwargs.get("input_file", None)
             context.execution_output_file = kwargs.get("execution_output_file", None)
+            context.eval_run = kwargs.get("eval_run", False)
             context.tracing_enabled = env.get("UIPATH_TRACING_ENABLED", True)
             context.trace_context = UiPathTraceContext(
                 trace_id=env.get("UIPATH_TRACE_ID"),
@@ -108,6 +109,64 @@ Usage: `uipath run <entrypoint_path> <input_arguments> [-f <input_json_file_path
             error_message=f"Error: Unexpected error occurred - {str(e)}",
             should_include_stacktrace=True,
         )
+
+
+def run_core(
+    entrypoint: Optional[str],
+    resume: bool,
+    input: Optional[str] = None,
+    input_file: Optional[str] = None,
+    execution_output_file: Optional[str] = None,
+    logs_file: Optional[str] = None,
+    **kwargs,
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Core execution logic that can be called programmatically.
+
+    Args:
+        entrypoint: Path to the Python script to execute
+        input: JSON string with input data
+        resume: Flag indicating if this is a resume execution
+        input_file: Path to input JSON file
+        logs_file: Path where execution output will be written
+        **kwargs: Additional arguments to be forwarded to the middleware
+
+    Returns:
+        Tuple containing:
+            - success: True if execution was successful
+            - error_message: Error message if any
+            - info_message: Info message if any
+    """
+    # Process through middleware chain
+    result = Middlewares.next(
+        "run",
+        entrypoint,
+        input,
+        resume,
+        input_file=input_file,
+        execution_output_file=execution_output_file,
+        logs_file=logs_file,
+        **kwargs,
+    )
+
+    if result.should_continue:
+        result = python_run_middleware(
+            entrypoint=entrypoint,
+            input=input,
+            resume=resume,
+            input_file=input_file,
+            execution_output_file=execution_output_file,
+            logs_file=logs_file,
+            **kwargs,
+        )
+
+    if result.should_continue:
+        return False, "Could not process the request with any available handler.", None
+
+    return (
+        not bool(result.error_message),
+        result.error_message,
+        result.info_message,
+    )
 
 
 @click.command()
@@ -161,44 +220,26 @@ def run(
     if not setup_debugging(debug, debug_port):
         console.error(f"Failed to start debug server on port {debug_port}")
 
-    # Process through middleware chain
-    result = Middlewares.next(
-        "run",
-        entrypoint,
-        input,
-        resume,
+    success, error_message, info_message = run_core(
+        entrypoint=entrypoint,
+        input=input,
+        resume=resume,
+        input_file=input_file,
+        output_file=output_file,
         debug=debug,
         debug_port=debug_port,
-        input_file=input_file,
-        execution_output_file=output_file,
     )
 
-    if result.should_continue:
-        result = python_run_middleware(
-            entrypoint=entrypoint,
-            input=input,
-            resume=resume,
-            input_file=input_file,
-            execution_output_file=output_file,
-        )
-
-    # Handle result from middleware
-    if result.error_message:
-        console.error(result.error_message, include_traceback=True)
-        if result.should_include_stacktrace:
+    if error_message:
+        console.error(error_message, include_traceback=True)
+        if not success:  # If there was an error and execution failed
             console.error(traceback.format_exc())
         click.get_current_context().exit(1)
 
-    if result.info_message:
-        console.info(result.info_message)
+    if info_message:
+        console.info(info_message)
 
-    # If middleware chain completed but didn't handle the request
-    if result.should_continue:
-        console.error(
-            "Error: Could not process the request with any available handler."
-        )
-
-    if not result.should_continue and not result.error_message:
+    if success:
         console.success("Successful execution.")
 
 

--- a/src/uipath/_services/api_client.py
+++ b/src/uipath/_services/api_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Literal, Union
 
 from httpx import URL, Response
 
@@ -24,6 +24,7 @@ class ApiClient(FolderContext, BaseService):
         self,
         method: str,
         url: Union[URL, str],
+        scoped: Literal["org", "tenant"] = "tenant",
         **kwargs: Any,
     ) -> Response:
         if kwargs.get("include_folder_headers", False):
@@ -35,12 +36,13 @@ class ApiClient(FolderContext, BaseService):
         if "include_folder_headers" in kwargs:
             del kwargs["include_folder_headers"]
 
-        return super().request(method, url, **kwargs)
+        return super().request(method, url, scoped=scoped, **kwargs)
 
     async def request_async(
         self,
         method: str,
         url: Union[URL, str],
+        scoped: Literal["org", "tenant"] = "tenant",
         **kwargs: Any,
     ) -> Response:
         if kwargs.get("include_folder_headers", False):
@@ -52,4 +54,4 @@ class ApiClient(FolderContext, BaseService):
         if "include_folder_headers" in kwargs:
             del kwargs["include_folder_headers"]
 
-        return await super().request_async(method, url, **kwargs)
+        return await super().request_async(method, url, scoped=scoped, **kwargs)

--- a/src/uipath/_utils/constants.py
+++ b/src/uipath/_utils/constants.py
@@ -16,6 +16,7 @@ HEADER_FOLDER_KEY = "x-uipath-folderkey"
 HEADER_FOLDER_PATH = "x-uipath-folderpath"
 HEADER_USER_AGENT = "x-uipath-user-agent"
 HEADER_TENANT_ID = "x-uipath-tenantid"
+HEADER_INTERNAL_TENANT_ID = "x-uipath-internal-tenantid"
 HEADER_JOB_KEY = "x-uipath-jobkey"
 
 # Data sources
@@ -25,3 +26,6 @@ ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
 
 # Local storage
 TEMP_ATTACHMENTS_FOLDER = "uipath_attachments"
+
+# LLM models
+COMMUNITY_AGENTS_SUFFIX = "-community-agents"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -2028,7 +2029,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.6"
+version = "2.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
### 🚀 Summary

This PR builds on top of [PR #483](https://github.com/UiPath/uipath-python/pull/483) to enable viewing eval runs on the frontend for the `uipath eval` command.

### 📁 Key Files Added/Modified
`evaluation_service.py`

- Temporary null check for evaluators to handle unimplemented trajectory evaluators (will be removed once trajectory evaluators are implemented)
- Tracking the results across eval runs in order to populate the eval set run

`progress_reporter.py`

- Updated API calls to use scoped="tenant" for proper URL construction
- Fixed API routes to use the correct agentsruntime_ paths
- Populated assertionSnapshot with evaluator metadata during eval run creation
- Added proper evaluatorScores and assertionRuns structures for eval run updates
- Implemented score aggregation for eval set run updates
- Added error handling with console warnings for failed API calls
- Added comments explaining how the API call will be updated soon to be cleaner

### Images
<img width="1095" height="335" alt="Screenshot 2025-07-29 at 2 38 41 PM" src="https://github.com/user-attachments/assets/945e441b-9baa-4067-a1b3-836522879d54" />

<img width="1439" height="642" alt="Screenshot 2025-07-29 at 2 38 54 PM" src="https://github.com/user-attachments/assets/dd25592d-37f0-4ac0-b05b-622a1ce89934" />

### Testing
The changes have been tested with the math-coded-agent sample and successfully report evaluation results to the frontend with proper scores and evaluator metadata.


