### PR TITLE
feat: adding pull and push for coded-evals folder files

### DIFF
--- a/samples/calculator/main.py
+++ b/samples/calculator/main.py
@@ -1,11 +1,11 @@
+import logging
 import random
-
-from pydantic.dataclasses import dataclass
 from enum import Enum
 
-from uipath.eval.mocks import mockable, ExampleCall
+from pydantic.dataclasses import dataclass
+
+from uipath.eval.mocks import ExampleCall, mockable
 from uipath.tracing import traced
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -155,7 +155,8 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
 
         event_bus = self.event_bus
 
-        evaluation_set = EvalHelpers.load_eval_set(
+        # Load eval set (path is already resolved in cli_eval.py)
+        evaluation_set, _ = EvalHelpers.load_eval_set(
             self.context.eval_set, self.context.eval_ids
         )
         evaluators = self._load_evaluators(evaluation_set)

--- a/src/uipath/_cli/_utils/_eval_set.py
+++ b/src/uipath/_cli/_utils/_eval_set.py
@@ -58,18 +58,36 @@ class EvalHelpers:
     @staticmethod
     def load_eval_set(
         eval_set_path: str, eval_ids: Optional[List[str]] = None
-    ) -> AnyEvaluationSet:
+    ) -> tuple[AnyEvaluationSet, str]:
         """Load the evaluation set from file.
 
+        Args:
+            eval_set_path: Path to the evaluation set file
+            eval_ids: Optional list of evaluation IDs to filter
+
         Returns:
-            The loaded evaluation set
+            Tuple of (AnyEvaluationSet, resolved_path)
         """
+        # If the file doesn't exist at the given path, try looking in evals/eval-sets/
+        resolved_path = eval_set_path
+        if not Path(eval_set_path).exists():
+            # Check if it's just a filename, then search in evals/eval-sets/
+            if Path(eval_set_path).name == eval_set_path:
+                eval_sets_path = Path("evals/eval-sets") / eval_set_path
+                if eval_sets_path.exists():
+                    resolved_path = str(eval_sets_path)
+
         try:
-            with open(eval_set_path, "r", encoding="utf-8") as f:
+            with open(resolved_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
+        except FileNotFoundError as e:
+            raise ValueError(
+                f"Evaluation set file not found: '{eval_set_path}'. "
+                f"Searched in current directory and evals/eval-sets/ directory."
+            ) from e
         except json.JSONDecodeError as e:
             raise ValueError(
-                f"Invalid JSON in evaluation set file '{eval_set_path}': {str(e)}. "
+                f"Invalid JSON in evaluation set file '{resolved_path}': {str(e)}. "
                 f"Please check the file for syntax errors."
             ) from e
 
@@ -79,9 +97,9 @@ class EvalHelpers:
             )
         except ValidationError as e:
             raise ValueError(
-                f"Invalid evaluation set format in '{eval_set_path}': {str(e)}. "
+                f"Invalid evaluation set format in '{resolved_path}': {str(e)}. "
                 f"Please verify the evaluation set structure."
             ) from e
         if eval_ids:
             eval_set.extract_selected_evals(eval_ids)
-        return eval_set
+        return eval_set, resolved_path

--- a/src/uipath/_cli/_utils/_studio_project.py
+++ b/src/uipath/_cli/_utils/_studio_project.py
@@ -148,6 +148,24 @@ def get_folder_by_name(
     return None
 
 
+def get_subfolder_by_name(
+    parent_folder: ProjectFolder, subfolder_name: str
+) -> Optional[ProjectFolder]:
+    """Get a subfolder from within a parent folder by name.
+
+    Args:
+        parent_folder: The parent folder to search within
+        subfolder_name: Name of the subfolder to find
+
+    Returns:
+        Optional[ProjectFolder]: The found subfolder or None
+    """
+    for folder in parent_folder.folders:
+        if folder.name == subfolder_name:
+            return folder
+    return None
+
+
 def resolve_path(
     folder: ProjectFolder,
     path: PurePath,

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -133,7 +133,11 @@ def eval(
 
         eval_context.no_report = no_report
         eval_context.workers = workers
-        eval_context.eval_set = eval_set or EvalHelpers.auto_discover_eval_set()
+
+        # Load eval set to resolve the path
+        eval_set_path = eval_set or EvalHelpers.auto_discover_eval_set()
+        _, resolved_eval_set_path = EvalHelpers.load_eval_set(eval_set_path, eval_ids)
+        eval_context.eval_set = resolved_eval_set_path
         eval_context.eval_ids = eval_ids
 
         console_reporter = ConsoleProgressReporter()

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -52,6 +52,9 @@ async def upload_source_files_to_project(
 
     await sw_file_handler.upload_source_files(config_data)
 
+    # Upload coded-evals files (files with version property) to coded-evals folder
+    await sw_file_handler.upload_coded_evals_files()
+
 
 @click.command()
 @click.argument(


### PR DESCRIPTION
Adds push/pull support for coded evaluators with version-based folder routing.

## Changes
- Files with `version` property pushed to `coded-evals/` folder structure
- Pull command maps `coded-evals/` to local `evals/` directory
- Legacy evals without `version` property continue using existing `evals/` folder
- File deletion syncs for both coded and legacy evaluation files

## Compatibility
Maintains backward compatibility with existing legacy evaluator structure.