### PR TITLE
feat: add dev command

### DIFF
--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -5,6 +5,7 @@ import click
 
 from .cli_auth import auth as auth
 from .cli_deploy import deploy as deploy  # type: ignore
+from .cli_dev import dev as dev
 from .cli_eval import eval as eval  # type: ignore
 from .cli_init import init as init  # type: ignore
 from .cli_invoke import invoke as invoke  # type: ignore
@@ -69,3 +70,4 @@ cli.add_command(invoke)
 cli.add_command(push)
 cli.add_command(pull)
 cli.add_command(eval)
+cli.add_command(dev)

--- a/src/uipath/_cli/cli_dev.py
+++ b/src/uipath/_cli/cli_dev.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import click
+
+from ..telemetry import track
+from ._utils._console import ConsoleLogger
+from .middlewares import Middlewares
+
+console = ConsoleLogger()
+
+
+@click.command()
+@click.argument("interface", default="terminal")
+@track
+def dev(interface: Optional[str]) -> None:
+    """Launch interactive debugging interface."""
+    console.info("🚀 Starting UiPath Dev Terminal...")
+    console.info("Use 'q' to quit, 'n' for new run, 'r' to execute")
+
+    result = Middlewares.next(
+        "dev",
+        interface,
+    )
+
+    if result.should_continue is False:
+        return

--- a/src/uipath/_cli/middlewares.py
+++ b/src/uipath/_cli/middlewares.py
@@ -28,6 +28,7 @@ class Middlewares:
         "pack": [],
         "publish": [],
         "run": [],
+        "dev": [],
     }
     _plugins_loaded = False
 


### PR DESCRIPTION
## Description

This PR adds a new `dev` command to the UiPath CLI that launches an interactive debugging interface. The implementation follows the existing CLI command pattern and integrates with the middleware system.

- Introduces a new `dev` CLI command with an interface parameter (defaults to "terminal")
- Integrates the command with the existing middleware system for extensibility
