### PR TITLE
fix: configurable log handler

### DIFF
--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -159,6 +159,7 @@ class UiPathRuntimeContext(BaseModel):
     execution_output_file: Optional[str] = None
     input_file: Optional[str] = None
     is_eval_run: bool = False
+    log_handler: Optional[logging.Handler] = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -328,6 +329,7 @@ class UiPathBaseRuntime(ABC):
             file=self.context.logs_file,
             job_id=self.context.job_id,
             is_debug_run=self.is_debug_run(),
+            log_handler=self.context.log_handler,
         )
         self.logs_interceptor.setup()
 


### PR DESCRIPTION
This PR introduces the ability to inject a custom log handler into the UiPath runtime logging system instead of relying solely on the default file or stdout handlers.

- Added configurable `log_handler` parameter to both `LogsInterceptor` and `UiPathRuntimeContext`
- Modified the logging initialization logic to use the provided handler when available
- Updated type annotations to accommodate the new handler type

```python
class RunContextLogHandler(logging.Handler):
    """Custom log handler that sends logs to CLI UI."""

    def __init__(
        self,
        run_id: str,
        on_log: Callable[[LogMessage], None],
    ):
        super().__init__()
        self.run_id = run_id
        self.on_log = on_log

    def emit(self, record: logging.LogRecord):
        """Emit a log record to CLI UI."""
        try:
            log_msg = LogMessage(
                run_id=self.run_id,
                level=record.levelname,
                message=self.format(record),
                timestamp=datetime.fromtimestamp(record.created),
            )
            self.on_log(log_msg)
        except Exception:
            # Don't let logging errors crash the app
            pass
```
```python
context: UiPathRuntimeContext = self.runtime_factory.new_context(
    entrypoint=run.entrypoint,
    input=run.input_data,
    logs_min_level=env.get("LOG_LEVEL", "INFO"),
    log_handler=RunContextLogHandler(
        run_id=run.id, on_log=self._handle_log_message
    ),
)

result = await self.runtime_factory.execute(context)

...

def _handle_log_message(self, log_msg: LogMessage):
    """Handle log message from exporter."""
    self.runs[log_msg.run_id].logs.append(log_msg)
    details_panel = self.query_one("#details-panel", RunDetailsPanel)
    details_panel.add_log(log_msg)
```