### PR TITLE
fix: load dotenv from cwd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.23"
+version = "2.1.24"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.24"
+version = "2.1.32"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -3,7 +3,8 @@ import sys
 
 import click
 
-from .cli_auth import auth as auth  # type: ignore
+from ._utils._common import load_environment_variables
+from .cli_auth import auth as auth
 from .cli_deploy import deploy as deploy  # type: ignore
 from .cli_eval import eval as eval  # type: ignore
 from .cli_init import init as init  # type: ignore
@@ -42,6 +43,8 @@ def _get_safe_version() -> str:
     help="Display the current version of uipath.",
 )
 def cli(lv: bool, v: bool) -> None:
+    load_environment_variables()
+
     if lv:
         try:
             version = importlib.metadata.version("uipath-langchain")

--- a/src/uipath/_cli/_auth/_auth_server.py
+++ b/src/uipath/_cli/_auth/_auth_server.py
@@ -7,12 +7,10 @@ import threading
 import time
 from typing import Optional
 
-from dotenv import load_dotenv
-
+from .._utils._common import load_environment_variables
 from ._oidc_utils import get_auth_config
 
-load_dotenv(override=True)
-
+load_environment_variables()
 # Server port
 PORT = 6234
 

--- a/src/uipath/_cli/_auth/_auth_server.py
+++ b/src/uipath/_cli/_auth/_auth_server.py
@@ -7,10 +7,8 @@ import threading
 import time
 from typing import Optional
 
-from .._utils._common import load_environment_variables
 from ._oidc_utils import get_auth_config
 
-load_environment_variables()
 # Server port
 PORT = 6234
 

--- a/src/uipath/_cli/_evals/progress_reporter.py
+++ b/src/uipath/_cli/_evals/progress_reporter.py
@@ -3,9 +3,11 @@
 import json
 import logging
 import os
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List
 
-from uipath import UiPath
+if TYPE_CHECKING:
+    from uipath import UiPath
+
 from uipath._cli._evals._evaluators import EvaluatorBase
 from uipath._cli._evals._models._evaluation_set import EvaluationStatus
 from uipath._cli._evals._models._evaluators import EvalItemResult, ScoreType
@@ -32,6 +34,8 @@ class ProgressReporter:
             no_of_evals: Number of evaluations in the set
             evaluators: List of evaluator instances
         """
+        from uipath import UiPath
+
         self._eval_set_id = eval_set_id
         self.agent_snapshot = agent_snapshot
         self._no_of_evals = no_of_evals
@@ -46,7 +50,6 @@ class ProgressReporter:
         logging.getLogger("uipath._cli.middlewares").setLevel(logging.CRITICAL)
 
         console_logger = ConsoleLogger.get_instance()
-
         uipath = UiPath()
 
         self._eval_set_run_id = None

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -106,4 +106,4 @@ def clean_directory(directory: str) -> None:
 
 
 def load_environment_variables():
-    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=False)

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -3,6 +3,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import click
+from dotenv import find_dotenv, load_dotenv
 
 from ..spinner import Spinner
 
@@ -102,3 +103,7 @@ def clean_directory(directory: str) -> None:
 
         if os.path.isfile(file_path) and file_name.endswith(".py"):
             os.remove(file_path)
+
+
+def load_environment_variables():
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=True)

--- a/src/uipath/_cli/cli_auth.py
+++ b/src/uipath/_cli/cli_auth.py
@@ -13,10 +13,9 @@ from ._auth._client_credentials import ClientCredentialsService
 from ._auth._oidc_utils import get_auth_config, get_auth_url
 from ._auth._portal_service import PortalService, select_tenant
 from ._auth._utils import update_auth_file, update_env_file
-from ._utils._common import environment_options, load_environment_variables
+from ._utils._common import environment_options
 from ._utils._console import ConsoleLogger
 
-load_environment_variables()
 console = ConsoleLogger()
 
 

--- a/src/uipath/_cli/cli_auth.py
+++ b/src/uipath/_cli/cli_auth.py
@@ -6,7 +6,6 @@ import socket
 import webbrowser
 
 import click
-from dotenv import load_dotenv
 
 from ..telemetry import track
 from ._auth._auth_server import HTTPServer
@@ -14,10 +13,10 @@ from ._auth._client_credentials import ClientCredentialsService
 from ._auth._oidc_utils import get_auth_config, get_auth_url
 from ._auth._portal_service import PortalService, select_tenant
 from ._auth._utils import update_auth_file, update_env_file
-from ._utils._common import environment_options
+from ._utils._common import environment_options, load_environment_variables
 from ._utils._console import ConsoleLogger
 
-load_dotenv(override=True)
+load_environment_variables()
 console = ConsoleLogger()
 
 

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -6,15 +6,12 @@ from typing import List, Optional, Tuple
 
 import click
 
-from uipath._cli._utils._common import load_environment_variables
-
 from .._utils.constants import ENV_JOB_ID
 from ..telemetry import track
 from ._evals.evaluation_service import EvaluationService
 from ._utils._console import ConsoleLogger
 
 console = ConsoleLogger()
-load_environment_variables()
 
 
 class LiteralOption(click.Option):

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -5,7 +5,8 @@ import os
 from typing import List, Optional, Tuple
 
 import click
-from dotenv import load_dotenv
+
+from uipath._cli._utils._common import load_environment_variables
 
 from .._utils.constants import ENV_JOB_ID
 from ..telemetry import track
@@ -13,7 +14,7 @@ from ._evals.evaluation_service import EvaluationService
 from ._utils._console import ConsoleLogger
 
 console = ConsoleLogger()
-load_dotenv(override=True)
+load_environment_variables()
 
 
 class LiteralOption(click.Option):

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -6,18 +6,18 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import click
-from dotenv import load_dotenv
 
 from .._utils.constants import ENV_TELEMETRY_ENABLED
 from ..telemetry import track
 from ..telemetry._constants import _PROJECT_KEY, _TELEMETRY_CONFIG_FILE
+from ._utils._common import load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._input_args import generate_args
 from ._utils._parse_ast import generate_bindings_json
 from .middlewares import Middlewares
 
 console = ConsoleLogger()
-
+load_environment_variables()
 CONFIG_PATH = "uipath.json"
 
 
@@ -125,9 +125,6 @@ def write_config_file(config_data: Dict[str, Any]) -> None:
 @track
 def init(entrypoint: str, infer_bindings: bool) -> None:
     """Create uipath.json with input/output schemas and bindings."""
-    current_path = os.getcwd()
-    load_dotenv(os.path.join(current_path, ".env"), override=True)
-
     with console.spinner("Initializing UiPath project ..."):
         current_directory = os.getcwd()
         generate_env_file(current_directory)

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -10,14 +10,12 @@ import click
 from .._utils.constants import ENV_TELEMETRY_ENABLED
 from ..telemetry import track
 from ..telemetry._constants import _PROJECT_KEY, _TELEMETRY_CONFIG_FILE
-from ._utils._common import load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._input_args import generate_args
 from ._utils._parse_ast import generate_bindings_json
 from .middlewares import Middlewares
 
 console = ConsoleLogger()
-load_environment_variables()
 CONFIG_PATH = "uipath.json"
 
 

--- a/src/uipath/_cli/cli_invoke.py
+++ b/src/uipath/_cli/cli_invoke.py
@@ -15,12 +15,11 @@ except ImportError:
 
 from .._utils._ssl_context import get_httpx_client_kwargs
 from ..telemetry import track
-from ._utils._common import get_env_vars, load_environment_variables
+from ._utils._common import get_env_vars
 from ._utils._folders import get_personal_workspace_info
 from ._utils._processes import get_release_info
 
 logger = logging.getLogger(__name__)
-load_environment_variables()
 console = ConsoleLogger()
 
 

--- a/src/uipath/_cli/cli_invoke.py
+++ b/src/uipath/_cli/cli_invoke.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import click
 import httpx
-from dotenv import load_dotenv
 
 from ._utils._console import ConsoleLogger
 
@@ -16,12 +15,12 @@ except ImportError:
 
 from .._utils._ssl_context import get_httpx_client_kwargs
 from ..telemetry import track
-from ._utils._common import get_env_vars
+from ._utils._common import get_env_vars, load_environment_variables
 from ._utils._folders import get_personal_workspace_info
 from ._utils._processes import get_release_info
 
 logger = logging.getLogger(__name__)
-load_dotenv(override=True)
+load_environment_variables()
 console = ConsoleLogger()
 
 
@@ -63,8 +62,6 @@ def invoke(
         with open(file) as f:
             input = f.read()
     with console.spinner("Loading configuration ..."):
-        current_path = os.getcwd()
-        load_dotenv(os.path.join(current_path, ".env"), override=True)
         [base_url, token] = get_env_vars()
 
         url = f"{base_url}/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs"

--- a/src/uipath/_cli/cli_publish.py
+++ b/src/uipath/_cli/cli_publish.py
@@ -7,13 +7,12 @@ import httpx
 
 from .._utils._ssl_context import get_httpx_client_kwargs
 from ..telemetry import track
-from ._utils._common import get_env_vars, load_environment_variables
+from ._utils._common import get_env_vars
 from ._utils._console import ConsoleLogger
 from ._utils._folders import get_personal_workspace_info
 from ._utils._processes import get_release_info
 
 console = ConsoleLogger()
-load_environment_variables()
 
 
 def get_most_recent_package():

--- a/src/uipath/_cli/cli_publish.py
+++ b/src/uipath/_cli/cli_publish.py
@@ -4,16 +4,16 @@ import os
 
 import click
 import httpx
-from dotenv import load_dotenv
 
 from .._utils._ssl_context import get_httpx_client_kwargs
 from ..telemetry import track
-from ._utils._common import get_env_vars
+from ._utils._common import get_env_vars, load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._folders import get_personal_workspace_info
 from ._utils._processes import get_release_info
 
 console = ConsoleLogger()
+load_environment_variables()
 
 
 def get_most_recent_package():
@@ -70,9 +70,6 @@ def get_available_feeds(
 @track
 def publish(feed):
     """Publish the package."""
-    current_path = os.getcwd()
-    load_dotenv(os.path.join(current_path, ".env"), override=True)
-
     [base_url, token] = get_env_vars()
     headers = {"Authorization": f"Bearer {token}"}
 

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -19,7 +19,6 @@ from typing import Dict, Set
 import click
 
 from ..telemetry import track
-from ._utils._common import load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._constants import UIPATH_PROJECT_ID
 from ._utils._studio_project import (
@@ -30,7 +29,6 @@ from ._utils._studio_project import (
 )
 
 console = ConsoleLogger()
-load_environment_variables()
 
 
 def compute_normalized_hash(content: str) -> str:

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -17,9 +17,9 @@ import os
 from typing import Dict, Set
 
 import click
-from dotenv import load_dotenv
 
 from ..telemetry import track
+from ._utils._common import load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._constants import UIPATH_PROJECT_ID
 from ._utils._studio_project import (
@@ -30,7 +30,7 @@ from ._utils._studio_project import (
 )
 
 console = ConsoleLogger()
-load_dotenv(override=True)
+load_environment_variables()
 
 
 def compute_normalized_hash(content: str) -> str:

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -8,7 +8,6 @@ import click
 
 from ..telemetry import track
 from ._push.sw_file_handler import SwFileHandler
-from ._utils._common import load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._constants import (
     UIPATH_PROJECT_ID,
@@ -21,7 +20,6 @@ from ._utils._project_files import (
 from ._utils._uv_helpers import handle_uv_operations
 
 console = ConsoleLogger()
-load_environment_variables()
 
 
 def get_org_scoped_url(base_url: str) -> str:

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -5,10 +5,10 @@ from typing import Any
 from urllib.parse import urlparse
 
 import click
-from dotenv import load_dotenv
 
 from ..telemetry import track
 from ._push.sw_file_handler import SwFileHandler
+from ._utils._common import load_environment_variables
 from ._utils._console import ConsoleLogger
 from ._utils._constants import (
     UIPATH_PROJECT_ID,
@@ -21,7 +21,7 @@ from ._utils._project_files import (
 from ._utils._uv_helpers import handle_uv_operations
 
 console = ConsoleLogger()
-load_dotenv(override=True)
+load_environment_variables()
 
 
 def get_org_scoped_url(base_url: str) -> str:

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -7,8 +7,8 @@ from typing import Optional, Tuple
 from uuid import uuid4
 
 import click
-from dotenv import load_dotenv
 
+from uipath._cli._utils._common import load_environment_variables
 from uipath._cli._utils._debug import setup_debugging
 
 from .._utils.constants import (
@@ -25,7 +25,7 @@ from ._utils._console import ConsoleLogger
 from .middlewares import MiddlewareResult, Middlewares
 
 console = ConsoleLogger()
-load_dotenv(override=True)
+load_environment_variables()
 
 
 def python_run_middleware(

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 
 import click
 
-from uipath._cli._utils._common import load_environment_variables
 from uipath._cli._utils._debug import setup_debugging
 
 from .._utils.constants import (
@@ -25,7 +24,6 @@ from ._utils._console import ConsoleLogger
 from .middlewares import MiddlewareResult, Middlewares
 
 console = ConsoleLogger()
-load_environment_variables()
 
 
 def python_run_middleware(

--- a/src/uipath/_execution_context.py
+++ b/src/uipath/_execution_context.py
@@ -1,10 +1,7 @@
 from os import environ as env
 from typing import Optional
 
-from ._cli._utils._common import load_environment_variables
 from ._utils.constants import ENV_JOB_ID, ENV_JOB_KEY, ENV_ROBOT_KEY
-
-load_environment_variables()
 
 
 class ExecutionContext:

--- a/src/uipath/_execution_context.py
+++ b/src/uipath/_execution_context.py
@@ -1,11 +1,10 @@
 from os import environ as env
 from typing import Optional
 
-from dotenv import load_dotenv
-
+from ._cli._utils._common import load_environment_variables
 from ._utils.constants import ENV_JOB_ID, ENV_JOB_KEY, ENV_ROBOT_KEY
 
-load_dotenv(override=True)
+load_environment_variables()
 
 
 class ExecutionContext:

--- a/src/uipath/_folder_context.py
+++ b/src/uipath/_folder_context.py
@@ -1,8 +1,7 @@
 from os import environ as env
 from typing import Any, Optional
 
-from dotenv import load_dotenv
-
+from ._cli._utils._common import load_environment_variables
 from ._utils.constants import (
     ENV_FOLDER_KEY,
     ENV_FOLDER_PATH,
@@ -10,7 +9,7 @@ from ._utils.constants import (
     HEADER_FOLDER_PATH,
 )
 
-load_dotenv(override=True)
+load_environment_variables()
 
 
 class FolderContext:

--- a/src/uipath/_folder_context.py
+++ b/src/uipath/_folder_context.py
@@ -1,15 +1,12 @@
 from os import environ as env
 from typing import Any, Optional
 
-from ._cli._utils._common import load_environment_variables
 from ._utils.constants import (
     ENV_FOLDER_KEY,
     ENV_FOLDER_PATH,
     HEADER_FOLDER_KEY,
     HEADER_FOLDER_PATH,
 )
-
-load_environment_variables()
 
 
 class FolderContext:

--- a/src/uipath/_uipath.py
+++ b/src/uipath/_uipath.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from pydantic import ValidationError
 
-from ._cli._utils._common import load_environment_variables
 from ._config import Config
 from ._execution_context import ExecutionContext
 from ._services import (
@@ -28,8 +27,6 @@ from ._utils.constants import (
     ENV_UNATTENDED_USER_ACCESS_TOKEN,
 )
 from .models.errors import BaseUrlMissingError, SecretMissingError
-
-load_environment_variables()
 
 
 class UiPath:

--- a/src/uipath/_uipath.py
+++ b/src/uipath/_uipath.py
@@ -1,9 +1,9 @@
 from os import environ as env
 from typing import Optional
 
-from dotenv import load_dotenv
 from pydantic import ValidationError
 
+from ._cli._utils._common import load_environment_variables
 from ._config import Config
 from ._execution_context import ExecutionContext
 from ._services import (
@@ -29,7 +29,7 @@ from ._utils.constants import (
 )
 from .models.errors import BaseUrlMissingError, SecretMissingError
 
-load_dotenv(override=True)
+load_environment_variables()
 
 
 class UiPath:

--- a/uv.lock
+++ b/uv.lock
@@ -2029,7 +2029,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.21"
+version = "2.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },

--- a/uv.lock
+++ b/uv.lock
@@ -2029,7 +2029,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.24"
+version = "2.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- load dotenv from cwd 
- use same implementation for all CLI commands
- fixes: https://github.com/UiPath/uipath-python/issues/507

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.32.dev1005100887",

  # Any version from PR
  "uipath>=2.1.32.dev1005100000,<2.1.32.dev1005110000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```