### PR TITLE
fix: traceback in terminal error logs

### DIFF
--- a/src/uipath/_cli/_dev/_terminal/_components/_details.py
+++ b/src/uipath/_cli/_dev/_terminal/_components/_details.py
@@ -416,14 +416,16 @@ class RunDetailsPanel(Container):
         timestamp_str = log_msg.timestamp.strftime("%H:%M:%S")
         level_short = log_msg.level[:4].upper()
 
-        log_text = (
-            f"[dim]{timestamp_str}[/dim] "
-            f"[{color}]{level_short}[/{color}] "
-            f"{log_msg.message}"
-        )
-
         logs_log = self.query_one("#logs-log", RichLog)
-        logs_log.write(log_text)
+        if isinstance(log_msg.message, str):
+            log_text = (
+                f"[dim]{timestamp_str}[/dim] "
+                f"[{color}]{level_short}[/{color}] "
+                f"{log_msg.message}"
+            )
+            logs_log.write(log_text)
+        else:
+            logs_log.write(log_msg.message)
 
     def clear_display(self):
         """Clear both traces and logs display."""

--- a/src/uipath/_cli/_dev/_terminal/_models/_messages.py
+++ b/src/uipath/_cli/_dev/_terminal/_models/_messages.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
+from rich.console import RenderableType
 from textual.message import Message
 
 
@@ -28,7 +29,7 @@ class LogMessage(Message):
         self,
         run_id: str,
         level: str,
-        message: str,
+        message: Union[str, RenderableType],
         timestamp: Optional[datetime] = None,
     ):
         self.run_id = run_id


### PR DESCRIPTION
## Description

This PR fixes traceback display in terminal error logs by enhancing the logging system to support rich traceback rendering instead of simple error messages.

- Modified `LogMessage` to accept both strings and `Rich` renderables for enhanced error display
- Updated error logging to generate `Rich` `Traceback` objects with detailed stack traces and local variables
- Enhanced log display logic to handle both string messages and `Rich` renderables appropriately

<img width="1459" height="671" alt="image" src="https://github.com/user-attachments/assets/8b3bd95e-6531-4803-8776-75ab4d910e02" />

<img width="1439" height="671" alt="image" src="https://github.com/user-attachments/assets/75884542-a93b-4f20-a4d9-7948de1f9dde" />

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.36.dev1005470941",

  # Any version from PR
  "uipath>=2.1.36.dev1005470000,<2.1.36.dev1005480000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```