### PR TITLE
chore(ci): use different python versions for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: ".python-version"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --all-extras


### PR DESCRIPTION
Currently hardcoded to contents of `.python-version` file, instead of using what is defined in the strategy matrix