### PR TITLE
fix: runtime context set kwargs attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.48"
+version = "2.1.49"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -315,7 +315,7 @@ class UiPathRuntimeContext(BaseModel):
     chat_handler: Optional[UiPathConversationHandler] = None
     is_conversational: Optional[bool] = None
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = {"arbitrary_types_allowed": True, "extra": "allow"}
 
     @classmethod
     def with_defaults(cls: type[C], config_path: Optional[str] = None, **kwargs) -> C:


### PR DESCRIPTION
## Description

This change updates the `with_defaults` classmethod in `UiPathRuntimeContext` to safely apply keyword arguments (`kwargs`) when constructing the context.

Key changes:

- Previously, `setattr(base, k, v)` would fail if `k` was not a defined attribute on the `Pydantic` model.
- Now, the method supports `extra="allow"` in the model config, so any extra fields in `kwargs` are applied without raising `AttributeError`.
- Maintains full support for overriding existing fields while allowing flexible runtime extensions.