### PR TITLE
fix: terminal trace tree view

### DIFF
--- a/src/uipath/_cli/_dev/_terminal/_components/_details.py
+++ b/src/uipath/_cli/_dev/_terminal/_components/_details.py
@@ -292,7 +292,11 @@ class RunDetailsPanel(Container):
     def _rebuild_spans_tree(self):
         """Rebuild the spans tree from current run's traces."""
         spans_tree = self.query_one("#spans-tree", Tree)
-        spans_tree.clear()
+        if spans_tree is None or spans_tree.root is None:
+            return
+
+        spans_tree.root.remove_children()
+
         # Only clear the node mapping since we're rebuilding the tree structure
         self.span_tree_nodes.clear()
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the terminal trace tree view by changing how the spans tree is cleared during rebuilds. The fix replaces the `clear()` method with `root.remove_children()` to properly reset the tree structure.