### PR TITLE
fix: update terminal run duration realtime

### DIFF
--- a/src/uipath/_cli/_dev/_terminal/_components/_history.py
+++ b/src/uipath/_cli/_dev/_terminal/_components/_history.py
@@ -34,6 +34,10 @@ class RunHistoryPanel(Container):
                         classes="new-run-btn",
                     )
 
+    def on_mount(self) -> None:
+        # Update only running items every 5 seconds
+        self.set_interval(5.0, self._refresh_running_items)
+
     def add_run(self, run: ExecutionRun):
         """Add a new run to history."""
         self.runs.insert(0, run)  # Add to top
@@ -67,3 +71,15 @@ class RunHistoryPanel(Container):
         """Clear all runs from history."""
         self.runs.clear()
         self.refresh_list()
+
+    def _refresh_running_items(self) -> None:
+        if not any(run.status == "running" for run in self.runs):
+            return None  # No running items, skip update
+
+        run_list = self.query_one("#run-list", ListView)
+
+        for item in run_list.children:
+            run = self.get_run_by_id(item.run_id)  # type: ignore[attr-defined]
+            if run and run.status == "running":
+                static = item.query_one(Static)
+                static.update(run.display_name)

--- a/src/uipath/_cli/_dev/_terminal/_models/_execution.py
+++ b/src/uipath/_cli/_dev/_terminal/_models/_execution.py
@@ -55,12 +55,12 @@ class ExecutionRun:
         )
         truncated_script = script_name[:8]
         time_str = self.start_time.strftime("%H:%M:%S")
-        duration_str = self.duration[:4]
+        duration_str = self.duration[:6]
 
         text = Text()
         text.append(f"{status_icon:<2} ", style=status_colors.get(self.status, "white"))
         text.append(f"{truncated_script:<8} ")
         text.append(f"({time_str:<8}) ")
-        text.append(f"[{duration_str:<4}]")
+        text.append(f"[{duration_str:<6}]")
 
         return text


### PR DESCRIPTION
### Description

This PR fixes real-time updates for terminal run duration display. The changes ensure that running executions show updated duration times without requiring manual refresh, improving user experience by providing live feedback on execution progress.

- Increased duration string display width from 4 to 6 characters to accommodate longer duration formats
- Added automatic refresh mechanism that updates running items every 5 seconds