### PR TITLE
fix(ProjectStructure): project structure id representation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.58"
+version = "2.1.59"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -291,7 +291,8 @@ class SwFileHandler:
 
             # Check if the current folder is empty after processing its children
             if self._is_folder_empty(subfolder):
-                empty_folders.append({"id": subfolder.id, "name": subfolder.name})
+                if subfolder.id is not None:
+                    empty_folders.append({"id": subfolder.id, "name": subfolder.name})
 
         return empty_folders
 

--- a/src/uipath/_cli/_utils/_studio_project.py
+++ b/src/uipath/_cli/_utils/_studio_project.py
@@ -67,7 +67,7 @@ class ProjectFolder(BaseModel):
     """Model representing a folder in a UiPath project structure.
 
     Attributes:
-        id: The unique identifier of the folder
+        id: The unique identifier of the folder. Root folder id may be None.
         name: The name of the folder
         folders: List of subfolders
         files: List of files in the folder
@@ -82,7 +82,7 @@ class ProjectFolder(BaseModel):
         extra="allow",
     )
 
-    id: str = Field(alias="id")
+    id: Optional[str] = Field(default=None, alias="id")
     name: str = Field(alias="name")
     folders: List["ProjectFolder"] = Field(default_factory=list)
     files: List[ProjectFile] = Field(default_factory=list)


### PR DESCRIPTION
The id of the project folder may `None` for root folders. Addressing this bug introduced in [this PR](https://github.com/UiPath/uipath-python/commit/bc4bf7f4daf668ca5d582b06bd53061e98099252).