### PR TITLE
feat: add option to exclude files

### DIFF
--- a/tests/cli/utils/uipath_json.py
+++ b/tests/cli/utils/uipath_json.py
@@ -66,11 +66,19 @@ class Bindings:
 
 
 class Settings:
-    def __init__(self, file_extensions_included=None, files_included=None):
+    def __init__(
+        self,
+        file_extensions_included=None,
+        files_included=None,
+        files_excluded=None,
+        directories_excluded=None,
+    ):
         self.file_extensions_included = (
             file_extensions_included if file_extensions_included else []
         )
         self.files_included = files_included if files_included else []
+        self.files_excluded = files_excluded if files_excluded else []
+        self.directories_excluded = directories_excluded if directories_excluded else []
 
 
 class UiPathJson:


### PR DESCRIPTION
# Description

Support for git will be added in StudioWeb which makes supporting .gitignore directly kind of redundant. Instead, as a temporary workaround until support in SW is rolled out, add 2 new options to uipath.json.settings:

- files_excluded: files referenced here should be excluded from pack/push (take precedence over files_included)
- directories_excluded: same as the above but of entire directories

Also fixed an existing bug, matching was done by file name instead of file path so if you had 2 files with the same name in different directories both would be included/excluded