### PR TITLE
fix: isolate logging across concurrent runtime executions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.71"
+version = "2.1.72"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -525,6 +525,7 @@ class UiPathBaseRuntime(ABC):
             dir=self.context.runtime_dir,
             file=self.context.logs_file,
             job_id=self.context.job_id,
+            execution_id=self.context.execution_id,
             is_debug_run=self.is_debug_run(),
             log_handler=self.context.log_handler,
         )


### PR DESCRIPTION
## Description

When multiple runtimes execute in parallel, logs from different executions get mixed together because they all share the same global logging handlers. This makes it impossible to track which logs belong to which execution.
**Root cause:** `LogsInterceptor` modifies global logging state, causing all parallel executions to interfere with each other.

### Solution
Use `contextvars.ContextVar` to scope logs per execution without fighting global state:

- Context variable for execution tracking - `current_execution_id` is set per async context and automatically propagates through async calls
- Execution-aware filter - `ExecutionContextFilter` checks the context variable to route logs to the correct handler
- Additive handlers in parallel mode - When `execution_id` is provided, handlers are added instead of replaced, allowing multiple executions to coexist
- Proper cleanup - Handlers and filters are removed only for the specific execution on teardown

### Usage

You can use a custom log handler to capture the logs per execution, eg:
```python
class RuntimeContextLogHandler(logging.Handler):
    """Custom log handler that captures logs per execution."""

    def __init__(
        self,
        execution_id: str,
        callback: Callable[[LogMessage], None],
    ):
        super().__init__()
        self.execution_id= execution_id
        self.callback = callback

    def emit(self, record: logging.LogRecord):
        try:
            log_msg = LogMessage(
                execution_id=self.execution_id,
                level=record.levelname,
                message=self.format(record),
                timestamp=datetime.fromtimestamp(record.created),
            )
            self.callback(log_msg)
        except Exception:
            # Don't let logging errors crash the app
            pass
...

runtime_context: C = self.factory.new_context(
    execution_id=eval_item.id,
    log_handler=RuntimeContextLogHandler(
        execution_id=eval_item.id, callback=self._handle_log_message
    ),
    input_json=eval_item.inputs,
    is_eval_run=True,
)


```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.72.dev1006401443",

  # Any version from PR
  "uipath>=2.1.72.dev1006400000,<2.1.72.dev1006410000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```