### PR TITLE
fix: optional eval in low code model

### DIFF
--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -309,12 +309,14 @@ class BaseAgentDefinition(BaseModel):
     resources: List[AgentResourceConfig] = Field(
         ..., description="List of tools, context, and escalation resources"
     )
-    evaluation_sets: List[EvaluationSet] = Field(
-        ...,
+    evaluation_sets: Optional[List[EvaluationSet]] = Field(
+        None,
         alias="evaluationSets",
         description="List of agent evaluation sets",
     )
-    evaluators: List[Evaluator] = Field(..., description="List of agent evaluators")
+    evaluators: Optional[List[Evaluator]] = Field(
+        None, description="List of agent evaluators"
+    )
 
     model_config = ConfigDict(
         validate_by_name=True, validate_by_alias=True, extra="allow"

--- a/tests/agent/models/test_agent.py
+++ b/tests/agent/models/test_agent.py
@@ -503,8 +503,6 @@ class TestAgentBuilderConfig:
                     "extraField": {"foo": "bar"},
                 }
             ],
-            "evaluators": [],
-            "evaluationSets": [],
         }
 
         config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
@@ -552,8 +550,6 @@ class TestAgentBuilderConfig:
                 },
             },
             "resources": [],
-            "evaluators": [],
-            "evaluationSets": [],
         }
 
         config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(


### PR DESCRIPTION
## Description

This PR makes the `evaluators` and `evaluation_sets` fields optional in the `BaseAgentDefinition` model to support low-code scenarios where evaluation components may not be required.

- Makes `evaluators` and `evaluation_sets` fields optional by wrapping them with `Optional[List[...]]`
- Updates test cases to remove the previously required empty lists for these fields