### PR TITLE
feat(Mocking): pass execution trace history into LLM mocker

### DIFF
--- a/src/uipath/_cli/_evals/_span_collection.py
+++ b/src/uipath/_cli/_evals/_span_collection.py
@@ -1,0 +1,24 @@
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from opentelemetry.sdk.trace import ReadableSpan, Span
+
+
+class ExecutionSpanCollector:
+    """Collects spans as they are created during execution."""
+
+    def __init__(self):
+        # { execution_id -> list of spans }
+        self._spans: Dict[str, List[ReadableSpan]] = defaultdict(list)
+
+    def add_span(self, span: Span, execution_id: str) -> None:
+        self._spans[execution_id].append(span)
+
+    def get_spans(self, execution_id: str) -> List[ReadableSpan]:
+        return self._spans.get(execution_id, [])
+
+    def clear(self, execution_id: Optional[str] = None) -> None:
+        if execution_id:
+            self._spans.pop(execution_id, None)
+        else:
+            self._spans.clear()

--- a/src/uipath/_cli/_evals/mocks/llm_mocker.py
+++ b/src/uipath/_cli/_evals/mocks/llm_mocker.py
@@ -6,6 +6,9 @@ from typing import Any, Callable
 
 from pydantic import BaseModel
 
+from uipath.tracing._traced import traced
+from uipath.tracing._utils import _SpanUtils
+
 from .._models._evaluation_set import (
     EvaluationItem,
     LLMMockingStrategy,
@@ -51,7 +54,7 @@ Based on the above information, provide a realistic response for this tool call.
 3. Always include the entire output regardless of token length.
 3. Consider the context of the current test run and the agent being tested.  If the agent is acting on a property, make sure the output includes that property.
 
-Respond ONLY with valid JSON that would be a realistic and completetool response. Do not include any explanations or markdown.
+Respond ONLY with valid JSON that would be a realistic and complete tool response. Do not include any explanations or markdown.
 """
 
 logger = logging.getLogger(__name__)
@@ -79,6 +82,7 @@ class LLMMocker(Mocker):
         self.evaluation_item = evaluation_item
         assert isinstance(self.evaluation_item.mocking_strategy, LLMMockingStrategy)
 
+    @traced(name="__mocker__")
     async def response(
         self, func: Callable[[T], R], params: dict[str, Any], *args: T, **kwargs
     ) -> R:
@@ -91,6 +95,8 @@ class LLMMocker(Mocker):
         ]:
             from uipath import UiPath
             from uipath._services.llm_gateway_service import _cleanup_schema
+
+            from .mocks import evaluation_context, span_collector_context
 
             llm = UiPath().llm
             return_type: Any = func.__annotations__.get("return", None)
@@ -116,9 +122,17 @@ class LLMMocker(Mocker):
                 example_calls = [
                     call for call in example_calls if isinstance(call, ExampleCall)
                 ]
+
+                test_run_history = "(empty)"
+                eval_item = evaluation_context.get()
+                span_collector = span_collector_context.get()
+                if eval_item and span_collector:
+                    spans = span_collector.get_spans(eval_item.id)
+                    test_run_history = _SpanUtils.spans_to_llm_context(spans)
+
                 prompt_input: dict[str, Any] = {
                     "toolRunExamples": example_calls,
-                    "testRunHistory": [],  # This should contain ordered spans.
+                    "testRunHistory": test_run_history,
                     "toolInfo": {
                         "name": function_name,
                         "description": params.get("description"),

--- a/src/uipath/_cli/_evals/mocks/mocks.py
+++ b/src/uipath/_cli/_evals/mocks/mocks.py
@@ -5,29 +5,48 @@ from contextvars import ContextVar
 from typing import Any, Callable, Optional
 
 from uipath._cli._evals._models._evaluation_set import EvaluationItem
+from uipath._cli._evals._span_collection import ExecutionSpanCollector
 from uipath._cli._evals.mocks.mocker import Mocker, UiPathNoMockFoundError
 from uipath._cli._evals.mocks.mocker_factory import MockerFactory
 
+# Context variables for evaluation items and mockers
 evaluation_context: ContextVar[Optional[EvaluationItem]] = ContextVar(
     "evaluation", default=None
 )
 
 mocker_context: ContextVar[Optional[Mocker]] = ContextVar("mocker", default=None)
 
+# Span collector for trace access during mocking
+span_collector_context: ContextVar[Optional[ExecutionSpanCollector]] = ContextVar(
+    "span_collector", default=None
+)
+
 logger = logging.getLogger(__name__)
 
 
-def set_evaluation_item(item: EvaluationItem) -> None:
-    """Set an evaluation item within an evaluation set."""
-    evaluation_context.set(item)
+def set_execution_context(
+    eval_item: EvaluationItem, span_collector: ExecutionSpanCollector
+) -> None:
+    """Set the execution context for an evaluation run for mocking and trace access."""
+    evaluation_context.set(eval_item)
+
     try:
-        if item.mocking_strategy:
-            mocker_context.set(MockerFactory.create(item))
+        if eval_item.mocking_strategy:
+            mocker_context.set(MockerFactory.create(eval_item))
         else:
             mocker_context.set(None)
     except Exception:
-        logger.warning(f"Failed to create mocker for evaluation {item.name}")
+        logger.warning(f"Failed to create mocker for evaluation {eval_item.name}")
         mocker_context.set(None)
+
+    span_collector_context.set(span_collector)
+
+
+def clear_execution_context() -> None:
+    """Clear the execution context after evaluation completes."""
+    evaluation_context.set(None)
+    mocker_context.set(None)
+    span_collector_context.set(None)
 
 
 async def get_mocked_response(

--- a/tests/cli/eval/mocks/test_mocks.py
+++ b/tests/cli/eval/mocks/test_mocks.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -10,8 +11,10 @@ from uipath._cli._evals._models._evaluation_set import (
     MockitoMockingStrategy,
 )
 from uipath._cli._evals.mocks.mocker import UiPathMockResponseGenerationError
-from uipath._cli._evals.mocks.mocks import set_evaluation_item
+from uipath._cli._evals.mocks.mocks import set_execution_context
 from uipath.eval.mocks import mockable
+
+_mock_span_collector = MagicMock()
 
 
 def test_mockito_mockable_sync():
@@ -51,7 +54,7 @@ def test_mockito_mockable_sync():
     assert isinstance(evaluation.mocking_strategy, MockitoMockingStrategy)
 
     # Act & Assert
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
     assert foo() == "bar1"
     assert foo() == "bar2"
     assert foo() == "bar2"
@@ -63,13 +66,13 @@ def test_mockito_mockable_sync():
         assert foofoo()
 
     evaluation.mocking_strategy.behaviors[0].arguments.kwargs = {"x": 1}
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
     assert foo(x=1) == "bar1"
 
     evaluation.mocking_strategy.behaviors[0].arguments.kwargs = {
         "x": {"_target_": "mockito.any"}
     }
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
     assert foo(x=2) == "bar1"
 
 
@@ -111,7 +114,7 @@ async def test_mockito_mockable_async():
     assert isinstance(evaluation.mocking_strategy, MockitoMockingStrategy)
 
     # Act & Assert
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
     assert await foo() == "bar1"
     assert await foo() == "bar2"
     assert await foo() == "bar2"
@@ -123,13 +126,13 @@ async def test_mockito_mockable_async():
         assert await foofoo()
 
     evaluation.mocking_strategy.behaviors[0].arguments.kwargs = {"x": 1}
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
     assert await foo(x=1) == "bar1"
 
     evaluation.mocking_strategy.behaviors[0].arguments.kwargs = {
         "x": {"_target_": "mockito.any"}
     }
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
     assert await foo(x=2) == "bar1"
 
 
@@ -201,7 +204,7 @@ def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
         },
     )
     # Act & Assert
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
 
     assert foo() == "bar1"
     with pytest.raises(NotImplementedError):
@@ -274,7 +277,7 @@ async def test_llm_mockable_async(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatc
         },
     )
     # Act & Assert
-    set_evaluation_item(evaluation)
+    set_execution_context(evaluation, _mock_span_collector)
 
     assert await foo() == "bar1"
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Add a span processor collect in-progress OpenTelemetry traces during execution and pass them to the LLM mocker. For example, in a calculator evaluation run that calls the `get_random_operator` tool twice, the LLM mocker gets the following run history added to its context.

First LLM mock:
```
CURRENT AGENT RUN SO FAR:
(empty)
```

Second LLM mock:

```
CURRENT AGENT RUN SO FAR:
get_random_operator
  Input: {}
  Output: {"result": "+"}
```