### PR TITLE
fix: include required fields in agent.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.28"
+version = "2.1.29"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -395,10 +395,8 @@ class SwFileHandler:
             return toml_data.get("authors", "").strip()
 
         try:
-            entrypoints = [
-                {"input": entrypoint["input"], "output": entrypoint["output"]}
-                for entrypoint in uipath_config["entryPoints"]
-            ]
+            input_schema = uipath_config["entryPoints"][0]["input"]
+            output_schema = uipath_config["entryPoints"][0]["output"]
         except (FileNotFoundError, KeyError) as e:
             self.console.error(
                 f"Unable to extract entrypoints from configuration file. Please run 'uipath init' : {str(e)}",
@@ -417,10 +415,12 @@ class SwFileHandler:
                 "author": author,
                 "pushDate": datetime.now(timezone.utc).isoformat(),
             },
-            "entryPoints": entrypoints,
+            "inputSchema": input_schema,
+            "outputSchema": output_schema,
             "bindings": uipath_config.get(
                 "bindings", {"version": "2.0", "resources": []}
             ),
+            "settings": {},
         }
 
         existing = root_files.get("agent.json")

--- a/tests/cli/test_push.py
+++ b/tests/cli/test_push.py
@@ -385,16 +385,13 @@ class TestPush:
             )
             assert "targetRuntime" in agent_json_content["metadata"]
             assert agent_json_content["metadata"]["targetRuntime"] == "python"
-            assert "entryPoints" in agent_json_content
-            assert len(agent_json_content["entryPoints"]) == 2
+            assert "inputSchema" in agent_json_content
+            assert "outputSchema" in agent_json_content
             assert (
-                agent_json_content["entryPoints"][0]["input"]["type"]
+                agent_json_content["inputSchema"]["type"]
                 == uipath_json.entry_points[0].input.type
             )
-            assert (
-                "agent_1_output"
-                in agent_json_content["entryPoints"][0]["output"]["properties"]
-            )
+            assert "agent_1_output" in agent_json_content["outputSchema"]["properties"]
 
     def test_push_with_api_error(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -2086,7 +2086,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.27"
+version = "2.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- include required fields in `agent.json` SW file

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.29.dev1005230872",

  # Any version from PR
  "uipath>=2.1.29.dev1005230000,<2.1.29.dev1005240000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```