### PR TITLE
fix: use pydantic models for create index payloads

### DIFF
--- a/src/uipath/_services/context_grounding_service.py
+++ b/src/uipath/_services/context_grounding_service.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import httpx
@@ -10,16 +9,28 @@ from .._execution_context import ExecutionContext
 from .._folder_context import FolderContext
 from .._utils import Endpoint, RequestSpec, header_folder, resource_override
 from .._utils.constants import (
-    CONFLUENCE_DATA_SOURCE,
-    DROPBOX_DATA_SOURCE,
-    GOOGLE_DRIVE_DATA_SOURCE,
-    LLMV4,
-    ONEDRIVE_DATA_SOURCE,
+    LLMV4_REQUEST,
     ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE,
 )
 from ..models import IngestionInProgressException
 from ..models.context_grounding import ContextGroundingQueryResponse
 from ..models.context_grounding_index import ContextGroundingIndex
+from ..models.context_grounding_payloads import (
+    BucketDataSource,
+    BucketSourceConfig,
+    ConfluenceDataSource,
+    ConfluenceSourceConfig,
+    CreateIndexPayload,
+    DropboxDataSource,
+    DropboxSourceConfig,
+    GoogleDriveDataSource,
+    GoogleDriveSourceConfig,
+    OneDriveDataSource,
+    OneDriveSourceConfig,
+    PreProcessing,
+    SourceConfig,
+)
+from ..models.exceptions import UnsupportedDataSourceException
 from ..tracing import traced
 from ._base_service import BaseService
 from .buckets_service import BucketsService
@@ -323,12 +334,10 @@ class ContextGroundingService(FolderContext, BaseService):
     def create_index(
         self,
         name: str,
-        source: Dict[str, Any],
+        source: SourceConfig,
         description: Optional[str] = None,
-        cron_expression: Optional[str] = None,
-        time_zone_id: Optional[str] = None,
         advanced_ingestion: Optional[bool] = True,
-        preprocessing_request: Optional[str] = LLMV4,
+        preprocessing_request: Optional[str] = LLMV4_REQUEST,
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
     ) -> ContextGroundingIndex:
@@ -336,17 +345,18 @@ class ContextGroundingService(FolderContext, BaseService):
 
         Args:
             name (str): The name of the index to create.
-            source (dict): Source configuration dictionary:
-                - For buckets: type="bucket", bucket_name, folder_path, directory_path="/" (optional), file_type (optional)
-                - For Google Drive: type="google", connection_name, connection_id, leaf_folder_id, directory_path, folder_path, file_type (optional)
-                - For Dropbox: type="dropbox", connection_name, connection_id, directory_path, folder_path, file_type (optional)
-                - For OneDrive: type="onedrive", connection_name, connection_id, leaf_folder_id, directory_path, folder_path, file_type (optional)
-                - For Confluence: type="confluence", connection_name, connection_id, space_id, directory_path, folder_path, file_type (optional)
+            source (SourceConfig): Source configuration using one of:
+                - BucketSourceConfig: For storage buckets
+                - GoogleDriveSourceConfig: For Google Drive
+                - DropboxSourceConfig: For Dropbox
+                - OneDriveSourceConfig: For OneDrive
+                - ConfluenceSourceConfig: For Confluence
+
+                The source can include an optional indexer field for scheduled indexing:
+                    source.indexer = Indexer(cron_expression="0 0 18 ? * 2", time_zone_id="UTC")
             description (Optional[str]): Description of the index.
-            cron_expression (Optional[str]): Cron expression for scheduled indexing (e.g., "0 0 18 ? * 2" for Tuesdays at 6 PM).
-            time_zone_id (Optional[str]): Valid Windows Timezone ID for the cron expression (e.g., "UTC", "Pacific Standard Time", "GTB Standard Time").
             advanced_ingestion (Optional[bool]): Enable advanced ingestion with preprocessing. Defaults to True.
-            preprocessing_request (Optional[str]): The OData type for preprocessing request. Defaults to LLMV4.
+            preprocessing_request (Optional[str]): The OData type for preprocessing request. Defaults to LLMV4_REQUEST.
             folder_key (Optional[str]): The key of the folder where the index will be created.
             folder_path (Optional[str]): The path of the folder where the index will be created.
 
@@ -357,12 +367,10 @@ class ContextGroundingService(FolderContext, BaseService):
             name=name,
             description=description,
             source=source,
-            cron_expression=cron_expression,
-            time_zone_id=time_zone_id,
             advanced_ingestion=advanced_ingestion
             if advanced_ingestion is not None
             else True,
-            preprocessing_request=preprocessing_request or LLMV4,
+            preprocessing_request=preprocessing_request or LLMV4_REQUEST,
             folder_path=folder_path,
             folder_key=folder_key,
         )
@@ -370,7 +378,7 @@ class ContextGroundingService(FolderContext, BaseService):
         response = self.request(
             spec.method,
             spec.endpoint,
-            content=spec.content,
+            json=spec.json,
             headers=spec.headers,
         )
 
@@ -381,12 +389,10 @@ class ContextGroundingService(FolderContext, BaseService):
     async def create_index_async(
         self,
         name: str,
-        source: Dict[str, Any],
+        source: SourceConfig,
         description: Optional[str] = None,
-        cron_expression: Optional[str] = None,
-        time_zone_id: Optional[str] = None,
         advanced_ingestion: Optional[bool] = True,
-        preprocessing_request: Optional[str] = LLMV4,
+        preprocessing_request: Optional[str] = LLMV4_REQUEST,
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
     ) -> ContextGroundingIndex:
@@ -394,17 +400,18 @@ class ContextGroundingService(FolderContext, BaseService):
 
         Args:
             name (str): The name of the index to create.
-            source (dict): Source configuration dictionary:
-                - For buckets: type="bucket", bucket_name, folder_path, directory_path="/" (optional), file_type (optional)
-                - For Google Drive: type="google_drive", connection_name, connection_id, leaf_folder_id, directory_path, folder_path, file_type (optional)
-                - For Dropbox: type="dropbox", connection_name, connection_id, directory_path, folder_path, file_type (optional)
-                - For OneDrive: type="onedrive", connection_name, connection_id, leaf_folder_id, directory_path, folder_path, file_type (optional)
-                - For Confluence: type="confluence", connection_name, connection_id, space_id, directory_path, folder_path, file_type (optional)
+            source (SourceConfig): Source configuration using one of:
+                - BucketSourceConfig: For storage buckets
+                - GoogleDriveSourceConfig: For Google Drive
+                - DropboxSourceConfig: For Dropbox
+                - OneDriveSourceConfig: For OneDrive
+                - ConfluenceSourceConfig: For Confluence
+
+                The source can include an optional indexer field for scheduled indexing:
+                    source.indexer = Indexer(cron_expression="0 0 18 ? * 2", time_zone_id="UTC")
             description (Optional[str]): Description of the index.
-            cron_expression (Optional[str]): Cron expression for scheduled indexing (e.g., "0 0 18 ? * 2" for Tuesdays at 6 PM).
-            time_zone_id (Optional[str]): Valid Windows Timezone ID for the cron expression (e.g., "UTC", "Pacific Standard Time", "GTB Standard Time").
             advanced_ingestion (Optional[bool]): Enable advanced ingestion with preprocessing. Defaults to True.
-            preprocessing_request (Optional[str]): The OData type for preprocessing request. Defaults to LLMV4.
+            preprocessing_request (Optional[str]): The OData type for preprocessing request. Defaults to LLMV4_REQUEST.
             folder_key (Optional[str]): The key of the folder where the index will be created.
             folder_path (Optional[str]): The path of the folder where the index will be created.
 
@@ -415,12 +422,10 @@ class ContextGroundingService(FolderContext, BaseService):
             name=name,
             description=description,
             source=source,
-            cron_expression=cron_expression,
-            time_zone_id=time_zone_id,
             advanced_ingestion=advanced_ingestion
             if advanced_ingestion is not None
             else True,
-            preprocessing_request=preprocessing_request or LLMV4,
+            preprocessing_request=preprocessing_request or LLMV4_REQUEST,
             folder_path=folder_path,
             folder_key=folder_key,
         )
@@ -428,7 +433,7 @@ class ContextGroundingService(FolderContext, BaseService):
         response = await self.request_async(
             spec.method,
             spec.endpoint,
-            content=spec.content,
+            json=spec.json,
             headers=spec.headers,
         )
 
@@ -701,11 +706,9 @@ class ContextGroundingService(FolderContext, BaseService):
         self,
         name: str,
         description: Optional[str],
-        source: Dict[str, Any],
+        source: SourceConfig,
         advanced_ingestion: bool,
         preprocessing_request: str,
-        cron_expression: Optional[str] = None,
-        time_zone_id: Optional[str] = None,
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
     ) -> RequestSpec:
@@ -714,9 +717,7 @@ class ContextGroundingService(FolderContext, BaseService):
         Args:
             name: Index name
             description: Index description
-            source: Source configuration dictionary
-            cron_expression: Optional cron expression for scheduled indexing
-            time_zone_id: Optional timezone for cron expression
+            source: Source configuration (typed model) with optional indexer
             advanced_ingestion: Whether to enable advanced ingestion with preprocessing
             preprocessing_request: OData type for preprocessing request
             folder_key: Optional folder key
@@ -725,175 +726,101 @@ class ContextGroundingService(FolderContext, BaseService):
         Returns:
             RequestSpec for the create index request
         """
-        source_type = source.get("type", "").lower()
-
         folder_key = self._resolve_folder_key(folder_key, folder_path)
-        file_type = source.get("file_type")
-        file_name_glob = f"**/*.{file_type}" if file_type else "**/*"
 
-        data_source = self._build_data_source(source_type, source, file_name_glob)
+        data_source_dict = self._build_data_source(source)
 
-        if cron_expression:
-            data_source["indexer"] = {
-                "cronExpression": cron_expression,
-                "timeZoneId": time_zone_id or "UTC",
-            }
+        # Add indexer from source config if present
+        if source.indexer:
+            data_source_dict["indexer"] = source.indexer.model_dump(by_alias=True)
 
-        payload = {
-            "name": name,
-            "description": description or "",
-            "dataSource": data_source,
-        }
-
-        if advanced_ingestion and preprocessing_request:
-            payload["preProcessing"] = {
-                "@odata.type": preprocessing_request,
-            }
+        payload = CreateIndexPayload(
+            name=name,
+            description=description or "",
+            data_source=data_source_dict,
+            pre_processing=(
+                PreProcessing(**{"@odata.type": preprocessing_request})
+                if advanced_ingestion and preprocessing_request
+                else None
+            ),
+        )
 
         return RequestSpec(
             method="POST",
             endpoint=Endpoint("/ecs_/v2/indexes/create"),
-            content=json.dumps(payload),
+            json=payload.model_dump(by_alias=True, exclude_none=True),
             headers={
                 **header_folder(folder_key, None),
-                "Content-Type": "application/json",
             },
         )
 
-    def _build_data_source(
-        self, source_type: str, source: Dict[str, Any], file_name_glob: str
-    ) -> Dict[str, Any]:
-        """Build data source configuration based on type."""
-        if source_type == "bucket":
-            return self._build_bucket_data_source(source, file_name_glob)
-        elif source_type in ["google_drive"]:
-            return self._build_google_drive_data_source(source, file_name_glob)
-        elif source_type == "dropbox":
-            return self._build_dropbox_data_source(source, file_name_glob)
-        elif source_type == "onedrive":
-            return self._build_onedrive_data_source(source, file_name_glob)
-        elif source_type == "confluence":
-            return self._build_confluence_data_source(source, file_name_glob)
+    def _build_data_source(self, source: SourceConfig) -> Dict[str, Any]:
+        """Build data source configuration from typed source config.
+
+        Args:
+            source: Typed source configuration model
+
+        Returns:
+            Dictionary with data source configuration for API
+        """
+        file_name_glob = f"**/*.{source.file_type}" if source.file_type else "**/*"
+
+        data_source: Union[
+            BucketDataSource,
+            GoogleDriveDataSource,
+            DropboxDataSource,
+            OneDriveDataSource,
+            ConfluenceDataSource,
+        ]
+
+        if isinstance(source, BucketSourceConfig):
+            data_source = BucketDataSource(
+                folder=source.folder_path,
+                bucketName=source.bucket_name,
+                fileNameGlob=file_name_glob,
+                directoryPath=source.directory_path,
+            )
+        elif isinstance(source, GoogleDriveSourceConfig):
+            data_source = GoogleDriveDataSource(
+                folder=source.folder_path,
+                connectionId=source.connection_id,
+                connectionName=source.connection_name,
+                leafFolderId=source.leaf_folder_id,
+                directoryPath=source.directory_path,
+                fileNameGlob=file_name_glob,
+            )
+        elif isinstance(source, DropboxSourceConfig):
+            data_source = DropboxDataSource(
+                folder=source.folder_path,
+                connectionId=source.connection_id,
+                connectionName=source.connection_name,
+                directoryPath=source.directory_path,
+                fileNameGlob=file_name_glob,
+            )
+        elif isinstance(source, OneDriveSourceConfig):
+            data_source = OneDriveDataSource(
+                folder=source.folder_path,
+                connectionId=source.connection_id,
+                connectionName=source.connection_name,
+                leafFolderId=source.leaf_folder_id,
+                directoryPath=source.directory_path,
+                fileNameGlob=file_name_glob,
+            )
+        elif isinstance(source, ConfluenceSourceConfig):
+            data_source = ConfluenceDataSource(
+                folder=source.folder_path,
+                connectionId=source.connection_id,
+                connectionName=source.connection_name,
+                directoryPath=source.directory_path,
+                fileNameGlob=file_name_glob,
+                spaceId=source.space_id,
+            )
         else:
             raise ValueError(
-                f"Unsupported data source type: {source_type}. "
-                f"Supported types: bucket, google_drive, dropbox, onedrive, confluence"
+                f"Unsupported source configuration type: {type(source).__name__}"
             )
 
-    def _build_bucket_data_source(
-        self, source: Dict[str, Any], file_name_glob: str
-    ) -> Dict[str, Any]:
-        """Build data source configuration for storage bucket."""
-        required_fields = ["bucket_name", "folder_path"]
-        for field in required_fields:
-            if not source.get(field):
-                raise ValueError(f"{field} is required for bucket data source")
-
-        return {
-            "@odata.type": ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE,
-            "folder": source["folder_path"],
-            "bucketName": source["bucket_name"],
-            "fileNameGlob": file_name_glob,
-            "directoryPath": source.get("directory_path", "/"),
-        }
-
-    def _build_google_drive_data_source(
-        self, source: Dict[str, Any], file_name_glob: str
-    ) -> Dict[str, Any]:
-        """Build data source configuration for Google Drive."""
-        required_fields = [
-            "connection_id",
-            "connection_name",
-            "leaf_folder_id",
-            "directory_path",
-            "folder_path",
-        ]
-        for field in required_fields:
-            if not source.get(field):
-                raise ValueError(f"{field} is required for Google Drive data source")
-
-        return {
-            "@odata.type": GOOGLE_DRIVE_DATA_SOURCE,
-            "folder": source["folder_path"],
-            "connectionId": source["connection_id"],
-            "connectionName": source["connection_name"],
-            "leafFolderId": source["leaf_folder_id"],
-            "directoryPath": source["directory_path"],
-            "fileNameGlob": file_name_glob,
-        }
-
-    def _build_dropbox_data_source(
-        self, source: Dict[str, Any], file_name_glob: str
-    ) -> Dict[str, Any]:
-        """Build data source configuration for Dropbox."""
-        required_fields = [
-            "connection_id",
-            "connection_name",
-            "directory_path",
-            "folder_path",
-        ]
-        for field in required_fields:
-            if not source.get(field):
-                raise ValueError(f"{field} is required for Dropbox data source")
-
-        return {
-            "@odata.type": DROPBOX_DATA_SOURCE,
-            "folder": source["folder_path"],
-            "connectionId": source["connection_id"],
-            "connectionName": source["connection_name"],
-            "directoryPath": source["directory_path"],
-            "fileNameGlob": file_name_glob,
-        }
-
-    def _build_onedrive_data_source(
-        self, source: Dict[str, Any], file_name_glob: str
-    ) -> Dict[str, Any]:
-        """Build data source configuration for OneDrive."""
-        required_fields = [
-            "connection_id",
-            "connection_name",
-            "leaf_folder_id",
-            "directory_path",
-            "folder_path",
-        ]
-        for field in required_fields:
-            if not source.get(field):
-                raise ValueError(f"{field} is required for OneDrive data source")
-
-        return {
-            "@odata.type": ONEDRIVE_DATA_SOURCE,
-            "folder": source["folder_path"],
-            "connectionId": source["connection_id"],
-            "connectionName": source["connection_name"],
-            "leafFolderId": source["leaf_folder_id"],
-            "directoryPath": source["directory_path"],
-            "fileNameGlob": file_name_glob,
-        }
-
-    def _build_confluence_data_source(
-        self, source: Dict[str, Any], file_name_glob: str
-    ) -> Dict[str, Any]:
-        """Build data source configuration for Confluence."""
-        required_fields = [
-            "connection_id",
-            "connection_name",
-            "directory_path",
-            "folder_path",
-            "space_id",
-        ]
-        for field in required_fields:
-            if not source.get(field):
-                raise ValueError(f"{field} is required for Confluence data source")
-
-        return {
-            "@odata.type": CONFLUENCE_DATA_SOURCE,
-            "folder": source["folder_path"],
-            "connectionId": source["connection_id"],
-            "connectionName": source["connection_name"],
-            "directoryPath": source["directory_path"],
-            "fileNameGlob": file_name_glob,
-            "spaceId": source["space_id"],
-        }
+        return data_source.model_dump(by_alias=True, exclude_none=True)
 
     def _retrieve_by_id_spec(
         self,
@@ -966,9 +893,38 @@ class ContextGroundingService(FolderContext, BaseService):
         return folder_key
 
     def _extract_bucket_info(self, index: ContextGroundingIndex) -> Tuple[str, str]:
-        try:
-            return index.data_source.bucketName, index.data_source.folder  # type: ignore
-        except AttributeError as e:
-            raise Exception(
-                "ContextGrounding: Cannot extract bucket data from index"
-            ) from e
+        """Extract bucket information from the index, validating it's a storage bucket data source.
+
+        Args:
+            index: The context grounding index
+
+        Returns:
+            Tuple of (bucket_name, folder_path)
+
+        Raises:
+            UnsupportedDataSourceException: If the data source is not an Orchestrator Storage Bucket
+        """
+        if not index.data_source:
+            raise UnsupportedDataSourceException("add_to_index")
+
+        # Check if the data source has the @odata.type field indicating it's a storage bucket
+        data_source_dict = (
+            index.data_source.model_dump(by_alias=True)
+            if hasattr(index.data_source, "model_dump")
+            else index.data_source.__dict__
+        )
+        odata_type = data_source_dict.get("@odata.type") or data_source_dict.get(
+            "odata.type"
+        )
+
+        if odata_type and odata_type != ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE:
+            raise UnsupportedDataSourceException("add_to_index", odata_type)
+
+        # Try to extract bucket information
+        bucket_name = getattr(index.data_source, "bucketName", None)
+        folder = getattr(index.data_source, "folder", None)
+
+        if not bucket_name or not folder:
+            raise UnsupportedDataSourceException("add_to_index")
+
+        return bucket_name, folder

--- a/src/uipath/_utils/constants.py
+++ b/src/uipath/_utils/constants.py
@@ -23,21 +23,36 @@ HEADER_INTERNAL_TENANT_ID = "x-uipath-internal-tenantid"
 HEADER_JOB_KEY = "x-uipath-jobkey"
 HEADER_SW_LOCK_KEY = "x-uipath-sw-lockkey"
 
-# Data sources
-ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
+# Data sources (request types)
+ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST = (
     "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSourceRequest"
 )
-CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
-DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
-GOOGLE_DRIVE_DATA_SOURCE = (
+CONFLUENCE_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
+)
+DROPBOX_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
+)
+GOOGLE_DRIVE_DATA_SOURCE_REQUEST = (
     "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSourceRequest"
 )
-ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
+ONEDRIVE_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
+)
+
+# Data sources
+ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSource"
+)
+CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSource"
+DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSource"
+GOOGLE_DRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSource"
+ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSource"
 
 # Preprocessing request types
-LLMV3Mini = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
-LLMV4 = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
-NativeV1 = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
+LLMV3Mini_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
+LLMV4_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
+NativeV1_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
 
 
 # Local storage

--- a/src/uipath/models/__init__.py
+++ b/src/uipath/models/__init__.py
@@ -6,6 +6,17 @@ from .buckets import Bucket, BucketFile
 from .connections import Connection, ConnectionMetadata, ConnectionToken, EventArguments
 from .context_grounding import ContextGroundingQueryResponse
 from .context_grounding_index import ContextGroundingIndex
+from .context_grounding_payloads import (
+    BaseSourceConfig,
+    BucketSourceConfig,
+    ConfluenceSourceConfig,
+    ConnectionSourceConfig,
+    DropboxSourceConfig,
+    GoogleDriveSourceConfig,
+    Indexer,
+    OneDriveSourceConfig,
+    SourceConfig,
+)
 from .errors import BaseUrlMissingError, SecretMissingError
 from .exceptions import IngestionInProgressException
 from .interrupt_models import (
@@ -57,4 +68,13 @@ __all__ = [
     "Tag",
     "Folder",
     "ResourceType",
+    "BaseSourceConfig",
+    "BucketSourceConfig",
+    "ConfluenceSourceConfig",
+    "ConnectionSourceConfig",
+    "DropboxSourceConfig",
+    "GoogleDriveSourceConfig",
+    "OneDriveSourceConfig",
+    "SourceConfig",
+    "Indexer",
 ]

--- a/src/uipath/models/context_grounding_payloads.py
+++ b/src/uipath/models/context_grounding_payloads.py
@@ -1,0 +1,185 @@
+import re
+from typing import Any, Dict, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.alias_generators import to_camel
+
+from uipath._utils.constants import (
+    CONFLUENCE_DATA_SOURCE_REQUEST,
+    DROPBOX_DATA_SOURCE_REQUEST,
+    GOOGLE_DRIVE_DATA_SOURCE_REQUEST,
+    ONEDRIVE_DATA_SOURCE_REQUEST,
+    ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST,
+)
+
+
+class DataSourceBase(BaseModel):
+    folder: str = Field(alias="folder", description="Folder path")
+    file_name_glob: str = Field(
+        alias="fileNameGlob", description="File name glob pattern"
+    )
+    directory_path: str = Field(alias="directoryPath", description="Directory path")
+
+
+class BucketDataSource(DataSourceBase):
+    odata_type: str = Field(
+        alias="@odata.type",
+        default=ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST,
+    )
+    bucket_name: str = Field(alias="bucketName", description="Storage bucket name")
+
+
+class GoogleDriveDataSource(DataSourceBase):
+    odata_type: str = Field(
+        alias="@odata.type",
+        default=GOOGLE_DRIVE_DATA_SOURCE_REQUEST,
+    )
+    connection_id: str = Field(alias="connectionId", description="Connection ID")
+    connection_name: str = Field(alias="connectionName", description="Connection name")
+    leaf_folder_id: str = Field(alias="leafFolderId", description="Leaf folder ID")
+
+
+class DropboxDataSource(DataSourceBase):
+    odata_type: str = Field(
+        alias="@odata.type",
+        default=DROPBOX_DATA_SOURCE_REQUEST,
+    )
+    connection_id: str = Field(alias="connectionId", description="Connection ID")
+    connection_name: str = Field(alias="connectionName", description="Connection name")
+
+
+class OneDriveDataSource(DataSourceBase):
+    odata_type: str = Field(
+        alias="@odata.type",
+        default=ONEDRIVE_DATA_SOURCE_REQUEST,
+    )
+    connection_id: str = Field(alias="connectionId", description="Connection ID")
+    connection_name: str = Field(alias="connectionName", description="Connection name")
+    leaf_folder_id: str = Field(alias="leafFolderId", description="Leaf folder ID")
+
+
+class ConfluenceDataSource(DataSourceBase):
+    odata_type: str = Field(
+        alias="@odata.type",
+        default=CONFLUENCE_DATA_SOURCE_REQUEST,
+    )
+    connection_id: str = Field(alias="connectionId", description="Connection ID")
+    connection_name: str = Field(alias="connectionName", description="Connection name")
+    space_id: str = Field(alias="spaceId", description="Space ID")
+
+
+class Indexer(BaseModel):
+    """Configuration for periodic indexing of data sources."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    cron_expression: str = Field(description="Cron expression for scheduling")
+    time_zone_id: str = Field(default="UTC", description="Time zone ID")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_cron(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate cron expression format."""
+        cron_expr = values.get("cron_expression") or values.get("cronExpression")
+        if not cron_expr:
+            return values
+
+        # Supports @aliases, @every syntax and standard cron expressions with 5-7 fields
+        cron_pattern = r"^(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})$"
+
+        if not re.match(cron_pattern, cron_expr.strip(), re.IGNORECASE):
+            raise ValueError(f"Invalid cron expression format: '{cron_expr}'")
+
+        return values
+
+
+class PreProcessing(BaseModel):
+    odata_type: str = Field(
+        alias="@odata.type", description="OData type for preprocessing"
+    )
+
+
+class CreateIndexPayload(BaseModel):
+    """Payload for creating a context grounding index.
+
+    Note: data_source is Dict[str, Any] because it may contain additional
+    fields like 'indexer' that are added dynamically based on configuration.
+    The data source is still validated through the _build_data_source method
+    which uses typed models internally.
+    """
+
+    name: str = Field(description="Index name")
+    description: str = Field(default="", description="Index description")
+    data_source: Dict[str, Any] = Field(
+        alias="dataSource", description="Data source configuration"
+    )
+    pre_processing: Optional[PreProcessing] = Field(
+        default=None, alias="preProcessing", description="Preprocessing configuration"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+# user-facing source configuration models
+class BaseSourceConfig(BaseModel):
+    """Base configuration for all source types."""
+
+    folder_path: str = Field(description="Folder path in orchestrator")
+    directory_path: str = Field(description="Directory path")
+    file_type: Optional[str] = Field(
+        default=None, description="File type filter (e.g., 'pdf', 'txt')"
+    )
+    indexer: Optional[Indexer] = Field(
+        default=None, description="Optional indexer configuration for periodic updates"
+    )
+
+
+class ConnectionSourceConfig(BaseSourceConfig):
+    """Base configuration for sources that use connections."""
+
+    connection_id: str = Field(description="Connection ID")
+    connection_name: str = Field(description="Connection name")
+
+
+class BucketSourceConfig(BaseSourceConfig):
+    type: Literal["bucket"] = Field(
+        default="bucket", description="Source type identifier"
+    )
+    bucket_name: str = Field(description="Storage bucket name")
+    directory_path: str = Field(default="/", description="Directory path in bucket")
+
+
+class GoogleDriveSourceConfig(ConnectionSourceConfig):
+    type: Literal["google_drive"] = Field(
+        default="google_drive", description="Source type identifier"
+    )
+    leaf_folder_id: str = Field(description="Leaf folder ID in Google Drive")
+
+
+class DropboxSourceConfig(ConnectionSourceConfig):
+    type: Literal["dropbox"] = Field(
+        default="dropbox", description="Source type identifier"
+    )
+
+
+class OneDriveSourceConfig(ConnectionSourceConfig):
+    type: Literal["onedrive"] = Field(
+        default="onedrive", description="Source type identifier"
+    )
+    leaf_folder_id: str = Field(description="Leaf folder ID in OneDrive")
+
+
+class ConfluenceSourceConfig(ConnectionSourceConfig):
+    type: Literal["confluence"] = Field(
+        default="confluence", description="Source type identifier"
+    )
+    space_id: str = Field(description="Confluence space ID")
+
+
+SourceConfig = Union[
+    BucketSourceConfig,
+    GoogleDriveSourceConfig,
+    DropboxSourceConfig,
+    OneDriveSourceConfig,
+    ConfluenceSourceConfig,
+]

--- a/src/uipath/models/exceptions.py
+++ b/src/uipath/models/exceptions.py
@@ -3,6 +3,17 @@ from typing import Optional
 from httpx import HTTPStatusError
 
 
+class UnsupportedDataSourceException(Exception):
+    """Exception raised when attempting to use an operation with an unsupported data source type."""
+
+    def __init__(self, operation: str, data_source_type: Optional[str] = None):
+        if data_source_type:
+            message = f"Operation '{operation}' is not supported for data source type: {data_source_type}. Only Orchestrator Storage Bucket data sources are supported."
+        else:
+            message = f"Operation '{operation}' requires an Orchestrator Storage Bucket data source."
+        super().__init__(message)
+
+
 class IngestionInProgressException(Exception):
     """An exception that is triggered when a search is attempted on an index that is currently undergoing ingestion."""
 

--- a/tests/sdk/services/test_context_grounding_service.py
+++ b/tests/sdk/services/test_context_grounding_service.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 from pytest_httpx import HTTPXMock
 
 from uipath._config import Config
@@ -8,8 +10,16 @@ from uipath._execution_context import ExecutionContext
 from uipath._services.buckets_service import BucketsService
 from uipath._services.context_grounding_service import ContextGroundingService
 from uipath._services.folder_service import FolderService
-from uipath._utils.constants import HEADER_USER_AGENT
+from uipath._utils.constants import HEADER_USER_AGENT, LLMV3Mini_REQUEST
 from uipath.models import ContextGroundingIndex, ContextGroundingQueryResponse
+from uipath.models.context_grounding_payloads import (
+    BucketSourceConfig,
+    ConfluenceSourceConfig,
+    DropboxSourceConfig,
+    GoogleDriveSourceConfig,
+    Indexer,
+    OneDriveSourceConfig,
+)
 
 
 @pytest.fixture
@@ -369,13 +379,12 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "bucket",
-            "bucket_name": "test-bucket",
-            "folder_path": "/test/folder",
-            "directory_path": "/",
-            "file_type": "pdf",
-        }
+        source = BucketSourceConfig(
+            bucket_name="test-bucket",
+            folder_path="/test/folder",
+            directory_path="/",
+            file_type="pdf",
+        )
 
         index = service.create_index(
             name="test-bucket-index",
@@ -401,8 +410,6 @@ class TestContextGroundingService:
             create_request.headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ContextGroundingService.create_index/{version}"
         )
-
-        import json
 
         request_data = json.loads(create_request.content)
         assert request_data["name"] == "test-bucket-index"
@@ -453,22 +460,22 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "google_drive",
-            "connection_id": "conn-123",
-            "connection_name": "Google Drive Connection",
-            "leaf_folder_id": "folder-456",
-            "directory_path": "/shared-docs",
-            "folder_path": "/test/folder",
-            "file_type": "docx",
-        }
+        source = GoogleDriveSourceConfig(
+            connection_id="conn-123",
+            connection_name="Google Drive Connection",
+            leaf_folder_id="folder-456",
+            directory_path="/shared-docs",
+            folder_path="/test/folder",
+            file_type="docx",
+            indexer=Indexer(
+                cron_expression="0 18 * * 2", time_zone_id="Pacific Standard Time"
+            ),
+        )
 
         index = service.create_index(
             name="test-google-index",
             description="Test Google Drive index",
             source=source,
-            cron_expression="0 0 18 ? * 2",
-            time_zone_id="Pacific Standard Time",
         )
 
         assert isinstance(index, ContextGroundingIndex)
@@ -477,8 +484,6 @@ class TestContextGroundingService:
 
         sent_requests = httpx_mock.get_requests()
         create_request = sent_requests[1]
-
-        import json
 
         request_data = json.loads(create_request.content)
         assert (
@@ -490,7 +495,7 @@ class TestContextGroundingService:
         assert request_data["dataSource"]["leafFolderId"] == "folder-456"
         assert request_data["dataSource"]["directoryPath"] == "/shared-docs"
         assert request_data["dataSource"]["fileNameGlob"] == "**/*.docx"
-        assert request_data["dataSource"]["indexer"]["cronExpression"] == "0 0 18 ? * 2"
+        assert request_data["dataSource"]["indexer"]["cronExpression"] == "0 18 * * 2"
         assert (
             request_data["dataSource"]["indexer"]["timeZoneId"]
             == "Pacific Standard Time"
@@ -527,13 +532,12 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "dropbox",
-            "connection_id": "dropbox-conn-789",
-            "connection_name": "Dropbox Connection",
-            "directory_path": "/company-files",
-            "folder_path": "/test/folder",
-        }
+        source = DropboxSourceConfig(
+            connection_id="dropbox-conn-789",
+            connection_name="Dropbox Connection",
+            directory_path="/company-files",
+            folder_path="/test/folder",
+        )
 
         index = service.create_index(
             name="test-dropbox-index", source=source, advanced_ingestion=False
@@ -544,8 +548,6 @@ class TestContextGroundingService:
 
         sent_requests = httpx_mock.get_requests()
         create_request = sent_requests[1]
-
-        import json
 
         request_data = json.loads(create_request.content)
         assert (
@@ -589,15 +591,14 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "onedrive",
-            "connection_id": "onedrive-conn-101",
-            "connection_name": "OneDrive Connection",
-            "leaf_folder_id": "onedrive-folder-202",
-            "directory_path": "/reports",
-            "folder_path": "/test/folder",
-            "file_type": "xlsx",
-        }
+        source = OneDriveSourceConfig(
+            connection_id="onedrive-conn-101",
+            connection_name="OneDrive Connection",
+            leaf_folder_id="onedrive-folder-202",
+            directory_path="/reports",
+            folder_path="/test/folder",
+            file_type="xlsx",
+        )
 
         index = service.create_index(name="test-onedrive-index", source=source)
 
@@ -606,8 +607,6 @@ class TestContextGroundingService:
 
         sent_requests = httpx_mock.get_requests()
         create_request = sent_requests[1]
-
-        import json
 
         request_data = json.loads(create_request.content)
         assert (
@@ -649,14 +648,13 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "confluence",
-            "connection_id": "confluence-conn-303",
-            "connection_name": "Confluence Connection",
-            "space_id": "space-404",
-            "directory_path": "/wiki-docs",
-            "folder_path": "/test/folder",
-        }
+        source = ConfluenceSourceConfig(
+            connection_id="confluence-conn-303",
+            connection_name="Confluence Connection",
+            space_id="space-404",
+            directory_path="/wiki-docs",
+            folder_path="/test/folder",
+        )
 
         index = service.create_index(name="test-confluence-index", source=source)
 
@@ -665,8 +663,6 @@ class TestContextGroundingService:
 
         sent_requests = httpx_mock.get_requests()
         create_request = sent_requests[1]
-
-        import json
 
         request_data = json.loads(create_request.content)
         assert (
@@ -710,11 +706,10 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "bucket",
-            "bucket_name": "async-bucket",
-            "folder_path": "/async/folder",
-        }
+        source = BucketSourceConfig(
+            bucket_name="async-bucket",
+            folder_path="/async/folder",
+        )
 
         index = await service.create_index_async(
             name="test-async-index", description="Test async index", source=source
@@ -741,25 +736,9 @@ class TestContextGroundingService:
         org: str,
         tenant: str,
     ) -> None:
-        httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
-            status_code=200,
-            json={
-                "PageItems": [
-                    {
-                        "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
-                    }
-                ]
-            },
-        )
-
-        source = {"type": "bucket", "folder_path": "/test/folder"}
-
-        with pytest.raises(
-            ValueError, match="bucket_name is required for bucket data source"
-        ):
-            service.create_index(name="test-invalid-bucket", source=source)
+        # Pydantic will raise ValidationError for missing required fields
+        with pytest.raises(ValidationError, match="bucket_name"):
+            BucketSourceConfig(folder_path="/test/folder")  # type: ignore[call-arg]
 
     def test_create_index_missing_google_drive_fields(
         self,
@@ -769,57 +748,12 @@ class TestContextGroundingService:
         org: str,
         tenant: str,
     ) -> None:
-        httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
-            status_code=200,
-            json={
-                "PageItems": [
-                    {
-                        "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
-                    }
-                ]
-            },
-        )
-
-        source = {
-            "type": "google_drive",
-            "connection_id": "conn-123",
-            "folder_path": "/test/folder",
-        }
-
-        with pytest.raises(
-            ValueError, match="connection_name is required for Google Drive data source"
-        ):
-            service.create_index(name="test-invalid-google", source=source)
-
-    def test_create_index_unsupported_source_type(
-        self,
-        httpx_mock: HTTPXMock,
-        service: ContextGroundingService,
-        base_url: str,
-        org: str,
-        tenant: str,
-    ) -> None:
-        httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
-            status_code=200,
-            json={
-                "PageItems": [
-                    {
-                        "Key": "test-folder-key",
-                        "FullyQualifiedName": "test-folder-path",
-                    }
-                ]
-            },
-        )
-
-        source = {"type": "unsupported", "folder_path": "/test/folder"}
-
-        with pytest.raises(
-            ValueError, match="Unsupported data source type: unsupported"
-        ):
-            service.create_index(name="test-unsupported", source=source)
+        # Pydantic will raise ValidationError for missing required fields
+        with pytest.raises(ValidationError, match="connection_name"):
+            GoogleDriveSourceConfig(  # type: ignore[call-arg]
+                connection_id="conn-123",
+                folder_path="/test/folder",
+            )
 
     def test_create_index_custom_preprocessing(
         self,
@@ -829,8 +763,6 @@ class TestContextGroundingService:
         org: str,
         tenant: str,
     ) -> None:
-        from uipath._utils.constants import LLMV3Mini
-
         httpx_mock.add_response(
             url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
             status_code=200,
@@ -854,16 +786,15 @@ class TestContextGroundingService:
             },
         )
 
-        source = {
-            "type": "bucket",
-            "bucket_name": "test-bucket",
-            "folder_path": "/test/folder",
-        }
+        source = BucketSourceConfig(
+            bucket_name="test-bucket",
+            folder_path="/test/folder",
+        )
 
         index = service.create_index(
             name="test-custom-prep-index",
             source=source,
-            preprocessing_request=LLMV3Mini,
+            preprocessing_request=LLMV3Mini_REQUEST,
         )
 
         assert isinstance(index, ContextGroundingIndex)
@@ -871,10 +802,8 @@ class TestContextGroundingService:
         sent_requests = httpx_mock.get_requests()
         create_request = sent_requests[1]
 
-        import json
-
         request_data = json.loads(create_request.content)
-        assert request_data["preProcessing"]["@odata.type"] == LLMV3Mini
+        assert request_data["preProcessing"]["@odata.type"] == LLMV3Mini_REQUEST
 
     def test_all_requests_pass_spec_parameters(
         self,
@@ -967,24 +896,23 @@ class TestContextGroundingService:
                 }
                 mock_request.return_value = mock_response
 
-                source = {
-                    "type": "bucket",
-                    "bucket_name": "test-bucket",
-                    "folder_path": "/test/folder",
-                }
+                source = BucketSourceConfig(
+                    bucket_name="test-bucket",
+                    folder_path="/test/folder",
+                    directory_path="/",
+                )
                 service.create_index(name="test-new-index", source=source)
 
                 assert mock_request.called
                 call_args = mock_request.call_args
                 assert call_args[0][0] == "POST"  # method
                 assert str(call_args[0][1]) == "/ecs_/v2/indexes/create"  # endpoint
-                assert "content" in call_args[1]
+                assert "json" in call_args[1]
                 assert "headers" in call_args[1]
                 assert "x-uipath-folderkey" in call_args[1]["headers"]
                 assert (
                     call_args[1]["headers"]["x-uipath-folderkey"] == "test-folder-key"
                 )
-                assert "Content-Type" in call_args[1]["headers"]
 
             # Test ingest_data method
             with patch.object(service, "request") as mock_request:

--- a/uv.lock
+++ b/uv.lock
@@ -212,21 +212,21 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "6.0.1"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/e6/5eac48095081c358926a0cd8821351d7a013168b05cad9530fa3bcae3071/backrefs-6.0.1.tar.gz", hash = "sha256:54f8453c9ae38417a83c06d23745c634138c8da622d87a12cb3eef9ba66dd466", size = 5767249, upload-time = "2025-07-30T02:51:32.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/c9/482590c6e687e8e962d6446c5279a4b5f498c31dd0352352e106af6fd1d7/backrefs-6.0.1-py310-none-any.whl", hash = "sha256:78a69e21b71d739b625b52b5adbf7eb1716fb4cf0a39833826f59546f321cb99", size = 381119, upload-time = "2025-07-30T02:51:21.376Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/ca/7476846268a6382f0e7535fecedf81b514bdeae1404d2866040e1ec21ae3/backrefs-6.0.1-py311-none-any.whl", hash = "sha256:6ba76d616ccb02479a3a098ad1f46d92225f280d7bdce7583bc62897f32d946c", size = 392915, upload-time = "2025-07-30T02:51:23.311Z" },
-    { url = "https://files.pythonhosted.org/packages/65/68/349b7d6d646d36d00aca3fd9c80082ec8991138b74046afb1895235f4ae9/backrefs-6.0.1-py312-none-any.whl", hash = "sha256:2f440f79f5ef5b9083fd366a09a976690044eca0ea0e59ac0508c3630e0ebc7c", size = 398827, upload-time = "2025-07-30T02:51:24.741Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/45/84853f5ce1182cc283beebd0a7f05e4210aac06b4f39192cefd60e5901b1/backrefs-6.0.1-py313-none-any.whl", hash = "sha256:62ea7e9b286808576f35b2d28a0daa09b85ae2fc71b82a951d35729b0138e66b", size = 400784, upload-time = "2025-07-30T02:51:26.577Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/07/2e43935cbaa0ec12d7e225e942a3c1e39fc8233f7b18100bcbffd25e6192/backrefs-6.0.1-py314-none-any.whl", hash = "sha256:3ba0d943178d24a3721c5d915734767fa93f3bde1d317c4ef9e0f33b21b9c302", size = 412645, upload-time = "2025-07-30T02:51:28.521Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/9b/14e312dbbc994093caa942a3462dc9f5f54bd0770c8171c6f6aec06e8600/backrefs-6.0.1-py39-none-any.whl", hash = "sha256:b1a61b29c35cc72cfb54886164b626fbe64cab74e9d8dcac125155bd3acdb023", size = 381118, upload-time = "2025-07-30T02:51:30.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
 ]
 
 [[package]]
 name = "bandit"
-version = "1.8.6"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -234,9 +234,9 @@ dependencies = [
     { name = "rich" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/b5/7eb834e213d6f73aace21938e5e90425c92e5f42abafaf8a6d5d21beed51/bandit-1.8.6.tar.gz", hash = "sha256:dbfe9c25fc6961c2078593de55fd19f2559f9e45b99f1272341f5b95dea4e56b", size = 4240271, upload-time = "2025-07-06T03:10:50.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/d5/82fc87a82ad9536215c1b5693bbb675439f6f2d0c2fca74b2df2cb9db925/bandit-1.9.1.tar.gz", hash = "sha256:6dbafd1a51e276e065404f06980d624bad142344daeac3b085121fcfd117b7cf", size = 4241552, upload-time = "2025-11-18T00:06:06.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/ca/ba5f909b40ea12ec542d5d7bdd13ee31c4d65f3beed20211ef81c18fa1f3/bandit-1.8.6-py3-none-any.whl", hash = "sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0", size = 133808, upload-time = "2025-07-06T03:10:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/249a7710242b7a05f7f4245a0da3cdd4042e4377f5d00059619fa2b941f3/bandit-1.9.1-py3-none-any.whl", hash = "sha256:0a1f34c04f067ee28985b7854edaa659c9299bd71e1b7e18236e46cccc79720b", size = 134216, upload-time = "2025-11-18T00:06:04.645Z" },
 ]
 
 [[package]]
@@ -458,14 +458,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -1207,11 +1207,11 @@ wheels = [
 
 [[package]]
 name = "mockito"
-version = "1.5.4"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/f5/52acd91a437530992c24ec00c223a1dba1ac51041fea430d28e16a0adb16/mockito-1.5.4.tar.gz", hash = "sha256:f00ed587c32966df3293c294cadb31769460adfc4154f52b90672946aa4b32df", size = 59915, upload-time = "2025-01-22T22:10:03.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/71/12c56464071524a7941744e8b8fb02c6614500d27475c2d643d2e780a4b0/mockito-1.5.5.tar.gz", hash = "sha256:49826e3901dc826d0204e93b16dce1c61dde9d3a94eadc9c209ab0e130283393", size = 60707, upload-time = "2025-11-17T11:28:41.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/1c/3eb92175fc541abeefcf135f14df4c4a9568e9f44b7d68b376867a39089a/mockito-1.5.4-py3-none-any.whl", hash = "sha256:ba7fbea6ede6ebc180f376bc5d97a4b95c7ccf54a57f12d2af740c440d35d553", size = 30293, upload-time = "2025-01-22T22:10:00.935Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/f0/fc3475ef7732d080c6a555e4ce12e606c699e82e220eb4bcafb9e801fc07/mockito-1.5.5-py3-none-any.whl", hash = "sha256:422a6ce2666e3c32d756547b98ee67e83a339f457e132476689643015845fc36", size = 30456, upload-time = "2025-11-17T11:28:40.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refactored the context grounding index creation to use Pydantic models instead of dictionary-based payloads. 
Added:
* Datasource models: typed models for each data source type with proper field validation
* Supporting models such as Indexer, PreProcessing, CreateIndexPayload
* User-facing config models (BucketSourceConfig, GoogleDriveSourceConfig etc.)
* create_index() and create_index_async() now accept typed SourceConfig instead of Dict[str, Any]
* automatic serialization in request spec