### PR TITLE
feat: add create project method for studio web

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.83"
+version = "2.1.84"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/agent/_utils.py
+++ b/src/uipath/agent/_utils.py
@@ -5,10 +5,12 @@ from httpx import Response
 from pydantic import TypeAdapter
 
 from uipath._cli._evals._models._evaluation_set import LLMMockingStrategy
+from uipath._cli._push.sw_file_handler import SwFileHandler
 from uipath._cli._utils._studio_project import (
     ProjectFile,
     ProjectFolder,
     StudioClient,
+    StudioSolutionsClient,
     resolve_path,
 )
 from uipath.agent.models.agent import (
@@ -25,6 +27,20 @@ async def get_file(
     resolved = resolve_path(folder, path)
     assert isinstance(resolved, ProjectFile), "Path file not found."
     return await studio_client.download_file_async(resolved.id)
+
+
+async def create_agent_project(solution_id: str, project_name: str) -> str:
+    studio_client = StudioSolutionsClient(solution_id=solution_id)
+    project = await studio_client.create_project_async(project_name=project_name)
+    return project["id"]
+
+
+async def upload_project_files(project_id: str, root: str) -> None:
+    sw_file_handler = SwFileHandler(
+        project_id=project_id,
+        directory=root,
+    )
+    await sw_file_handler.upload_source_files({})
 
 
 async def load_agent_definition(project_id: str) -> AgentDefinition:

--- a/uv.lock
+++ b/uv.lock
@@ -2146,7 +2146,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.82"
+version = "2.1.83"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Adds ability to create new Agent projects in Studio Web solutions programmatically.

  - Added `StudioSolutionsClient` class with `create_project_async()` method
  - Added helper methods in `uipath.agent._utils`:
    - `create_agent_project(solution_id, project_name)` - creates project and returns ID
    - `upload_project_files(project_id, root)` - uploads local files to project

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.84.dev1006881695",

  # Any version from PR
  "uipath>=2.1.84.dev1006880000,<2.1.84.dev1006890000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```