### PR TITLE
feat(action_flag): add option to get the whole action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.84"
+version = "2.1.85"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_hitl.py
+++ b/src/uipath/_cli/_runtime/_hitl.py
@@ -62,12 +62,23 @@ class HitlReader:
         default_escalation = Escalation()
         match resume_trigger.trigger_type:
             case UiPathResumeTriggerType.ACTION:
+                include_metadata = False
+                if resume_trigger.payload:
+                    try:
+                        payload_data = json.loads(resume_trigger.payload)
+                        include_metadata = payload_data.get("include_metadata", False)
+                    except (json.JSONDecodeError, AttributeError):
+                        include_metadata = False
+
                 if resume_trigger.item_key:
                     action = await uipath.actions.retrieve_async(
                         resume_trigger.item_key,
                         app_folder_key=resume_trigger.folder_key,
                         app_folder_path=resume_trigger.folder_path,
                     )
+
+                    if include_metadata:
+                        return action
 
                     if default_escalation.enabled:
                         return default_escalation.extract_response_value(action.data)

--- a/src/uipath/models/interrupt_models.py
+++ b/src/uipath/models/interrupt_models.py
@@ -28,9 +28,11 @@ class CreateAction(BaseModel):
     app_folder_key: Optional[str] = None
     app_key: Optional[str] = None
     app_version: Optional[int] = 1
+    include_metadata: bool = False
 
 
 class WaitAction(BaseModel):
     action: Action
     app_folder_path: Optional[str] = None
     app_folder_key: Optional[str] = None
+    include_metadata: bool = False


### PR DESCRIPTION
**Description**
Add return_all_action flag to support full action object retrieval in HITL scenarios

**Problem**
Some applications require access to the complete action object (including status, metadata, and user decisions) when processing Human-In-The-Loop (HITL) responses, but the current implementation only returns action.data. This limitation prevents applications from accessing critical fields like the action status field that indicates user decisions (e.g., "Reject", "Approve").

**Jira: [PRODEV-237](https://uipath.atlassian.net/browse/PRODEV-237)**

[PRODEV-237]: https://uipath.atlassian.net/browse/PRODEV-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ