### PR TITLE
fix(httpx): fix HTTP 415 unsupported media type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.50"
+version = "2.1.51"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_evals/progress_reporter.py
+++ b/src/uipath/_cli/_evals/progress_reporter.py
@@ -65,7 +65,7 @@ class ProgressReporter:
             method=spec.method,
             url=spec.endpoint,
             params=spec.params,
-            content=spec.content,
+            json=spec.json,
             headers=spec.headers,
         )
         self._eval_set_run_id = json.loads(response.content)["id"]
@@ -84,7 +84,7 @@ class ProgressReporter:
             method=spec.method,
             url=spec.endpoint,
             params=spec.params,
-            content=spec.content,
+            json=spec.json,
             headers=spec.headers,
         )
         return json.loads(response.content)["id"]
@@ -116,7 +116,7 @@ class ProgressReporter:
             method=spec.method,
             url=spec.endpoint,
             params=spec.params,
-            content=spec.content,
+            json=spec.json,
             headers=spec.headers,
         )
 
@@ -127,7 +127,7 @@ class ProgressReporter:
             method=spec.method,
             url=spec.endpoint,
             params=spec.params,
-            content=spec.content,
+            json=spec.json,
             headers=spec.headers,
         )
 
@@ -201,18 +201,16 @@ class ProgressReporter:
             endpoint=Endpoint(
                 f"agentsruntime_/api/execution/agents/{self._project_id}/evalRun"
             ),
-            content=json.dumps(
-                {
-                    "evalRunId": eval_run_id,
-                    "status": EvaluationStatus.COMPLETED.value,
-                    "result": {
-                        "output": {"content": {**actual_output}},
-                        "evaluatorScores": evaluator_scores,
-                    },
-                    "completionMetrics": {"duration": int(execution_time)},
-                    "assertionRuns": assertion_runs,
-                }
-            ),
+            json={
+                "evalRunId": eval_run_id,
+                "status": EvaluationStatus.COMPLETED.value,
+                "result": {
+                    "output": {"content": {**actual_output}},
+                    "evaluatorScores": evaluator_scores,
+                },
+                "completionMetrics": {"duration": int(execution_time)},
+                "assertionRuns": assertion_runs,
+            },
             headers=self._tenant_header(),
         )
 
@@ -222,18 +220,16 @@ class ProgressReporter:
             endpoint=Endpoint(
                 f"agentsruntime_/api/execution/agents/{self._project_id}/evalRun"
             ),
-            content=json.dumps(
-                {
-                    "evalSetRunId": self._eval_set_run_id,
-                    "evalSnapshot": {
-                        "id": eval_item["id"],
-                        "name": eval_item["name"],
-                        "inputs": eval_item.get("inputs"),
-                        "expectedOutput": eval_item.get("expectedOutput", {}),
-                    },
-                    "status": EvaluationStatus.IN_PROGRESS.value,
-                }
-            ),
+            json={
+                "evalSetRunId": self._eval_set_run_id,
+                "evalSnapshot": {
+                    "id": eval_item["id"],
+                    "name": eval_item["name"],
+                    "inputs": eval_item.get("inputs"),
+                    "expectedOutput": eval_item.get("expectedOutput", {}),
+                },
+                "status": EvaluationStatus.IN_PROGRESS.value,
+            },
             headers=self._tenant_header(),
         )
 
@@ -247,15 +243,13 @@ class ProgressReporter:
             endpoint=Endpoint(
                 f"agentsruntime_/api/execution/agents/{self._project_id}/evalSetRun"
             ),
-            content=json.dumps(
-                {
-                    "agentId": self._project_id,
-                    "evalSetId": self._eval_set_id,
-                    "agentSnapshot": agent_snapshot_dict,
-                    "status": EvaluationStatus.IN_PROGRESS.value,
-                    "numberOfEvalsExecuted": self._no_of_evals,
-                }
-            ),
+            json={
+                "agentId": self._project_id,
+                "evalSetId": self._eval_set_id,
+                "agentSnapshot": agent_snapshot_dict,
+                "status": EvaluationStatus.IN_PROGRESS.value,
+                "numberOfEvalsExecuted": self._no_of_evals,
+            },
             headers=self._tenant_header(),
         )
 
@@ -293,13 +287,11 @@ class ProgressReporter:
             endpoint=Endpoint(
                 f"agentsruntime_/api/execution/agents/{self._project_id}/evalSetRun"
             ),
-            content=json.dumps(
-                {
-                    "evalSetRunId": self._eval_set_run_id,
-                    "status": EvaluationStatus.COMPLETED.value,
-                    "evaluatorScores": evaluator_scores,
-                }
-            ),
+            json={
+                "evalSetRunId": self._eval_set_run_id,
+                "status": EvaluationStatus.COMPLETED.value,
+                "evaluatorScores": evaluator_scores,
+            },
             headers=self._tenant_header(),
         )
 

--- a/src/uipath/_services/context_grounding_service.py
+++ b/src/uipath/_services/context_grounding_service.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, List, Optional, Tuple, Union
 
 import httpx
@@ -353,7 +352,7 @@ class ContextGroundingService(FolderContext, BaseService):
         response = self.request(
             spec.method,
             spec.endpoint,
-            content=spec.content,
+            json=spec.json,
         )
 
         return TypeAdapter(List[ContextGroundingQueryResponse]).validate_python(
@@ -403,7 +402,7 @@ class ContextGroundingService(FolderContext, BaseService):
         response = await self.request_async(
             spec.method,
             spec.endpoint,
-            content=spec.content,
+            json=spec.json,
         )
 
         return TypeAdapter(List[ContextGroundingQueryResponse]).validate_python(
@@ -592,21 +591,19 @@ class ContextGroundingService(FolderContext, BaseService):
         return RequestSpec(
             method="POST",
             endpoint=Endpoint("/ecs_/v2/indexes/create"),
-            content=json.dumps(
-                {
-                    "name": name,
-                    "description": description,
-                    "dataSource": {
-                        "@odata.type": ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE,
-                        "folder": storage_bucket_folder_path,
-                        "bucketName": storage_bucket_name,
-                        "fileNameGlob": file_name_glob
-                        if file_name_glob is not None
-                        else "*",
-                        "directoryPath": "/",
-                    },
-                }
-            ),
+            json={
+                "name": name,
+                "description": description,
+                "dataSource": {
+                    "@odata.type": ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE,
+                    "folder": storage_bucket_folder_path,
+                    "bucketName": storage_bucket_name,
+                    "fileNameGlob": file_name_glob
+                    if file_name_glob is not None
+                    else "*",
+                    "directoryPath": "/",
+                },
+            },
             headers={
                 **header_folder(folder_key, None),
             },
@@ -657,12 +654,10 @@ class ContextGroundingService(FolderContext, BaseService):
         return RequestSpec(
             method="POST",
             endpoint=Endpoint("/ecs_/v1/search"),
-            content=json.dumps(
-                {
-                    "query": {"query": query, "numberOfResults": number_of_results},
-                    "schema": {"name": name},
-                }
-            ),
+            json={
+                "query": {"query": query, "numberOfResults": number_of_results},
+                "schema": {"name": name},
+            },
             headers={
                 **header_folder(folder_key, None),
             },

--- a/src/uipath/_services/jobs_service.py
+++ b/src/uipath/_services/jobs_service.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import tempfile
@@ -81,7 +80,7 @@ class JobsService(FolderContext, BaseService):
             spec.method,
             url=spec.endpoint,
             headers=spec.headers,
-            content=spec.content,
+            json=spec.json,
         )
 
     async def resume_async(
@@ -142,7 +141,7 @@ class JobsService(FolderContext, BaseService):
             spec.method,
             url=spec.endpoint,
             headers=spec.headers,
-            content=spec.content,
+            json=spec.json,
         )
 
     @property
@@ -412,7 +411,7 @@ class JobsService(FolderContext, BaseService):
             endpoint=Endpoint(
                 f"/orchestrator_/api/JobTriggers/DeliverPayload/{inbox_id}"
             ),
-            content=json.dumps({"payload": payload}),
+            json={"payload": payload},
             headers={
                 **header_folder(folder_key, folder_path),
             },

--- a/src/uipath/_services/llm_gateway_service.py
+++ b/src/uipath/_services/llm_gateway_service.py
@@ -16,7 +16,6 @@ Classes:
     UiPathLlmChatService: Service using UiPath's normalized API format
 """
 
-import json
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
@@ -195,7 +194,7 @@ class UiPathOpenAIService(BaseService):
         response = await self.request_async(
             "POST",
             endpoint,
-            content=json.dumps({"input": input}),
+            json={"input": input},
             params={"api-version": API_VERSION},
             headers=DEFAULT_LLM_HEADERS,
         )
@@ -322,7 +321,7 @@ class UiPathOpenAIService(BaseService):
         response = await self.request_async(
             "POST",
             endpoint,
-            content=json.dumps(request_body),
+            json=request_body,
             params={"api-version": API_VERSION},
             headers=DEFAULT_LLM_HEADERS,
         )
@@ -534,7 +533,7 @@ class UiPathLlmChatService(BaseService):
         response = await self.request_async(
             "POST",
             endpoint,
-            content=json.dumps(request_body),
+            json=request_body,
             params={"api-version": NORMALIZED_API_VERSION},
             headers=headers,
         )

--- a/tests/sdk/services/test_jobs_service.py
+++ b/tests/sdk/services/test_jobs_service.py
@@ -214,7 +214,8 @@ class TestJobsService:
             sent_request.url
             == f"{base_url}{org}{tenant}/orchestrator_/api/JobTriggers/DeliverPayload/{inbox_id}"
         )
-        assert json.loads(sent_request.content) == {"payload": payload}
+
+        assert json.loads(sent_request.content.decode()) == {"payload": payload}
 
         assert HEADER_USER_AGENT in sent_request.headers
         assert (
@@ -255,7 +256,8 @@ class TestJobsService:
             sent_requests[1].url
             == f"{base_url}{org}{tenant}/orchestrator_/api/JobTriggers/DeliverPayload/{inbox_id}"
         )
-        assert json.loads(sent_requests[1].content) == {"payload": payload}
+
+        assert json.loads(sent_requests[1].content.decode()) == {"payload": payload}
 
         assert HEADER_USER_AGENT in sent_requests[1].headers
         assert (
@@ -289,7 +291,8 @@ class TestJobsService:
             sent_request.url
             == f"{base_url}{org}{tenant}/orchestrator_/api/JobTriggers/DeliverPayload/{inbox_id}"
         )
-        assert json.loads(sent_request.content) == {"payload": payload}
+
+        assert json.loads(sent_request.content.decode()) == {"payload": payload}
 
         assert HEADER_USER_AGENT in sent_request.headers
         assert (
@@ -331,7 +334,8 @@ class TestJobsService:
             sent_requests[1].url
             == f"{base_url}{org}{tenant}/orchestrator_/api/JobTriggers/DeliverPayload/{inbox_id}"
         )
-        assert json.loads(sent_requests[1].content) == {"payload": payload}
+
+        assert json.loads(sent_requests[1].content.decode()) == {"payload": payload}
 
         assert HEADER_USER_AGENT in sent_requests[1].headers
         assert (

--- a/tests/sdk/services/test_uipath_llm_integration.py
+++ b/tests/sdk/services/test_uipath_llm_integration.py
@@ -1,4 +1,3 @@
-import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -280,9 +279,9 @@ class TestUiPathLLMServiceMocked:
         # Verify the correct endpoint and payload
         args, kwargs = mock_request.call_args
         assert "/llmgateway_/api/chat/completions" in args[1]
-        assert json.loads(kwargs["content"])["messages"] == messages
-        assert json.loads(kwargs["content"])["max_tokens"] == 50
-        assert json.loads(kwargs["content"])["temperature"] == 0
+        assert kwargs["json"]["messages"] == messages
+        assert kwargs["json"]["max_tokens"] == 50
+        assert kwargs["json"]["temperature"] == 0
 
     @pytest.mark.asyncio
     @patch.object(UiPathLlmChatService, "request_async")
@@ -509,6 +508,6 @@ class TestUiPathLLMServiceMocked:
 
         # Verify the correct payload was sent
         args, kwargs = mock_request.call_args
-        assert json.loads(kwargs["content"])["messages"] == messages
-        assert json.loads(kwargs["content"])["max_tokens"] == 100
-        assert json.loads(kwargs["content"])["temperature"] == 0.7
+        assert kwargs["json"]["messages"] == messages
+        assert kwargs["json"]["max_tokens"] == 100
+        assert kwargs["json"]["temperature"] == 0.7


### PR DESCRIPTION
The call to the ECS index fails with HTTP 415 unsupported media type. (full error in thread).
This is the code to create the tool:
```
retriever = ContextGroundingRetriever(index_name = "LoanStateRequirements", folder_path = "Shared/FINS")
retriever_tool = create_retriever_tool(
    retriever,
    "ContextforStateRequirements",
   """
   Use this tool to search for state by state requirements for documents need to process loan applications.
   """
)
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.51.dev1005871119",

  # Any version from PR
  "uipath>=2.1.51.dev1005870000,<2.1.51.dev1005880000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```