### PR TITLE
fix: pass a unique id to every runtime spawned by eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.84"
+version = "2.1.85"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -432,12 +432,12 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
     async def execute_runtime(
         self, eval_item: EvaluationItem
     ) -> UiPathEvalRunExecutionOutput:
-        eval_item_id = eval_item.id
+        execution_id = str(uuid.uuid4())
         runtime_context: C = self.factory.new_context(
-            execution_id=eval_item_id,
+            execution_id=execution_id,
             input_json=eval_item.inputs,
             is_eval_run=True,
-            log_handler=self._setup_execution_logging(eval_item_id),
+            log_handler=self._setup_execution_logging(execution_id),
         )
         if runtime_context.execution_id is None:
             raise ValueError("execution_id must be set for eval runs")
@@ -445,9 +445,8 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
         attributes = {
             "evalId": eval_item.id,
             "span_type": "eval",
+            "execution.id": runtime_context.execution_id,
         }
-        if runtime_context.execution_id:
-            attributes["execution.id"] = runtime_context.execution_id
 
         start_time = time()
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -2146,7 +2146,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.84"
+version = "2.1.85"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- pass a unique id to every runtime spawned by eval

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.85.dev1007011716",

  # Any version from PR
  "uipath>=2.1.85.dev1007010000,<2.1.85.dev1007020000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```