### PR TITLE
chore: add check for requires-python pyproject field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.18"
+version = "2.1.19"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_utils/_project_files.py
+++ b/src/uipath/_cli/_utils/_project_files.py
@@ -68,6 +68,7 @@ def get_project_config(directory: str) -> dict[str, str]:
         "version": toml_data["version"],
         "authors": toml_data["authors"],
         "dependencies": toml_data.get("dependencies", {}),
+        "requires-python": toml_data.get("requires-python", {}),
     }
 
 
@@ -95,6 +96,11 @@ def validate_config(config: dict[str, str]) -> None:
     if not config["authors"] or config["authors"].strip() == "":
         console.error(
             'Project authors cannot be empty. Please specify authors in pyproject.toml:\n    authors = [{ name = "John Doe" }]'
+        )
+
+    if not config["requires-python"] or config["requires-python"].strip() == "":
+        console.error(
+            "'requires-python' field cannot be empty. Please specify it in pyproject.toml:  requires-python = \">=3.10\""
         )
 
     invalid_chars = ["&", "<", ">", '"', "'", ";"]
@@ -296,6 +302,7 @@ def read_toml_project(file_path: str) -> dict:
         "version": project["version"].strip(),
         "authors": author_name.strip(),
         "dependencies": dependencies,
+        "requires-python": project.get("requires-python", "").strip(),
     }
 
 

--- a/tests/cli/test_pack.py
+++ b/tests/cli/test_pack.py
@@ -79,6 +79,27 @@ class TestPack:
                 in result.output
             )
 
+    def test_pyproject_missing_requires_python(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        uipath_json: UiPathJson,
+    ) -> None:
+        project_details.requires_python = None
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("uipath.json", "w") as f:
+                f.write(uipath_json.to_json())
+            with open("pyproject.toml", "w") as f:
+                f.write(project_details.to_toml())
+
+            result = runner.invoke(pack, ["./"])
+            assert result.exit_code == 1
+            assert (
+                "'requires-python' field cannot be empty. Please specify it in pyproject.toml"
+                in result.output
+            )
+
     def test_pyproject_missing_project_name(
         self,
         runner: CliRunner,

--- a/uv.lock
+++ b/uv.lock
@@ -2029,7 +2029,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.18"
+version = "2.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- validate `requires-python` pyproject field (for bot `push` and `pack` CLI commands)