### PR TITLE
Run specific evaluations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.20"
+version = "2.1.21"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_evals/_evaluators/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluators/_evaluator_factory.py
@@ -107,6 +107,10 @@ class EvaluatorFactory:
         model = data.get("model", "")
         if not model:
             raise ValueError("LLM evaluator must include 'model' field")
+        if model == "same-as-agent":
+            raise ValueError(
+                "'same-as-agent' model option is not supported by coded agents evaluations. Please select a specific model for the evaluator."
+            )
 
         return LlmAsAJudgeEvaluator.from_params(
             base_params,

--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -36,6 +36,16 @@ class EvaluationSet(BaseModel):
     createdAt: str
     updatedAt: str
 
+    def extract_selected_evals(self, eval_ids) -> None:
+        selected_evals: list[EvaluationItem] = []
+        for evaluation in self.evaluations:
+            if evaluation.id in eval_ids:
+                selected_evals.append(evaluation)
+                eval_ids.remove(evaluation.id)
+        if len(eval_ids) > 0:
+            raise ValueError("Unknown evaluation ids: {}".format(eval_ids))
+        self.evaluations = selected_evals
+
 
 class EvaluationStatus(IntEnum):
     PENDING = 0

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -1,7 +1,8 @@
 # type: ignore
+import ast
 import asyncio
 import os
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import click
 from dotenv import load_dotenv
@@ -15,9 +16,18 @@ console = ConsoleLogger()
 load_dotenv(override=True)
 
 
+class LiteralOption(click.Option):
+    def type_cast_value(self, ctx, value):
+        try:
+            return ast.literal_eval(value)
+        except Exception as e:
+            raise click.BadParameter(value) from e
+
+
 def eval_agent(
     entrypoint: Optional[str] = None,
     eval_set: Optional[str] = None,
+    eval_ids: Optional[List[str]] = None,
     workers: int = 8,
     no_report: bool = False,
     **kwargs,
@@ -27,6 +37,7 @@ def eval_agent(
     Args:
         entrypoint: Path to the agent script to evaluate (optional, will auto-discover if not provided)
         eval_set: Path to the evaluation set JSON file (optional, will auto-discover if not provided)
+        eval_ids: Optional list of evaluation IDs
         workers: Number of parallel workers for running evaluations
         no_report: Do not report the evaluation results
         **kwargs: Additional arguments for future extensibility
@@ -41,8 +52,13 @@ def eval_agent(
         if workers < 1:
             return False, "Number of workers must be at least 1", None
 
+        print("EVAL SET")
+        print(eval_set)
+        if eval_set is not None and len(eval_set) == 0:
+            return False, "Evaluation set must not be empty", None
+
         service = EvaluationService(
-            entrypoint, eval_set, workers, report_progress=not no_report
+            entrypoint, eval_set, eval_ids, workers, report_progress=not no_report
         )
         asyncio.run(service.run_evaluation())
 
@@ -55,6 +71,7 @@ def eval_agent(
 @click.command()
 @click.argument("entrypoint", required=False)
 @click.argument("eval_set", required=False)
+@click.option("--eval-ids", cls=LiteralOption, default="[]")
 @click.option(
     "--no-report",
     is_flag=True,
@@ -69,20 +86,28 @@ def eval_agent(
 )
 @track(when=lambda *_a, **_kw: os.getenv(ENV_JOB_ID) is None)
 def eval(
-    entrypoint: Optional[str], eval_set: Optional[str], no_report: bool, workers: int
+    entrypoint: Optional[str],
+    eval_set: Optional[str],
+    eval_ids: List[str],
+    no_report: bool,
+    workers: int,
 ) -> None:
     """Run an evaluation set against the agent.
 
     Args:
         entrypoint: Path to the agent script to evaluate (optional, will auto-discover if not specified)
         eval_set: Path to the evaluation set JSON file (optional, will auto-discover if not specified)
+        eval_ids: Optional list of evaluation IDs
         workers: Number of parallel workers for running evaluations
         no_report: Do not report the evaluation results
     """
     success, error_message, info_message = eval_agent(
-        entrypoint=entrypoint, eval_set=eval_set, workers=workers, no_report=no_report
+        entrypoint=entrypoint,
+        eval_set=eval_set,
+        eval_ids=eval_ids,
+        workers=workers,
+        no_report=no_report,
     )
-
     if error_message:
         console.error(error_message)
         click.get_current_context().exit(1)

--- a/src/uipath/_cli/cli_invoke.py
+++ b/src/uipath/_cli/cli_invoke.py
@@ -70,7 +70,6 @@ def invoke(
         url = f"{base_url}/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs"
         _, personal_workspace_folder_id = get_personal_workspace_info(base_url, token)
         project_name, project_version = _read_project_details()
-
         if not personal_workspace_folder_id:
             console.error(
                 "No personal workspace found for user. Please try reauthenticating."

--- a/uv.lock
+++ b/uv.lock
@@ -2029,7 +2029,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.19"
+version = "2.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
# Add support for running specific evaluations within an evaluation set

## Summary

Added support for running specific evaluations within an evaluation set through a new `--eval-ids` flag. This enhancement allows users to selectively execute individual evaluations rather than running the entire evaluation set, providing better granular control and aligning with current StudioWeb behavior.

## Usage

### Basic Command Structure
```bash
uipath eval [entrypoint] [evaluationSet] [--eval-ids EVAL_IDS]
```

### Examples

**Run all evaluations (default behavior):**
```bash
uipath eval
uipath eval agent .\evals\eval-sets\evaluation_set.json
```

**Run specific evaluations by ID:**
```bash
# Multiple evaluations
uipath eval --eval-ids '["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]'

# With explicit entrypoint and evaluation set
uipath eval agent .\evals\eval-sets\evaluation_set.json --eval-ids '["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]'
```