### PR TITLE
feat: add conversational agent contracts

### DIFF
--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -22,6 +22,7 @@ from opentelemetry.sdk.trace.export import (
 from opentelemetry.trace import Tracer
 from pydantic import BaseModel, Field
 
+from uipath.agent.conversation import UiPathConversationEvent
 from uipath.tracing import TracingManager
 
 from ._logging import LogsInterceptor
@@ -134,6 +135,17 @@ class UiPathRuntimeResult(BaseModel):
         return result
 
 
+class UiPathConversationHandler(ABC):
+    """Base delegate for handling UiPath conversation events."""
+
+    use_streaming: bool = True
+
+    @abstractmethod
+    def on_event(self, event: UiPathConversationEvent) -> None:
+        """Handle a conversation event for a given execution run."""
+        pass
+
+
 class UiPathTraceContext(BaseModel):
     """Trace context information for tracing and debugging."""
 
@@ -173,6 +185,8 @@ class UiPathRuntimeContext(BaseModel):
     input_file: Optional[str] = None
     is_eval_run: bool = False
     log_handler: Optional[logging.Handler] = None
+    chat_handler: Optional[UiPathConversationHandler] = None
+
     model_config = {"arbitrary_types_allowed": True}
 
     @classmethod

--- a/src/uipath/agent/conversation/__init__.py
+++ b/src/uipath/agent/conversation/__init__.py
@@ -1,0 +1,131 @@
+"""UiPath Conversation Models.
+
+This module provides Pydantic models that represent the JSON event schema for conversations between a client (UI) and an LLM/agent.
+
+The event objects define a hierarchal conversation structure:
+
+* Conversation
+    * Exchange
+        * Message
+            * Content Parts
+                * Citations
+            * Tool Calls
+                * Tool Results
+
+ A conversation may contain multiple exchanges, and an exchange may contain multiple messages. A message may contain
+ multiple content parts, each of which can be text or binary, including media input and output streams; and each
+ content part can include multiple citations. A message may also contain multiple tool calls, which may contain a tool
+ result.
+
+ The protocol also supports a top level, "async", input media streams (audio and video), which can span multiple
+ exchanges. These are used for Gemini's automatic turn detection mode, where the LLM determines when the user has
+ stopped talking and starts producing output. The output forms one or more messages in an exchange with no explicit
+ input message. However, the LLM may produce an input transcript which can be used to construct the implicit input
+ message that started the exchange.
+
+ In addition, the protocol also supports "async" tool calls that span multiple exchanges. This can be used with
+ Gemini's asynchronous function calling protocol, which allows function calls to produce results that interrupt the
+ conversation when ready, even after multiple exchanges. They also support generating multiple results from a single
+ tool call. By contrast most tool calls are scoped to a single message, which contains both the call and the single
+ result produced by that call.
+
+ Not all features supported by the protocol will be supported by all clients and LLMs. The optional top level
+ `capabilities` property can be used to communicate information about supported features. This property should be set
+ on the first event written to a new websocket connection. This initial event may or may not contain additional
+ sub-events.
+"""
+
+from .async_stream import (
+    UiPathConversationAsyncInputStreamEndEvent,
+    UiPathConversationAsyncInputStreamEvent,
+    UiPathConversationAsyncInputStreamStartEvent,
+    UiPathConversationInputStreamChunkEvent,
+)
+from .citation import (
+    UiPathConversationCitationEndEvent,
+    UiPathConversationCitationEvent,
+    UiPathConversationCitationSource,
+    UiPathConversationCitationSourceMedia,
+    UiPathConversationCitationSourceUrl,
+    UiPathConversationCitationStartEvent,
+)
+from .content import (
+    UiPathConversationContentPart,
+    UiPathConversationContentPartChunkEvent,
+    UiPathConversationContentPartEndEvent,
+    UiPathConversationContentPartEvent,
+    UiPathConversationContentPartStartEvent,
+)
+from .conversation import (
+    UiPathConversationCapabilities,
+    UiPathConversationEndEvent,
+    UiPathConversationStartedEvent,
+    UiPathConversationStartEvent,
+)
+from .event import UiPathConversationEvent
+from .exchange import (
+    UiPathConversationExchange,
+    UiPathConversationExchangeEndEvent,
+    UiPathConversationExchangeEvent,
+    UiPathConversationExchangeStartEvent,
+)
+from .message import (
+    UiPathConversationMessage,
+    UiPathConversationMessageEndEvent,
+    UiPathConversationMessageEvent,
+    UiPathConversationMessageStartEvent,
+)
+from .meta import UiPathConversationMetaEvent
+from .tool import (
+    UiPathConversationToolCall,
+    UiPathConversationToolCallEndEvent,
+    UiPathConversationToolCallEvent,
+    UiPathConversationToolCallResult,
+    UiPathConversationToolCallStartEvent,
+)
+
+__all__ = [
+    # Root
+    "UiPathConversationEvent",
+    # Conversation
+    "UiPathConversationCapabilities",
+    "UiPathConversationStartEvent",
+    "UiPathConversationStartedEvent",
+    "UiPathConversationEndEvent",
+    # Exchange
+    "UiPathConversationExchangeStartEvent",
+    "UiPathConversationExchangeEndEvent",
+    "UiPathConversationExchangeEvent",
+    "UiPathConversationExchange",
+    # Message
+    "UiPathConversationMessageStartEvent",
+    "UiPathConversationMessageEndEvent",
+    "UiPathConversationMessageEvent",
+    "UiPathConversationMessage",
+    # Content
+    "UiPathConversationContentPartChunkEvent",
+    "UiPathConversationContentPartStartEvent",
+    "UiPathConversationContentPartEndEvent",
+    "UiPathConversationContentPartEvent",
+    "UiPathConversationContentPart",
+    # Citation
+    "UiPathConversationCitationStartEvent",
+    "UiPathConversationCitationEndEvent",
+    "UiPathConversationCitationEvent",
+    "UiPathConversationCitationSource",
+    "UiPathConversationCitationSourceUrl",
+    "UiPathConversationCitationSourceMedia",
+    # Tool
+    "UiPathConversationToolCallStartEvent",
+    "UiPathConversationToolCallEndEvent",
+    "UiPathConversationToolCallEvent",
+    "UiPathConversationToolCallResult",
+    "UiPathConversationToolCall",
+    # Async Stream
+    "UiPathConversationInputStreamChunkEvent",
+    "UiPathConversationAsyncInputStreamStartEvent",
+    "UiPathConversationAsyncInputStreamEndEvent",
+    "UiPathConversationAsyncInputStreamEvent",
+    # Meta
+    "UiPathConversationMetaEvent",
+]

--- a/src/uipath/agent/conversation/async_stream.py
+++ b/src/uipath/agent/conversation/async_stream.py
@@ -1,0 +1,54 @@
+"""Async input stream events."""
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UiPathConversationInputStreamChunkEvent(BaseModel):
+    """Represents a single chunk of input stream data."""
+
+    input_stream_sequence: Optional[int] = Field(None, alias="inputStreamSequence")
+    data: str
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationAsyncInputStreamStartEvent(BaseModel):
+    """Signals the start of an asynchronous input stream."""
+
+    mime_type: str = Field(..., alias="mimeType")
+    start_of_speech_sensitivity: Optional[str] = Field(
+        None, alias="startOfSpeechSensitivity"
+    )
+    end_of_speech_sensitivity: Optional[str] = Field(
+        None, alias="endOfSpeechSensitivity"
+    )
+    prefix_padding_ms: Optional[int] = Field(None, alias="prefixPaddingMs")
+    silence_duration_ms: Optional[int] = Field(None, alias="silenceDurationMs")
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationAsyncInputStreamEndEvent(BaseModel):
+    """Signals the end of an asynchronous input stream."""
+
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+    last_chunk_content_part_sequence: Optional[int] = Field(
+        None, alias="lastChunkContentPartSequence"
+    )
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationAsyncInputStreamEvent(BaseModel):
+    """Encapsulates sub-events related to an asynchronous input stream."""
+
+    stream_id: str = Field(..., alias="streamId")
+    start: Optional[UiPathConversationAsyncInputStreamStartEvent] = None
+    end: Optional[UiPathConversationAsyncInputStreamEndEvent] = None
+    chunk: Optional[UiPathConversationInputStreamChunkEvent] = None
+    meta_event: Optional[Dict[str, Any]] = Field(None, alias="metaEvent")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/citation.py
+++ b/src/uipath/agent/conversation/citation.py
@@ -1,0 +1,70 @@
+"""Citation events for message content."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UiPathConversationCitationStartEvent(BaseModel):
+    """Indicates the start of a citation target in a content part."""
+
+    pass
+
+
+class UiPathConversationCitationEndEvent(BaseModel):
+    """Indicates the end of a citation target in a content part."""
+
+    sources: List[Dict[str, Any]]
+
+
+class UiPathConversationCitationEvent(BaseModel):
+    """Encapsulates sub-events related to citations."""
+
+    citation_id: str = Field(..., alias="citationId")
+    start: Optional[UiPathConversationCitationStartEvent] = None
+    end: Optional[UiPathConversationCitationEndEvent] = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationCitationSourceUrl(BaseModel):
+    """Represents a citation source that can be rendered as a link (URL)."""
+
+    url: str
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationCitationSourceMedia(BaseModel):
+    """Represents a citation source that references media, such as a PDF document."""
+
+    mime_type: str = Field(..., alias="mimeType")
+    download_url: Optional[str] = Field(None, alias="downloadUrl")
+    page_number: Optional[str] = Field(None, alias="pageNumber")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationCitationSource(BaseModel):
+    """Represents a citation source, either a URL or media reference."""
+
+    title: Optional[str] = None
+
+    # Union of Url or Media
+    url: Optional[str] = None
+    mime_type: Optional[str] = Field(None, alias="mimeType")
+    download_url: Optional[str] = Field(None, alias="downloadUrl")
+    page_number: Optional[str] = Field(None, alias="pageNumber")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationCitation(BaseModel):
+    """Represents a citation or reference inside a content part."""
+
+    citation_id: str = Field(..., alias="citationId")
+    offset: int
+    length: int
+    sources: List[UiPathConversationCitationSource]
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/content.py
+++ b/src/uipath/agent/conversation/content.py
@@ -1,0 +1,81 @@
+"""Message content part events."""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .citation import UiPathConversationCitation, UiPathConversationCitationEvent
+
+
+class UiPathConversationContentPartChunkEvent(BaseModel):
+    """Contains a chunk of a message content part."""
+
+    content_part_sequence: Optional[int] = Field(None, alias="contentPartSequence")
+    data: Optional[str] = None
+    citation: Optional[UiPathConversationCitationEvent] = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationContentPartStartEvent(BaseModel):
+    """Signals the start of a message content part."""
+
+    mime_type: str = Field(..., alias="mimeType")
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationContentPartEndEvent(BaseModel):
+    """Signals the end of a message content part."""
+
+    last_chunk_content_part_sequence: Optional[int] = Field(
+        None, alias="lastChunkContentPartSequence"
+    )
+    interrupted: Optional[Dict[str, Any]] = None
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationContentPartEvent(BaseModel):
+    """Encapsulates events related to message content parts."""
+
+    content_part_id: str = Field(..., alias="contentPartId")
+    start: Optional[UiPathConversationContentPartStartEvent] = None
+    end: Optional[UiPathConversationContentPartEndEvent] = None
+    chunk: Optional[UiPathConversationContentPartChunkEvent] = None
+    meta_event: Optional[Dict[str, Any]] = Field(None, alias="metaEvent")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathInlineValue(BaseModel):
+    """Used when a value is small enough to be returned inline."""
+
+    inline: Any
+
+
+class UiPathExternalValue(BaseModel):
+    """Used when a value is too large to be returned inline."""
+
+    url: str
+    byte_count: Optional[int] = Field(None, alias="byteCount")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+InlineOrExternal = Union[UiPathInlineValue, UiPathExternalValue]
+
+
+class UiPathConversationContentPart(BaseModel):
+    """Represents a single part of message content."""
+
+    content_part_id: str = Field(..., alias="contentPartId")
+    mime_type: str = Field(..., alias="mimeType")
+    data: InlineOrExternal
+    citations: Optional[List[UiPathConversationCitation]] = None
+    is_transcript: Optional[bool] = Field(None, alias="isTranscript")
+    is_incomplete: Optional[bool] = Field(None, alias="isIncomplete")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/conversation.py
+++ b/src/uipath/agent/conversation/conversation.py
@@ -1,0 +1,49 @@
+"""Conversation-level events and capabilities."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UiPathConversationCapabilities(BaseModel):
+    """Describes the capabilities of a conversation participant."""
+
+    async_input_stream_emitter: Optional[bool] = Field(
+        None, alias="asyncInputStreamEmitter"
+    )
+    async_input_stream_handler: Optional[bool] = Field(
+        None, alias="asyncInputStreamHandler"
+    )
+    async_tool_call_emitter: Optional[bool] = Field(None, alias="asyncToolCallEmitter")
+    async_tool_call_handler: Optional[bool] = Field(None, alias="asyncToolCallHandler")
+    mime_types_emitted: Optional[List[str]] = Field(None, alias="mimeTypesEmitted")
+    mime_types_handled: Optional[List[str]] = Field(None, alias="mimeTypesHandled")
+
+    model_config = ConfigDict(
+        validate_by_name=True, validate_by_alias=True, extra="allow"
+    )
+
+
+class UiPathConversationStartEvent(BaseModel):
+    """Signals the start of a conversation event stream."""
+
+    capabilities: Optional[UiPathConversationCapabilities] = None
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationStartedEvent(BaseModel):
+    """Signals the acceptance of the start of a conversation."""
+
+    capabilities: Optional[UiPathConversationCapabilities] = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationEndEvent(BaseModel):
+    """Signals the end of a conversation event stream."""
+
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/event.py
+++ b/src/uipath/agent/conversation/event.py
@@ -1,0 +1,56 @@
+"""The top-level event type representing an event in a conversation.
+
+This is the root container for all other event subtypes (conversation start,
+exchanges, messages, content, citations, tool calls, and async streams).
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .async_stream import UiPathConversationAsyncInputStreamEvent
+from .conversation import (
+    UiPathConversationEndEvent,
+    UiPathConversationStartedEvent,
+    UiPathConversationStartEvent,
+)
+from .exchange import UiPathConversationExchangeEvent
+from .meta import UiPathConversationMetaEvent
+from .tool import UiPathConversationToolCallEvent
+
+
+class UiPathConversationEvent(BaseModel):
+    """The top-level event type representing an event in a conversation.
+
+    This is the root container for all other event subtypes (conversation start,
+    exchanges, messages, content, citations, tool calls, and async streams).
+    """
+
+    """A globally unique identifier for conversation to which the other sub-event and data properties apply."""
+    conversation_id: str = Field(..., alias="conversationId")
+    """Signals the start of an event stream concerning a conversation. This event does NOT necessarily mean this is a
+    brand new conversation. It may be a continuation of an existing conversation.
+    """
+    start: Optional[UiPathConversationStartEvent] = None
+    """Signals the acceptance of the start of a conversation."""
+    started: Optional[UiPathConversationStartedEvent] = None
+    """Signals the end of a conversation event stream. This does NOT mean the conversation is over. A new event stream for
+    the conversation could be started in the future.
+    """
+    end: Optional[UiPathConversationEndEvent] = None
+    """Encapsulates sub-events related to an exchange within a conversation."""
+    exchange: Optional[UiPathConversationExchangeEvent] = None
+    """Encapsulates sub-events related to an asynchronous input stream."""
+    async_input_stream: Optional[UiPathConversationAsyncInputStreamEvent] = Field(
+        None, alias="asyncInputStream"
+    )
+    """Optional async tool call sub-event. This feature is not supported by all LLMs. Most tool calls are scoped to a
+    message, and use the toolCall and toolResult properties defined by the ConversationMessage type.
+    """
+    async_tool_call: Optional[UiPathConversationToolCallEvent] = Field(
+        None, alias="asyncToolCall"
+    )
+    """Allows additional events to be sent in the context of the enclosing event stream."""
+    meta_event: Optional[UiPathConversationMetaEvent] = Field(None, alias="metaEvent")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/exchange.py
+++ b/src/uipath/agent/conversation/exchange.py
@@ -1,0 +1,61 @@
+"""Exchange-level events.
+
+Characteristics of an Exchange:
+It groups together messages that belong to the same turn of conversation.
+
+Example:
+    User says something → one message inside the exchange.
+    LLM responds → one or more messages in the same exchange.
+
+Each exchange has:
+    A start event (signals the beginning of the turn).
+    An end event (signals the end of the turn).
+    Messages that happened in between.
+
+An exchange can include multiple messages (e.g. LLM streaming several outputs, or user message + assistant + tool outputs).
+Exchanges are ordered within a conversation via conversation_sequence.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .message import UiPathConversationMessage, UiPathConversationMessageEvent
+
+
+class UiPathConversationExchangeStartEvent(BaseModel):
+    """Signals the start of an exchange of messages within a conversation."""
+
+    conversation_sequence: Optional[int] = Field(None, alias="conversationSequence")
+    metadata: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationExchangeEndEvent(BaseModel):
+    """Signals the end of an exchange of messages within a conversation."""
+
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationExchangeEvent(BaseModel):
+    """Encapsulates a single exchange in the conversation."""
+
+    exchange_id: str = Field(..., alias="exchangeId")
+    start: Optional[UiPathConversationExchangeStartEvent] = None
+    end: Optional[UiPathConversationExchangeEndEvent] = None
+    message: Optional[UiPathConversationMessageEvent] = None
+    meta_event: Optional[Dict[str, Any]] = Field(None, alias="metaEvent")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationExchange(BaseModel):
+    """Represents a group of related messages (one turn of conversation)."""
+
+    exchange_id: str = Field(..., alias="exchangeId")
+    messages: List[UiPathConversationMessage]
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/message.py
+++ b/src/uipath/agent/conversation/message.py
@@ -1,0 +1,59 @@
+"""Message-level events."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .content import UiPathConversationContentPart, UiPathConversationContentPartEvent
+from .tool import UiPathConversationToolCall, UiPathConversationToolCallEvent
+
+
+class UiPathConversationMessageStartEvent(BaseModel):
+    """Signals the start of a message within an exchange."""
+
+    exchange_sequence: Optional[int] = Field(None, alias="exchangeSequence")
+    timestamp: Optional[str] = None
+    role: str
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationMessageEndEvent(BaseModel):
+    """Signals the end of a message."""
+
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationMessageEvent(BaseModel):
+    """Encapsulates sub-events related to a message."""
+
+    message_id: str = Field(..., alias="messageId")
+    start: Optional[UiPathConversationMessageStartEvent] = None
+    end: Optional[UiPathConversationMessageEndEvent] = None
+    content_part: Optional[UiPathConversationContentPartEvent] = Field(
+        None, alias="contentPart"
+    )
+    tool_call: Optional[UiPathConversationToolCallEvent] = Field(None, alias="toolCall")
+    meta_event: Optional[Dict[str, Any]] = Field(None, alias="metaEvent")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationMessage(BaseModel):
+    """Represents a single message within an exchange."""
+
+    message_id: str = Field(..., alias="messageId")
+    role: str
+    content_parts: Optional[List[UiPathConversationContentPart]] = Field(
+        None, alias="contentParts"
+    )
+    tool_calls: Optional[List[UiPathConversationToolCall]] = Field(
+        None, alias="toolCalls"
+    )
+    created_at: str = Field(..., alias="createdAt")
+    updated_at: str = Field(..., alias="updatedAt")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/src/uipath/agent/conversation/meta.py
+++ b/src/uipath/agent/conversation/meta.py
@@ -1,0 +1,11 @@
+"""Meta events allow additional extensible data."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UiPathConversationMetaEvent(BaseModel):
+    """Arbitrary metadata events in the conversation schema."""
+
+    model_config = ConfigDict(
+        validate_by_name=True, validate_by_alias=True, extra="allow"
+    )

--- a/src/uipath/agent/conversation/tool.py
+++ b/src/uipath/agent/conversation/tool.py
@@ -1,0 +1,64 @@
+"""Tool call events."""
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .content import InlineOrExternal
+
+
+class UiPathConversationToolCallResult(BaseModel):
+    """Represents the result of a tool call execution."""
+
+    timestamp: Optional[str] = None
+    value: Optional[InlineOrExternal] = None
+    is_error: Optional[bool] = Field(None, alias="isError")
+    cancelled: Optional[bool] = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationToolCall(BaseModel):
+    """Represents a call to an external tool or function within a message."""
+
+    tool_call_id: str = Field(..., alias="toolCallId")
+    name: str
+    arguments: Optional[InlineOrExternal] = None
+    timestamp: Optional[str] = None
+    result: Optional[UiPathConversationToolCallResult] = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationToolCallStartEvent(BaseModel):
+    """Signals the start of a tool call."""
+
+    tool_name: str = Field(..., alias="toolName")
+    timestamp: Optional[str] = None
+    arguments: Optional[InlineOrExternal] = None
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationToolCallEndEvent(BaseModel):
+    """Signals the end of a tool call."""
+
+    timestamp: Optional[str] = None
+    result: Optional[Any] = None
+    is_error: Optional[bool] = Field(None, alias="isError")
+    cancelled: Optional[bool] = None
+    meta_data: Optional[Dict[str, Any]] = Field(None, alias="metaData")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationToolCallEvent(BaseModel):
+    """Encapsulates the data related to a tool call event."""
+
+    tool_call_id: str = Field(..., alias="toolCallId")
+    start: Optional[UiPathConversationToolCallStartEvent] = None
+    end: Optional[UiPathConversationToolCallEndEvent] = None
+    meta_event: Optional[Dict[str, Any]] = Field(None, alias="metaEvent")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)


### PR DESCRIPTION
### Description

This PR adds Pydantic models that define a comprehensive JSON event schema for conversations between a client (UI) and an LLM/agent. The implementation establishes a hierarchical conversation structure supporting real-time streaming events, tool calls, citations, and async input streams.

- Introduces conversation event models with proper field aliasing and validation
- Implements a structured hierarchy: Conversation → Exchange → Message → Content Parts/Tool Calls
- Adds conversation handler integration to the runtime context