### PR TITLE
feat: added ability to create indexes through the sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.70"
+version = "2.1.71"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_utils/constants.py
+++ b/src/uipath/_utils/constants.py
@@ -25,6 +25,18 @@ HEADER_SW_LOCK_KEY = "x-uipath-sw-lockkey"
 ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
     "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSourceRequest"
 )
+CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
+DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
+GOOGLE_DRIVE_DATA_SOURCE = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSourceRequest"
+)
+ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
+
+# Preprocessing request types
+LLMV3Mini = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
+LLMV4 = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
+NativeV1 = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
+
 
 # Local storage
 TEMP_ATTACHMENTS_FOLDER = "uipath_attachments"

--- a/tests/sdk/services/test_context_grounding_service.py
+++ b/tests/sdk/services/test_context_grounding_service.py
@@ -332,3 +332,544 @@ class TestContextGroundingService:
             sent_requests[1].headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ContextGroundingService.retrieve_async/{version}"
         )
+
+    def test_create_index_bucket(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "new-index-id",
+                "name": "test-bucket-index",
+                "description": "Test bucket index",
+                "lastIngestionStatus": "Queued",
+                "dataSource": {"bucketName": "test-bucket", "folder": "/test/folder"},
+            },
+        )
+
+        source = {
+            "type": "bucket",
+            "bucket_name": "test-bucket",
+            "folder_path": "/test/folder",
+            "directory_path": "/",
+            "file_type": "pdf",
+        }
+
+        index = service.create_index(
+            name="test-bucket-index",
+            description="Test bucket index",
+            source=source,
+            advanced_ingestion=True,
+        )
+
+        assert isinstance(index, ContextGroundingIndex)
+        assert index.id == "new-index-id"
+        assert index.name == "test-bucket-index"
+        assert index.description == "Test bucket index"
+        assert index.last_ingestion_status == "Queued"
+
+        sent_requests = httpx_mock.get_requests()
+        assert len(sent_requests) == 2
+
+        create_request = sent_requests[1]
+        assert create_request.method == "POST"
+        assert create_request.url == f"{base_url}{org}{tenant}/ecs_/v2/indexes/create"
+        assert HEADER_USER_AGENT in create_request.headers
+        assert (
+            create_request.headers[HEADER_USER_AGENT]
+            == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ContextGroundingService.create_index/{version}"
+        )
+
+        import json
+
+        request_data = json.loads(create_request.content)
+        assert request_data["name"] == "test-bucket-index"
+        assert request_data["description"] == "Test bucket index"
+        assert (
+            request_data["dataSource"]["@odata.type"]
+            == "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSourceRequest"
+        )
+        assert request_data["dataSource"]["bucketName"] == "test-bucket"
+        assert request_data["dataSource"]["folder"] == "/test/folder"
+        assert request_data["dataSource"]["directoryPath"] == "/"
+        assert request_data["dataSource"]["fileNameGlob"] == "**/*.pdf"
+        assert (
+            request_data["preProcessing"]["@odata.type"]
+            == "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
+        )
+
+    def test_create_index_google_drive(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "google-index-id",
+                "name": "test-google-index",
+                "description": "Test Google Drive index",
+                "lastIngestionStatus": "Queued",
+                "dataSource": {"connectionId": "conn-123", "folder": "/test/folder"},
+            },
+        )
+
+        source = {
+            "type": "google_drive",
+            "connection_id": "conn-123",
+            "connection_name": "Google Drive Connection",
+            "leaf_folder_id": "folder-456",
+            "directory_path": "/shared-docs",
+            "folder_path": "/test/folder",
+            "file_type": "docx",
+        }
+
+        index = service.create_index(
+            name="test-google-index",
+            description="Test Google Drive index",
+            source=source,
+            cron_expression="0 0 18 ? * 2",
+            time_zone_id="Pacific Standard Time",
+        )
+
+        assert isinstance(index, ContextGroundingIndex)
+        assert index.id == "google-index-id"
+        assert index.name == "test-google-index"
+
+        sent_requests = httpx_mock.get_requests()
+        create_request = sent_requests[1]
+
+        import json
+
+        request_data = json.loads(create_request.content)
+        assert (
+            request_data["dataSource"]["@odata.type"]
+            == "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSourceRequest"
+        )
+        assert request_data["dataSource"]["connectionId"] == "conn-123"
+        assert request_data["dataSource"]["connectionName"] == "Google Drive Connection"
+        assert request_data["dataSource"]["leafFolderId"] == "folder-456"
+        assert request_data["dataSource"]["directoryPath"] == "/shared-docs"
+        assert request_data["dataSource"]["fileNameGlob"] == "**/*.docx"
+        assert request_data["dataSource"]["indexer"]["cronExpression"] == "0 0 18 ? * 2"
+        assert (
+            request_data["dataSource"]["indexer"]["timeZoneId"]
+            == "Pacific Standard Time"
+        )
+
+    def test_create_index_dropbox(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "dropbox-index-id",
+                "name": "test-dropbox-index",
+                "lastIngestionStatus": "Queued",
+            },
+        )
+
+        source = {
+            "type": "dropbox",
+            "connection_id": "dropbox-conn-789",
+            "connection_name": "Dropbox Connection",
+            "directory_path": "/company-files",
+            "folder_path": "/test/folder",
+        }
+
+        index = service.create_index(
+            name="test-dropbox-index", source=source, advanced_ingestion=False
+        )
+
+        assert isinstance(index, ContextGroundingIndex)
+        assert index.id == "dropbox-index-id"
+
+        sent_requests = httpx_mock.get_requests()
+        create_request = sent_requests[1]
+
+        import json
+
+        request_data = json.loads(create_request.content)
+        assert (
+            request_data["dataSource"]["@odata.type"]
+            == "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
+        )
+        assert request_data["dataSource"]["connectionId"] == "dropbox-conn-789"
+        assert request_data["dataSource"]["connectionName"] == "Dropbox Connection"
+        assert request_data["dataSource"]["directoryPath"] == "/company-files"
+        assert request_data["dataSource"]["fileNameGlob"] == "**/*"
+        assert "preProcessing" not in request_data
+
+    def test_create_index_onedrive(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "onedrive-index-id",
+                "name": "test-onedrive-index",
+                "lastIngestionStatus": "Queued",
+            },
+        )
+
+        source = {
+            "type": "onedrive",
+            "connection_id": "onedrive-conn-101",
+            "connection_name": "OneDrive Connection",
+            "leaf_folder_id": "onedrive-folder-202",
+            "directory_path": "/reports",
+            "folder_path": "/test/folder",
+            "file_type": "xlsx",
+        }
+
+        index = service.create_index(name="test-onedrive-index", source=source)
+
+        assert isinstance(index, ContextGroundingIndex)
+        assert index.id == "onedrive-index-id"
+
+        sent_requests = httpx_mock.get_requests()
+        create_request = sent_requests[1]
+
+        import json
+
+        request_data = json.loads(create_request.content)
+        assert (
+            request_data["dataSource"]["@odata.type"]
+            == "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
+        )
+        assert request_data["dataSource"]["connectionId"] == "onedrive-conn-101"
+        assert request_data["dataSource"]["leafFolderId"] == "onedrive-folder-202"
+        assert request_data["dataSource"]["fileNameGlob"] == "**/*.xlsx"
+
+    def test_create_index_confluence(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "confluence-index-id",
+                "name": "test-confluence-index",
+                "lastIngestionStatus": "Queued",
+            },
+        )
+
+        source = {
+            "type": "confluence",
+            "connection_id": "confluence-conn-303",
+            "connection_name": "Confluence Connection",
+            "space_id": "space-404",
+            "directory_path": "/wiki-docs",
+            "folder_path": "/test/folder",
+        }
+
+        index = service.create_index(name="test-confluence-index", source=source)
+
+        assert isinstance(index, ContextGroundingIndex)
+        assert index.id == "confluence-index-id"
+
+        sent_requests = httpx_mock.get_requests()
+        create_request = sent_requests[1]
+
+        import json
+
+        request_data = json.loads(create_request.content)
+        assert (
+            request_data["dataSource"]["@odata.type"]
+            == "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
+        )
+        assert request_data["dataSource"]["connectionId"] == "confluence-conn-303"
+        assert request_data["dataSource"]["connectionName"] == "Confluence Connection"
+
+    @pytest.mark.anyio
+    async def test_create_index_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "async-index-id",
+                "name": "test-async-index",
+                "description": "Test async index",
+                "lastIngestionStatus": "Queued",
+            },
+        )
+
+        source = {
+            "type": "bucket",
+            "bucket_name": "async-bucket",
+            "folder_path": "/async/folder",
+        }
+
+        index = await service.create_index_async(
+            name="test-async-index", description="Test async index", source=source
+        )
+
+        assert isinstance(index, ContextGroundingIndex)
+        assert index.id == "async-index-id"
+        assert index.name == "test-async-index"
+
+        sent_requests = httpx_mock.get_requests()
+        create_request = sent_requests[1]
+        assert create_request.method == "POST"
+        assert HEADER_USER_AGENT in create_request.headers
+        assert (
+            create_request.headers[HEADER_USER_AGENT]
+            == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ContextGroundingService.create_index_async/{version}"
+        )
+
+    def test_create_index_missing_bucket_name(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        source = {"type": "bucket", "folder_path": "/test/folder"}
+
+        with pytest.raises(
+            ValueError, match="bucket_name is required for bucket data source"
+        ):
+            service.create_index(name="test-invalid-bucket", source=source)
+
+    def test_create_index_missing_google_drive_fields(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        source = {
+            "type": "google_drive",
+            "connection_id": "conn-123",
+            "folder_path": "/test/folder",
+        }
+
+        with pytest.raises(
+            ValueError, match="connection_name is required for Google Drive data source"
+        ):
+            service.create_index(name="test-invalid-google", source=source)
+
+    def test_create_index_unsupported_source_type(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        source = {"type": "unsupported", "folder_path": "/test/folder"}
+
+        with pytest.raises(
+            ValueError, match="Unsupported data source type: unsupported"
+        ):
+            service.create_index(name="test-unsupported", source=source)
+
+    def test_create_index_custom_preprocessing(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ContextGroundingService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        from uipath._utils.constants import LLMV3Mini
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/create",
+            status_code=200,
+            json={
+                "id": "custom-prep-index-id",
+                "name": "test-custom-prep-index",
+                "lastIngestionStatus": "Queued",
+            },
+        )
+
+        source = {
+            "type": "bucket",
+            "bucket_name": "test-bucket",
+            "folder_path": "/test/folder",
+        }
+
+        index = service.create_index(
+            name="test-custom-prep-index",
+            source=source,
+            preprocessing_request=LLMV3Mini,
+        )
+
+        assert isinstance(index, ContextGroundingIndex)
+
+        sent_requests = httpx_mock.get_requests()
+        create_request = sent_requests[1]
+
+        import json
+
+        request_data = json.loads(create_request.content)
+        assert request_data["preProcessing"]["@odata.type"] == LLMV3Mini


### PR DESCRIPTION
Added `create_index` and `create_index_async` methods to ContextGroundingService to enable programmatic creation of context grounding indexes. 


Create methods for buckets (and assets) will be added under a different PR, for [this issue](https://github.com/UiPath/uipath-python/issues/572)


## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.71.dev1006221397",

  # Any version from PR
  "uipath>=2.1.71.dev1006220000,<2.1.71.dev1006230000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```