### PR TITLE
feat: wiring ExactMatch evaluator to new schema

### DIFF
--- a/samples/calculator/evals/eval-sets/default.json
+++ b/samples/calculator/evals/eval-sets/default.json
@@ -1,9 +1,10 @@
 {
   "version": "1.0",
-  "id": "ClaimDenialReview",
-  "name": "Claim Denial Review",
+  "id": "NewSchemaSampleEval",
+  "name": "New Schema Sample Evaluation",
   "evaluatorRefs": [
-    "ContainsEvaluator"
+    "ContainsEvaluator",
+    "ExactMatchEvaluator"
   ],
   "evaluations": [
     {
@@ -15,7 +16,8 @@
         "operator": "+"
       },
       "evaluationCriterias": {
-        "ContainsEvaluator": null
+        "ContainsEvaluator": null,
+        "ExactMatchEvaluator": null
       }
     },
     {
@@ -29,6 +31,11 @@
       "evaluationCriterias": {
         "ContainsEvaluator": {
           "searchText": "8"
+        },
+        "ExactMatchEvaluator": {
+          "expectedOutput": {
+            "result": "8.0"
+          }
         }
       }
     },

--- a/samples/calculator/evals/evaluators/exact-match.json
+++ b/samples/calculator/evals/evaluators/exact-match.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "id": "ExactMatchEvaluator",
+  "description": "Checks if the response text exactly matches the expected value.",
+  "evaluatorTypeId": "uipath-exact-match",
+  "evaluatorConfig": {
+    "name": "ExactMatchEvaluator",
+    "targetOutputKey": "result",
+    "negated": false,
+    "ignoreCase": false,
+    "defaultEvaluationCriteria": {
+      "expectedOutput": {
+        "result": "5.0"
+      }
+    }
+  }
+}

--- a/src/uipath/_cli/_evals/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluator_factory.py
@@ -18,10 +18,14 @@ from uipath.eval.coded_evaluators.contains_evaluator import (
     ContainsEvaluator,
     ContainsEvaluatorConfig,
 )
-from uipath.eval.evaluators import (
+from uipath.eval.coded_evaluators.exact_match_evaluator import (
     ExactMatchEvaluator,
+    ExactMatchEvaluatorConfig,
+)
+from uipath.eval.evaluators import (
     JsonSimilarityEvaluator,
     LegacyBaseEvaluator,
+    LegacyExactMatchEvaluator,
     LlmAsAJudgeEvaluator,
     TrajectoryEvaluator,
 )
@@ -46,12 +50,23 @@ class EvaluatorFactory:
         match config:
             case ContainsEvaluatorConfig():
                 return EvaluatorFactory._create_contains_evaluator(data)
+            case ExactMatchEvaluatorConfig():
+                return EvaluatorFactory._create_exact_match_evaluator(data)
             case _:
                 raise ValueError(f"Unknown evaluator configuration: {config}")
 
     @staticmethod
     def _create_contains_evaluator(data: Dict[str, Any]) -> ContainsEvaluator:
         return ContainsEvaluator(
+            id=data.get("id"),
+            config=data.get("evaluatorConfig"),
+        )  # type: ignore
+
+    @staticmethod
+    def _create_exact_match_evaluator(
+        data: Dict[str, Any],
+    ) -> ExactMatchEvaluator:
+        return ExactMatchEvaluator(
             id=data.get("id"),
             config=data.get("evaluatorConfig"),
         )  # type: ignore
@@ -88,9 +103,9 @@ class EvaluatorFactory:
     @staticmethod
     def _create_legacy_exact_match_evaluator(
         params: EqualsEvaluatorParams,
-    ) -> ExactMatchEvaluator:
+    ) -> LegacyExactMatchEvaluator:
         """Create a deterministic evaluator."""
-        return ExactMatchEvaluator(**params.model_dump())
+        return LegacyExactMatchEvaluator(**params.model_dump())
 
     @staticmethod
     def _create_legacy_json_similarity_evaluator(

--- a/src/uipath/_cli/_evals/_models/_evaluator.py
+++ b/src/uipath/_cli/_evals/_models/_evaluator.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
 
 from uipath.eval.coded_evaluators.base_evaluator import BaseEvaluatorConfig
 from uipath.eval.coded_evaluators.contains_evaluator import ContainsEvaluatorConfig
+from uipath.eval.coded_evaluators.exact_match_evaluator import ExactMatchEvaluatorConfig
 from uipath.eval.models.models import (
     EvaluatorType,
     LegacyEvaluatorCategory,
@@ -149,6 +150,8 @@ def evaluator_config_discriminator(data: Any) -> str:
         match evaluator_type_id:
             case EvaluatorType.CONTAINS:
                 return "ContainsEvaluatorConfig"
+            case EvaluatorType.EXACT_MATCH:
+                return "ExactMatchEvaluatorConfig"
             case _:
                 return "UnknownEvaluatorConfig"
     else:
@@ -186,6 +189,10 @@ EvaluatorConfig = Annotated[
         Annotated[
             ContainsEvaluatorConfig,
             Tag("ContainsEvaluatorConfig"),
+        ],
+        Annotated[
+            ExactMatchEvaluatorConfig,
+            Tag("ExactMatchEvaluatorConfig"),
         ],
         Annotated[
             UnknownEvaluatorConfig,

--- a/src/uipath/eval/coded_evaluators/__init__.py
+++ b/src/uipath/eval/coded_evaluators/__init__.py
@@ -37,7 +37,7 @@ EVALUATORS: list[type[BaseEvaluator[Any, Any, Any]]] = [
 
 __all__ = [
     "BaseEvaluator",
-    "ExactMatchEvaluator",
+    "LegacyExactMatchEvaluator",
     "ContainsEvaluator",
     "JsonSimilarityEvaluator",
     "BaseLLMOutputEvaluator",

--- a/src/uipath/eval/coded_evaluators/exact_match_evaluator.py
+++ b/src/uipath/eval/coded_evaluators/exact_match_evaluator.py
@@ -50,7 +50,6 @@ class ExactMatchEvaluator(
         """
         actual_output = str(self._get_actual_output(agent_execution))
         expected_output = str(self._get_expected_output(evaluation_criteria))
-
         if not self.evaluator_config.case_sensitive:
             actual_output = actual_output.lower()
             expected_output = expected_output.lower()

--- a/src/uipath/eval/evaluators/__init__.py
+++ b/src/uipath/eval/evaluators/__init__.py
@@ -1,14 +1,14 @@
 """UiPath evaluator implementations for agent performance evaluation."""
 
 from .base_evaluator import LegacyBaseEvaluator
-from .exact_match_evaluator import ExactMatchEvaluator
+from .exact_match_evaluator import LegacyExactMatchEvaluator
 from .json_similarity_evaluator import JsonSimilarityEvaluator
 from .llm_as_judge_evaluator import LlmAsAJudgeEvaluator
 from .trajectory_evaluator import TrajectoryEvaluator
 
 __all__ = [
     "LegacyBaseEvaluator",
-    "ExactMatchEvaluator",
+    "LegacyExactMatchEvaluator",
     "JsonSimilarityEvaluator",
     "LlmAsAJudgeEvaluator",
     "TrajectoryEvaluator",

--- a/src/uipath/eval/evaluators/exact_match_evaluator.py
+++ b/src/uipath/eval/evaluators/exact_match_evaluator.py
@@ -8,7 +8,7 @@ from ..models.models import AgentExecution
 from .deterministic_evaluator_base import DeterministicEvaluatorBase
 
 
-class ExactMatchEvaluator(DeterministicEvaluatorBase[dict[str, Any]]):
+class LegacyExactMatchEvaluator(DeterministicEvaluatorBase[dict[str, Any]]):
     """Evaluator that performs exact structural matching between expected and actual outputs.
 
     This evaluator returns True if the actual output exactly matches the expected output

--- a/src/uipath/eval/models/models.py
+++ b/src/uipath/eval/models/models.py
@@ -234,6 +234,7 @@ class EvaluatorType(str, Enum):
     """Evaluator type."""
 
     CONTAINS = "uipath-contains"
+    EXACT_MATCH = "uipath-exact-match"
 
 
 class ToolCall(BaseModel):


### PR DESCRIPTION
```
(uipath-python) (kind-kind-cloudgen/default) 
 ➜  calculator git:(mj/wire-exact-match) ✗  uipath eval main.py evals/eval-sets/default.json 
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/2be094bd-2634-4ca8-8ea7-2df981516a86/evalSetRun "HTTP/1.1 400 Bad Request"
Cannot report progress to SW. Function: create_eval_set_run, Error type: EnrichedException, Details: 
Request URL: https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/2be094bd-2634-4ca8-8ea7-2df981516a86/evalSetRun
HTTP Method: POST
Status Code: 400
Response Content: {"type":"https://tools.ietf.org/html/rfc9110#section-15.5.1","title":"One or more validation errors occurred.","status":400,"errors":{"request":["The request field is required."],"$.evalSetId":["The JSON value could not be converted to System.Guid. Path: $.evalSetId | LineNumber: 0 | BytePositionInLine: 83."]},"traceId":"00-7909ed9e717b1d445b67869743887afd-2afbdd025677df3a-01"}
Cannot create eval run: eval_set_run_id not available
→ Running Evaluations
  ○ Add - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=bbd2e136-51f4-4e4c-9a3c-82ce4126a14a&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '67c4003d-7cd6-4f53-9fac-3a372c684c16'
▌ Add
  ExactMatchEvaluator    1.0  
  ContainsEvaluator      1.0  
──────────────────────────────────────────────────────────────── Execution Logs: Add ─────────────────────────────────────────────────────────────────
  No execution logs
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot create eval run: eval_set_run_id not available
  ○ Multiply - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=5adb043b-b7f4-47b2-9930-98349f518e85&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '67c4003d-7cd6-4f53-9fac-3a372c684c16'
▌ Multiply
  ExactMatchEvaluator    1.0  
  ContainsEvaluator      1.0  
────────────────────────────────────────────────────────────── Execution Logs: Multiply ──────────────────────────────────────────────────────────────
  No execution logs
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot create eval run: eval_set_run_id not available
  ○ Skip denial code check - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=0c0b8157-41d8-41d0-a287-4d3c38770d22&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '67c4003d-7cd6-4f53-9fac-3a372c684c16'
  ✓ Skip denial code check - No evaluators
─────────────────────────────────────────────────────── Execution Logs: Skip denial code check ───────────────────────────────────────────────────────
  No execution logs
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot update eval set run: eval_set_run_id not available
Evaluation Results
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃  Evaluation              ┃  ExactMatchEvaluator  ┃  ContainsEvaluator  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│  Add                     │                  1.0  │                1.0  │
│  Multiply                │                  1.0  │                1.0  │
│  Skip denial code check  │                    -  │                  -  │
├──────────────────────────┼───────────────────────┼─────────────────────┤
│  Average                 │                  1.0  │                1.0  │
└──────────────────────────┴───────────────────────┴─────────────────────┘

````

Legacy
```
➜  calculator git:(mj/wire-exact-match) ✗  uipath eval main.py evals/eval-sets/legacy.json
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/2be094bd-2634-4ca8-8ea7-2df981516a86/evalSetRun "HTTP/1.1 400 Bad Request"
Cannot report progress to SW. Function: create_eval_set_run, Error type: EnrichedException, Details: 
Request URL: https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/2be094bd-2634-4ca8-8ea7-2df981516a86/evalSetRun
HTTP Method: POST
Status Code: 400
Response Content: {"type":"https://tools.ietf.org/html/rfc9110#section-15.5.1","title":"One or more validation errors occurred.","status":400,"errors":{"request":["The request field is required."],"$.evalSetId":["The JSON value could not be converted to System.Guid. Path: $.evalSetId | LineNumber: 0 | BytePositionInLine: 83."]},"traceId":"00-f903a6aeebe05cf3995b0d605f341276-f4574121c9fcca87-01"}
Cannot create eval run: eval_set_run_id not available
→ Running Evaluations
  ○ Test Addition - Running...
HTTP Request: GET https://alpha.uipath.com/uipathmj/DefaultTenant/orchestrator_/llm/api/capabilities "HTTP/1.1 500 Internal Server Error"
HTTP Request: GET https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/capabilities "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=94c69a68-fcc0-476f-8cfb-a4f5cd9001e1&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '6c6bd611-36ee-4230-b6b1-c5536a9a917c'
▌ Test Addition
  Equality Evaluator       100.0  
  LLMAsAJudge Evaluator    100.0  
  ExactMatch Evaluator     100.0  
────────────────────────────────────────────────────────────────────────────────────── Execution Logs: Test Addition ───────────────────────────────────────────────────────────────────────────────────────
  No execution logs
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot create eval run: eval_set_run_id not available
  ○ Test Random Addition Using Mockito - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=89ced118-4091-4fc5-aac4-39af3df793bd&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '6c6bd611-36ee-4230-b6b1-c5536a9a917c'
▌ Test Random Addition Using Mockito
  Equality Evaluator       100.0  
  LLMAsAJudge Evaluator    100.0  
  ExactMatch Evaluator     100.0  
──────────────────────────────────────────────────────────────────────────── Execution Logs: Test Random Addition Using Mockito ────────────────────────────────────────────────────────────────────────────
  No execution logs
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot create eval run: eval_set_run_id not available
  ○ Test Random Addition Using LLM - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=5201f237-992f-4cf5-858b-873412025d98&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '6c6bd611-36ee-4230-b6b1-c5536a9a917c'
▌ Test Random Addition Using LLM
  Equality Evaluator       100.0  
  LLMAsAJudge Evaluator    100.0  
  ExactMatch Evaluator     100.0  
────────────────────────────────────────────────────────────────────────────── Execution Logs: Test Random Addition Using LLM ──────────────────────────────────────────────────────────────────────────────
  No execution logs
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot update eval set run: eval_set_run_id not available
Evaluation Results
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  Evaluation                          ┃  Equality Evaluator  ┃  LLMAsAJudge Evaluator  ┃  ExactMatch Evaluator  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
│  Test Addition                       │               100.0  │                  100.0  │                 100.0  │
│  Test Random Addition Using Mockito  │               100.0  │                  100.0  │                 100.0  │
│  Test Random Addition Using LLM      │               100.0  │                  100.0  │                 100.0  │
├──────────────────────────────────────┼──────────────────────┼─────────────────────────┼────────────────────────┤
│  Average                             │               100.0  │                  100.0  │                 100.0  │
└──────────────────────────────────────┴──────────────────────┴─────────────────────────┴────────────────────────┘
(uipath-python) (kind-kind-cloudgen/default) 
```