### PR TITLE
[wip]feat: Add list command for uipath resources

### DIFF
--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -16,7 +16,7 @@ from .cli_publish import publish as publish  # type: ignore
 from .cli_pull import pull as pull  # type: ignore
 from .cli_push import push as push  # type: ignore
 from .cli_run import run as run  # type: ignore
-
+from .cli_list import get as get # type: ignore
 
 def _get_safe_version() -> str:
     """Get the version of the uipath package."""
@@ -73,3 +73,4 @@ cli.add_command(push)
 cli.add_command(pull)
 cli.add_command(eval)
 cli.add_command(dev)
+cli.add_command(get)

--- a/src/uipath/_cli/cli_list.py
+++ b/src/uipath/_cli/cli_list.py
@@ -1,0 +1,63 @@
+import json
+from typing import List, Protocol, Any, Dict, Callable
+
+import click
+
+from ._utils._common import environment_options, get_env_vars
+from ._utils._console import ConsoleLogger
+from ..telemetry import track
+
+from .._config import Config
+from .._execution_context import ExecutionContext
+from .._services import EntitiesService, AssetsService
+
+console = ConsoleLogger()
+
+
+class CLIListable(Protocol):
+    """Protocol for services that support listing"""
+    def _list(self, **kwargs) -> List[Any]:
+        ...
+
+def create_service(resource_type: str) -> CLIListable:
+    """Service factory - creates the appropriate service"""
+    [base_url, token] = get_env_vars()
+
+    config = Config(base_url=base_url, secret=token)
+    execution_context = ExecutionContext()
+
+    services: Dict[str, Callable[[], CLIListable]] = {
+        'entities': lambda: EntitiesService(config, execution_context),
+        'assets': lambda: AssetsService(config, execution_context),
+    }
+
+    if resource_type not in services:
+        available = ', '.join(services.keys())
+        raise ValueError(f"Unknown resource type '{resource_type}'. Available: {available}")
+
+    return services[resource_type]()
+
+@click.command()
+@click.argument('resource_type')
+@click.option('--folder-path', '-f', help='Folder path to list resources from')
+def get(
+    resource_type: str,
+    folder_path: str = None):
+    """List resources of a given type."""
+
+    with console.spinner(f"Fetching {resource_type}..."):
+        try:
+            service: CLIListable = create_service(resource_type)
+            # Only pass folder_path if it's provided
+            kwargs = {}
+            if folder_path:
+                kwargs['folder_path'] = folder_path
+            list_results = service._list(**kwargs)
+
+            data = [item.model_dump(mode='json') for item in list_results]
+            console.success(json.dumps(data, indent=2))
+
+        except Exception as e:
+            console.error(f"Error fetching {resource_type}: {e}")
+            raise click.Abort()
+

--- a/src/uipath/_services/_cli_service.py
+++ b/src/uipath/_services/_cli_service.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class ClIService(ABC):
+    """
+    Abstract class implemented by services supported in the CLI commands.
+    """
+    @abstractmethod
+    def _list(self, **kwargs):
+        pass

--- a/src/uipath/_services/entities_service.py
+++ b/src/uipath/_services/entities_service.py
@@ -12,9 +12,10 @@ from ..models.entities import (
 )
 from ..tracing import traced
 from ._base_service import BaseService
+from ._cli_service import ClIService
 
 
-class EntitiesService(BaseService):
+class EntitiesService(BaseService, ClIService):
     """Service for managing UiPath Data Service entities.
 
     Entities are database tables in UiPath Data Service that can store
@@ -23,6 +24,9 @@ class EntitiesService(BaseService):
 
     def __init__(self, config: Config, execution_context: ExecutionContext) -> None:
         super().__init__(config=config, execution_context=execution_context)
+
+    def _list(self, **kwargs) -> List[Entity]:
+        return self.list_entities()
 
     @traced(name="entity_retrieve", run_type="uipath")
     def retrieve(self, entity_key: str) -> Entity:


### PR DESCRIPTION
# Description

- Added the `uipath get` command to list resources.

- Currently supports assets and entities

- For folder-scoped entities such as assets you either need to:

1.  Pass the folder-path as an option to the command, e.g:  `uipath get -f Shared/assets-demo assets` 
2.  Have the `folder_key` env variable configured       