### PR TITLE
feat(MockingOverrides): allow schema overrides for mockable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.78"
+version = "2.1.79"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/eval/mocks/mockable.py
+++ b/src/uipath/eval/mocks/mockable.py
@@ -82,6 +82,8 @@ def get_input_schema(func):
 def mockable(
     name: Optional[str] = None,
     description: Optional[str] = None,
+    input_schema: Optional[dict[str, Any]] = None,
+    output_schema: Optional[dict[str, Any]] = None,
     example_calls: Optional[List[ExampleCall]] = None,
     **kwargs,
 ):
@@ -91,8 +93,8 @@ def mockable(
         params = {
             "name": name or func.__name__,
             "description": description or func.__doc__,
-            "input_schema": get_input_schema(func),
-            "output_schema": get_output_schema(func),
+            "input_schema": input_schema or get_input_schema(func),
+            "output_schema": output_schema or get_output_schema(func),
             "example_calls": example_calls,
             **kwargs,
         }

--- a/uv.lock
+++ b/uv.lock
@@ -2146,7 +2146,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.78"
+version = "2.1.79"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Similar to `@tool(args_schema=..`, we now support overriding `input_schema` and `output_schema` for `@mockable` functions. This will help with dynamic schemas from resources.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.79.dev1006671609",

  # Any version from PR
  "uipath>=2.1.79.dev1006670000,<2.1.79.dev1006680000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```