### PR TITLE
fix: remove type annotation for from_config base method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.9"
+version = "2.1.10"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -163,7 +163,7 @@ class UiPathRuntimeContext(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
     @classmethod
-    def from_config(cls, config_path=None, **kwargs) -> "UiPathRuntimeContext":
+    def from_config(cls, config_path=None, **kwargs):
         """Load configuration from uipath.json file.
 
         Args:


### PR DESCRIPTION
- remove type annotation for from_config base method
this causes linting errors in extension packages