### PR TITLE
feat: add support for custom evaluators

### DIFF
--- a/samples/calculator/README.md
+++ b/samples/calculator/README.md
@@ -11,3 +11,17 @@ uipath run main.py '{"a": 0, "b": 1, "operator": "+"}'
 ```
 uipath eval .\main.py .\evals\eval-sets\default.json --no-report --output-file output.json
 ```
+
+# Add and register custom evaluator
+
+1. (Optional) Add a new evaluator -> can be created manually in the evals/custom-evaluators directory
+```
+uipath add evaluator my_custom_evaluator
+```
+2. Implement the logic
+
+3. Register the evaluator
+```
+uipath register evaluator my_custom_evaluator
+```
+4. Apply it to any dataset

--- a/samples/calculator/evals/eval-sets/default.json
+++ b/samples/calculator/evals/eval-sets/default.json
@@ -8,7 +8,8 @@
     "JsonSimilarityEvaluator",
     "LLMJudgeOutputEvaluator",
     "LLMJudgeStrictJSONSimilarityOutputEvaluator",
-    "TrajectoryEvaluator"
+    "TrajectoryEvaluator",
+    "CorrectOperatorEvaluator"
   ],
   "evaluations": [
     {
@@ -25,7 +26,8 @@
         "JsonSimilarityEvaluator": null,
         "LLMJudgeOutputEvaluator": null,
         "LLMJudgeStrictJSONSimilarityOutputEvaluator": null,
-        "TrajectoryEvaluator": null
+        "TrajectoryEvaluator": null,
+        "CorrectOperatorEvaluator": null
       }
     },
     {
@@ -39,6 +41,9 @@
       "evaluationCriterias": {
         "ContainsEvaluator": {
           "searchText": "8"
+        },
+        "CorrectOperatorEvaluator": {
+          "operator": "*"
         },
         "ExactMatchEvaluator": {
           "expectedOutput": {

--- a/samples/calculator/evals/evaluators/correct-operator-evaluator.json
+++ b/samples/calculator/evals/evaluators/correct-operator-evaluator.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "id": "CorrectOperatorEvaluator",
+  "evaluatorTypeId": "file://types/correct-operator-evaluator-types.json",
+  "evaluatorSchema": "file://correct_operator.py:CorrectOperatorEvaluator",
+  "description": "A custom evaluator that checks if the correct operator is being used by the agent ",
+  "evaluatorConfig": {
+    "name": "CorrectOperatorEvaluator",
+    "defaultEvaluationCriteria": {
+      "operator": "+"
+    },
+    "negated": false
+  }
+}

--- a/samples/calculator/evals/evaluators/custom/correct_operator.py
+++ b/samples/calculator/evals/evaluators/custom/correct_operator.py
@@ -1,0 +1,43 @@
+import json
+
+from uipath.eval.evaluators import BaseEvaluator, BaseEvaluationCriteria, BaseEvaluatorConfig
+from uipath.eval.models import AgentExecution, EvaluationResult, NumericEvaluationResult
+from opentelemetry.sdk.trace import ReadableSpan
+
+class CorrectOperatorEvaluationCriteria(BaseEvaluationCriteria):
+    """Evaluation criteria for the contains evaluator."""
+
+    operator: str
+
+class CorrectOperatorEvaluatorConfig(BaseEvaluatorConfig[CorrectOperatorEvaluationCriteria]):
+    """Configuration for the contains evaluator."""
+
+    name: str = "CorrectOperatorEvaluator"
+    negated: bool = False
+    default_evaluation_criteria: CorrectOperatorEvaluationCriteria = CorrectOperatorEvaluationCriteria(operator="+")
+
+class CorrectOperatorEvaluator(BaseEvaluator[CorrectOperatorEvaluationCriteria, CorrectOperatorEvaluatorConfig, type(None)]):
+    """A custom evaluator that checks if the correct operator is being used by the agent """
+
+    def extract_operator_from_spans(self, agent_trace: list[ReadableSpan]) -> str:
+        for span in agent_trace:
+            if span.name == "track_operator":
+                input_value = json.loads(span.attributes.get("input.value", {}))
+                return input_value.get("operator")
+        raise Exception(f"No 'track_operator' span found")
+
+
+    @classmethod
+    def get_evaluator_id(cls) -> str:
+        return "CorrectOperatorEvaluator"
+
+
+    async def evaluate(self, agent_execution: AgentExecution, evaluation_criteria: CorrectOperatorEvaluationCriteria) -> EvaluationResult:
+        actual_operator = self.extract_operator_from_spans(agent_execution.agent_trace)
+        print(actual_operator)
+        is_expected_operator = evaluation_criteria.operator == actual_operator
+        if self.evaluator_config.negated:
+            is_expected_operator = not is_expected_operator
+        return NumericEvaluationResult(
+            score=float(is_expected_operator),
+        )

--- a/samples/calculator/evals/evaluators/custom/types/correct-operator-evaluator-types.json
+++ b/samples/calculator/evals/evaluators/custom/types/correct-operator-evaluator-types.json
@@ -1,0 +1,57 @@
+{
+  "evaluatorTypeId": "CorrectOperatorEvaluator",
+  "evaluatorConfigSchema": {
+    "$defs": {
+      "CorrectOperatorEvaluationCriteria": {
+        "description": "Evaluation criteria for the contains evaluator.",
+        "properties": {
+          "operator": {
+            "title": "Operator",
+            "type": "string"
+          }
+        },
+        "required": [
+          "operator"
+        ],
+        "title": "CorrectOperatorEvaluationCriteria",
+        "type": "object"
+      }
+    },
+    "description": "Configuration for the contains evaluator.",
+    "properties": {
+      "name": {
+        "default": "CorrectOperatorEvaluator",
+        "title": "Name",
+        "type": "string"
+      },
+      "defaultEvaluationCriteria": {
+        "$ref": "#/$defs/CorrectOperatorEvaluationCriteria",
+        "default": {
+          "operator": "+"
+        }
+      },
+      "negated": {
+        "default": false,
+        "title": "Negated",
+        "type": "boolean"
+      }
+    },
+    "title": "CorrectOperatorEvaluatorConfig",
+    "type": "object"
+  },
+  "evaluationCriteriaSchema": {
+    "description": "Evaluation criteria for the contains evaluator.",
+    "properties": {
+      "operator": {
+        "title": "Operator",
+        "type": "string"
+      }
+    },
+    "required": [
+      "operator"
+    ],
+    "title": "CorrectOperatorEvaluationCriteria",
+    "type": "object"
+  },
+  "justificationSchema": {}
+}

--- a/samples/calculator/main.py
+++ b/samples/calculator/main.py
@@ -39,6 +39,9 @@ async def get_random_operator() -> Wrapper:
     """Get a random operator."""
     return Wrapper(result=random.choice([Operator.ADD, Operator.SUBTRACT, Operator.MULTIPLY, Operator.DIVIDE]))
 
+@traced(name="track_operator")
+def track_operator(operator: Operator):
+    pass
 
 @traced()
 async def main(input: CalculatorInput) -> CalculatorOutput:
@@ -46,6 +49,7 @@ async def main(input: CalculatorInput) -> CalculatorOutput:
         operator = (await get_random_operator()).result
     else:
         operator = input.operator
+    track_operator(operator)
     match operator:
         case Operator.ADD: result = input.a + input.b
         case Operator.SUBTRACT: result = input.a - input.b

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -4,6 +4,7 @@ import sys
 import click
 
 from ._utils._common import load_environment_variables
+from .cli_add import add as add
 from .cli_auth import auth as auth
 from .cli_deploy import deploy as deploy  # type: ignore
 from .cli_dev import dev as dev
@@ -16,6 +17,7 @@ from .cli_pack import pack as pack  # type: ignore
 from .cli_publish import publish as publish  # type: ignore
 from .cli_pull import pull as pull  # type: ignore
 from .cli_push import push as push  # type: ignore
+from .cli_register import register as register  # type: ignore
 from .cli_run import run as run  # type: ignore
 
 
@@ -74,4 +76,6 @@ cli.add_command(push)
 cli.add_command(pull)
 cli.add_command(eval)
 cli.add_command(dev)
+cli.add_command(add)
+cli.add_command(register)
 cli.add_command(run, name="debug")

--- a/src/uipath/_cli/_evals/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluator_factory.py
@@ -1,7 +1,11 @@
+import importlib.util
+import sys
+from pathlib import Path
 from typing import Any, Dict
 
 from pydantic import TypeAdapter
 
+from uipath._cli._evals._helpers import try_extract_file_and_class_name  # type: ignore
 from uipath._cli._evals._models._evaluation_set import AnyEvaluator
 from uipath._cli._evals._models._evaluator import (
     EqualsEvaluatorParams,
@@ -76,6 +80,17 @@ class EvaluatorFactory:
     def _create_evaluator_internal(
         data: Dict[str, Any],
     ) -> BaseEvaluator[Any, Any, Any]:
+        # check custom evaluator
+        evaluator_schema = data.get("evaluatorSchema", "")
+        success, file_path, class_name = try_extract_file_and_class_name(
+            evaluator_schema
+        )
+        if success:
+            return EvaluatorFactory._create_coded_evaluator_internal(
+                data, file_path, class_name
+            )
+
+        # use built-in evaluators
         config: BaseEvaluatorConfig[Any] = TypeAdapter(EvaluatorConfig).validate_python(
             data
         )
@@ -113,9 +128,79 @@ class EvaluatorFactory:
 
     @staticmethod
     def _create_contains_evaluator(data: Dict[str, Any]) -> ContainsEvaluator:
+        evaluator_id = data.get("id")
+        if not evaluator_id or not isinstance(evaluator_id, str):
+            raise ValueError("Evaluator 'id' must be a non-empty string")
         return ContainsEvaluator(
-            id=data.get("id"),
+            id=evaluator_id,
             config=data.get("evaluatorConfig"),
+        )  # type: ignore
+
+    @staticmethod
+    def _create_coded_evaluator_internal(
+        data: Dict[str, Any], file_path_str: str, class_name: str
+    ) -> BaseEvaluator[Any, Any, Any]:
+        """Create a coded evaluator by dynamically loading from a Python file.
+
+        Args:
+            data: Dictionary containing evaluator configuration with evaluatorTypeId
+                  in format "file://path/to/file.py:ClassName"
+
+        Returns:
+            Instance of the dynamically loaded evaluator class
+
+        Raises:
+            ValueError: If file or class cannot be loaded, or if the class is not a BaseEvaluator subclass
+        """
+        file_path = Path(file_path_str)
+        if not file_path.is_absolute():
+            if not file_path.exists():
+                file_path = (
+                    Path.cwd() / "evals" / "evaluators" / "custom" / file_path_str
+                )
+
+        if not file_path.exists():
+            raise ValueError(
+                f"Evaluator file not found: {file_path}. "
+                f"Make sure the file exists in evals/evaluators/custom/"
+            )
+
+        module_name = f"_custom_evaluator_{file_path.stem}_{id(data)}"
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Could not load module from {file_path}")
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception as e:
+            raise ValueError(
+                f"Error executing module from {file_path}: {str(e)}"
+            ) from e
+
+        # Get the class from the module
+        if not hasattr(module, class_name):
+            raise ValueError(
+                f"Class '{class_name}' not found in {file_path}. "
+                f"Available classes: {[name for name in dir(module) if not name.startswith('_')]}"
+            )
+
+        evaluator_class = getattr(module, class_name)
+
+        if not isinstance(evaluator_class, type) or not issubclass(
+            evaluator_class, BaseEvaluator
+        ):
+            raise ValueError(
+                f"Class '{class_name}' must be a subclass of BaseEvaluator"
+            )
+
+        evaluator_id = data.get("id")
+        if not evaluator_id or not isinstance(evaluator_id, str):
+            raise ValueError("Evaluator 'id' must be a non-empty string")
+        return evaluator_class(
+            id=evaluator_id,
+            config=data.get("evaluatorConfig", {}),
         )  # type: ignore
 
     @staticmethod

--- a/src/uipath/_cli/_evals/_helpers.py
+++ b/src/uipath/_cli/_evals/_helpers.py
@@ -1,0 +1,194 @@
+# type: ignore
+import ast
+import importlib.util
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import click
+
+from uipath._cli._utils._console import ConsoleLogger
+from uipath._utils.constants import CUSTOM_EVALUATOR_PREFIX
+
+logger = logging.getLogger(__name__)
+console = ConsoleLogger().get_instance()
+
+
+def try_extract_file_and_class_name(text: str) -> tuple[bool, str, str]:
+    if text.startswith(CUSTOM_EVALUATOR_PREFIX):
+        file_and_class = text[len(CUSTOM_EVALUATOR_PREFIX) :]
+        if ":" not in file_and_class:
+            raise ValueError(
+                f"evaluatorSchema must include class name after ':' - got: {text}"
+            )
+        file_path_str, class_name = file_and_class.rsplit(":", 1)
+
+        return True, file_path_str, class_name
+    return False, "", ""
+
+
+def to_kebab_case(text: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", text).lower()
+
+
+def find_evaluator_file(filename: str) -> Optional[Path]:
+    """Find the evaluator file in evals/evaluators/custom folder."""
+    custom_evaluators_path = Path.cwd() / "evals" / "evaluators" / "custom"
+
+    if not custom_evaluators_path.exists():
+        return None
+
+    file_path = custom_evaluators_path / filename
+    if file_path.exists():
+        return file_path
+
+    return None
+
+
+def find_base_evaluator_class(file_path: Path) -> Optional[str]:
+    """Parse the Python file and find the class that inherits from BaseEvaluator."""
+    try:
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read(), filename=str(file_path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for base in node.bases:
+                    if isinstance(base, ast.Name) and base.id == "BaseEvaluator":
+                        return node.name
+                    elif isinstance(base, ast.Subscript):
+                        if (
+                            isinstance(base.value, ast.Name)
+                            and base.value.id == "BaseEvaluator"
+                        ):
+                            return node.name
+
+        return None
+    except Exception as e:
+        logger.error(f"Error parsing file: {e}")
+        return None
+
+
+def load_evaluator_class(file_path: Path, class_name: str) -> Optional[type]:
+    """Dynamically load the evaluator class from the file."""
+    try:
+        parent_dir = str(file_path.parent)
+        if parent_dir not in sys.path:
+            sys.path.insert(0, parent_dir)
+
+        spec = importlib.util.spec_from_file_location("custom_evaluator", file_path)
+        if spec is None or spec.loader is None:
+            return None
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        if hasattr(module, class_name):
+            return getattr(module, class_name)
+
+        return None
+    except Exception as e:
+        logger.error(f"Error loading class: {e}")
+        return None
+    finally:
+        # Remove from sys.path
+        if parent_dir in sys.path:
+            sys.path.remove(parent_dir)
+
+
+def generate_evaluator_config(evaluator_class: type, class_name: str) -> dict[str, Any]:
+    """Generate the evaluator config from the class."""
+    try:
+        config_type = evaluator_class._extract_config_type()
+        config_instance = config_type()
+        config_dict = config_instance.model_dump(by_alias=True, exclude_none=False)
+
+        return config_dict
+    except Exception as e:
+        console.error(f"Error inferring evaluator config: {e}")
+
+
+def register_evaluator(filename: str) -> tuple[str, str]:
+    """Infers the schema and types of a custom evaluator
+
+    Returns:
+        tuple[str, str]:
+            - The first string is the path to the python evaluator file.
+            - The second string is the evaluator type that corresponds to the schema file.
+    """
+    if not filename.endswith(".py"):
+        filename = filename + ".py"
+    file_path = find_evaluator_file(filename)
+    if file_path is None:
+        console.error(f"Could not find '{filename}' in evals/evaluators/custom folder")
+
+    relative_path = f"evals/evaluators/custom/{filename}"
+    console.info(
+        f"Found custom evaluator file: {click.style(relative_path, fg='cyan')}"
+    )
+
+    class_name = find_base_evaluator_class(file_path)
+    if class_name is None:
+        console.error(
+            f"Could not find a class inheriting from BaseEvaluator in {filename}"
+        )
+
+    console.info(f"Found custom evaluator class: {click.style(class_name, fg='cyan')}")
+
+    evaluator_class = load_evaluator_class(file_path, class_name)
+    if evaluator_class is None:
+        console.error(f"Could not load class {class_name} from {filename}")
+
+    try:
+        evaluator_id = evaluator_class.get_evaluator_id()
+    except Exception as e:
+        console.error(f"Error getting evaluator ID: {e}")
+
+    evaluator_config = generate_evaluator_config(evaluator_class, class_name)
+    evaluator_json_type = evaluator_class.generate_json_type()
+
+    evaluators_dir = Path.cwd() / "evals" / "evaluators"
+    evaluators_dir.mkdir(parents=True, exist_ok=True)
+
+    evaluator_types_dir = evaluators_dir / "custom" / "types"
+    evaluator_types_dir.mkdir(parents=True, exist_ok=True)
+
+    kebab_class_name = to_kebab_case(class_name)
+    output_file_evaluator_types = kebab_class_name + "-types.json"
+    evaluator_types_output_path = (
+        evaluators_dir / "custom" / "types" / output_file_evaluator_types
+    )
+
+    with open(evaluator_types_output_path, "w") as f:
+        json.dump(evaluator_json_type, f, indent=2)
+
+    relative_output_path = (
+        f"evals/evaluators/custom/types/{output_file_evaluator_types}"
+    )
+    console.success(
+        f"Generated evaluator types: {click.style(relative_output_path, fg='cyan')}"
+    )
+
+    output = {
+        "version": "1.0",
+        "id": evaluator_id,
+        "evaluatorTypeId": f"{CUSTOM_EVALUATOR_PREFIX}types/{output_file_evaluator_types}",
+        "evaluatorSchema": f"{CUSTOM_EVALUATOR_PREFIX}{filename}:{class_name}",
+        "description": evaluator_class.__doc__,
+        "evaluatorConfig": evaluator_config,
+    }
+
+    output_file_evaluator_spec = kebab_class_name + ".json"
+    evaluator_spec_output_path = evaluators_dir / output_file_evaluator_spec
+    with open(evaluator_spec_output_path, "w") as f:
+        json.dump(output, f, indent=2)
+
+    relative_output_path = f"evals/evaluators/{output_file_evaluator_spec}"
+    console.success(
+        f"Generated evaluator spec: {click.style(relative_output_path, fg='cyan')}"
+    )
+
+    return str(file_path), str(evaluator_types_output_path)

--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -40,7 +40,7 @@ from uipath._utils.constants import (
     ENV_TENANT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )
-from uipath.eval.coded_evaluators import BaseEvaluator
+from uipath.eval.evaluators import BaseEvaluator
 from uipath.eval.evaluators import LegacyBaseEvaluator
 from uipath.eval.models import EvalItemResult, ScoreType
 from uipath.tracing import LlmOpsHttpExporter

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -448,7 +448,7 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
             raise ValueError("execution_id must be set for eval runs")
 
         attributes = {
-            "evalId": eval_item.id,
+            "evalId": eval_item_id,
             "span_type": "eval",
         }
         if runtime_context.execution_id:

--- a/src/uipath/_cli/_push/models.py
+++ b/src/uipath/_cli/_push/models.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+
+
+class EvaluatorFileDetails(BaseModel):
+    path: str
+    custom_evaluator_file_name: str = Field(
+        "", description="Name of the custom evaluator file, if available."
+    )
+
+    @property
+    def is_custom(self) -> bool:
+        return len(self.custom_evaluator_file_name) > 0

--- a/src/uipath/_cli/_templates/custom_evaluator.py.template
+++ b/src/uipath/_cli/_templates/custom_evaluator.py.template
@@ -1,0 +1,65 @@
+from uipath.eval.evaluators import BaseEvaluator, BaseEvaluationCriteria, BaseEvaluatorConfig
+from uipath.eval.models import AgentExecution, EvaluationResult, NumericEvaluationResult, BooleanEvaluationResult, ErrorEvaluationResult
+
+
+class $criteria_class(BaseEvaluationCriteria):
+    """Evaluation criteria for the $evaluator_name evaluator."""
+
+    # Define your evaluation criteria fields here
+    # Example: expected_value: str
+    pass
+
+
+class $config_class(BaseEvaluatorConfig[$criteria_class]):
+    """Configuration for the $evaluator_name evaluator."""
+
+    name: str = "$class_name"
+    # Set default evaluation criteria if needed
+    # default_evaluation_criteria: $criteria_class | None = $criteria_class(expected_value="example")
+
+
+class $class_name(BaseEvaluator[$criteria_class, $config_class, type(None)]):
+    """Description for $class_name"""
+
+    @classmethod
+    def get_evaluator_id(cls) -> str:
+        """Get the evaluator ID."""
+        return "$class_name"
+
+    async def evaluate(
+        self,
+        agent_execution: AgentExecution,
+        evaluation_criteria: $criteria_class
+    ) -> EvaluationResult:
+        """Evaluate the agent execution against the criteria.
+
+        Args:
+            agent_execution: The execution details containing:
+                - agent_input: The input received by the agent
+                - agent_output: The actual output from the agent
+                - agent_trace: The execution trace from the agent (list of OpenTelemetry spans)
+                - simulation_instructions: The simulation instructions for the agent
+            evaluation_criteria: The criteria to evaluate against
+
+        Returns:
+            EvaluationResult containing the score and details
+        """
+
+        '''
+        # TODO: Implement your evaluation logic here
+        Example: Check if the agent output matches expected criteria
+
+        Access agent execution data:
+        agent_input = agent_execution.agent_input
+        agent_output = agent_execution.agent_output
+        agent_trace = agent_execution.agent_trace
+
+        # Perform your evaluation
+        score = 0.0  # Replace with your scoring logic
+
+        return NumericEvaluationResult(
+            score=score,
+        )
+        '''
+
+        raise NotImplementedError(f"evaluate method not implemented")

--- a/src/uipath/_cli/_utils/_resources.py
+++ b/src/uipath/_cli/_utils/_resources.py
@@ -1,0 +1,21 @@
+import enum
+
+from ._console import ConsoleLogger
+
+console = ConsoleLogger().get_instance()
+
+
+class Resources(str, enum.Enum):
+    """Available resources that can be created."""
+
+    EVALUATOR = "evaluator"
+
+    @classmethod
+    def from_string(cls, resource: str) -> "Resources":  # type: ignore
+        try:
+            return Resources(resource)
+        except ValueError:
+            valid_resources = ", ".join([r.value for r in Resources])
+            console.error(
+                f"Invalid resource type: '{resource}'. Valid types are: {valid_resources}"
+            )

--- a/src/uipath/_cli/cli_add.py
+++ b/src/uipath/_cli/cli_add.py
@@ -1,0 +1,114 @@
+import logging
+import os
+import re
+from pathlib import Path
+from string import Template
+
+import click
+
+from ..telemetry import track
+from ._utils._console import ConsoleLogger
+from ._utils._resources import Resources
+
+logger = logging.getLogger(__name__)
+console = ConsoleLogger()
+
+
+def to_pascal_case(text: str) -> str:
+    """Convert kebab-case or snake_case to PascalCase."""
+    return "".join(word.capitalize() for word in re.sub(r"[-_]", " ", text).split())
+
+
+def to_snake_case(text: str) -> str:
+    """Convert kebab-case or PascalCase to snake_case."""
+    return re.sub(r"(?<!^)(?=[A-Z])|-", "_", text).lower()
+
+
+def generate_evaluator_template(evaluator_name: str) -> str:
+    """Generate a generic evaluator template."""
+    class_name = to_pascal_case(evaluator_name)
+    if not class_name.endswith("Evaluator"):
+        class_name = class_name + "Evaluator"
+
+    variables = {
+        "class_name": class_name,
+        "evaluator_name": evaluator_name,
+        "criteria_class": class_name.replace("Evaluator", "EvaluationCriteria"),
+        "config_class": class_name + "Config",
+    }
+    templates_path = os.path.join(
+        os.path.dirname(__file__), "_templates", "custom_evaluator.py.template"
+    )
+    with open(templates_path, "r", encoding="utf-8-sig") as f:
+        content = f.read()
+
+    return Template(content).substitute(variables)
+
+
+def create_evaluator(evaluator_name):
+    cwd = Path.cwd()
+    custom_evaluators_dir = cwd / "evals" / "evaluators" / "custom"
+
+    if not custom_evaluators_dir.exists():
+        console.info(
+            f"Creating {click.style('evals/evaluators/custom', fg='cyan')} folder"
+        )
+        custom_evaluators_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = to_snake_case(evaluator_name)
+    if not filename.endswith(".py"):
+        filename = filename + ".py"
+
+    file_path = custom_evaluators_dir / filename
+
+    if file_path.exists():
+        console.error(f"Evaluator file already exists: {file_path}")
+
+    template_content = generate_evaluator_template(evaluator_name)
+
+    with open(file_path, "w") as f:
+        f.write(template_content)
+
+    relative_path = f"evals/evaluators/custom/{filename}"
+
+    console.success(f"Created new evaluator: {click.style(relative_path, fg='cyan')}")
+    console.hint("Next steps:")
+    console.hint(
+        f"  1. Edit {click.style(relative_path, fg='cyan')} to implement your evaluation logic"
+    )
+    console.hint(
+        f"  2. Run {click.style(f'uipath register evaluator {filename}', fg='cyan')} to generate the evaluator spec"
+    )
+
+
+@click.command()
+@click.argument("resource", required=True)
+@click.argument("args", nargs=-1)
+@track
+def add(resource: str, args: tuple[str]) -> None:
+    """Create a local resource.
+
+    Examples:
+        uipath add evaluator my-custom-evaluator
+    """
+    match Resources.from_string(resource):
+        case Resources.EVALUATOR:
+            usage_hint = f"Usage: {click.style('uipath add evaluator <evaluator_name>', fg='cyan')}"
+            if len(args) < 1:
+                console.hint(usage_hint)
+                console.error("Missing required argument: evaluator_name")
+                return
+            if len(args) > 1:
+                console.hint(usage_hint)
+                console.error(
+                    f"Too many arguments provided: {args}. Expected only evaluator_name."
+                )
+
+            evaluator_name = args[0]
+
+            if not isinstance(evaluator_name, str) or not evaluator_name.strip():
+                console.hint(usage_hint)
+                console.error("Invalid evaluator_name: must be a non-empty string")
+                return
+
+            create_evaluator(evaluator_name)

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -239,7 +239,9 @@ def pull(root: str) -> None:
 
             if coded_evals_folder:
                 # New structure: coded-evals folder exists, use it and skip legacy evals
-                console.info("Found coded-evals folder, downloading to local evals structure")
+                console.info(
+                    "Found coded-evals folder, downloading to local evals structure"
+                )
                 asyncio.run(
                     download_coded_evals_files(
                         studio_client,
@@ -252,7 +254,9 @@ def pull(root: str) -> None:
                 # Fallback to legacy evals folder
                 evals_folder = get_folder_by_name(structure, "evals")
                 if evals_folder:
-                    console.info("Found legacy evals folder, downloading to local evals structure")
+                    console.info(
+                        "Found legacy evals folder, downloading to local evals structure"
+                    )
                     evals_path = os.path.join(root, "evals")
                     asyncio.run(
                         download_folder_files(

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -52,7 +52,6 @@ async def upload_source_files_to_project(
 
     await sw_file_handler.upload_source_files(config_data)
 
-    # Upload coded-evals files (files with version property) to coded-evals folder
     await sw_file_handler.upload_coded_evals_files()
 
 

--- a/src/uipath/_cli/cli_register.py
+++ b/src/uipath/_cli/cli_register.py
@@ -1,0 +1,45 @@
+# type: ignore
+import logging
+
+import click
+
+from ..telemetry import track
+from ._evals._helpers import register_evaluator
+from ._utils._console import ConsoleLogger
+from ._utils._resources import Resources
+
+logger = logging.getLogger(__name__)
+console = ConsoleLogger()
+
+
+@click.command()
+@click.argument("resource", required=True)
+@click.argument("args", nargs=-1)
+@track
+def register(resource: str, args: tuple[str]) -> None:
+    """Register a local resource.
+
+    Examples:
+        uipath register evaluator my-custom-evaluator.py
+    """
+    match Resources.from_string(resource):
+        case Resources.EVALUATOR:
+            usage_hint = f"Usage: {click.style('uipath register evaluator <evaluator_file_name> (ex. my_custom_evaluator.py)', fg='cyan')}"
+            if len(args) < 1:
+                console.hint(usage_hint)
+                console.error("Missing required argument: evaluator_file_name.")
+                return
+            if len(args) > 1:
+                console.hint(usage_hint)
+                console.error(
+                    f"Too many arguments provided: {args}. Expected only evaluator_file_name (ex. my_custom_evaluator.py)"
+                )
+
+            filename = args[0]
+
+            if not isinstance(filename, str) or not filename.strip():
+                console.hint(usage_hint)
+                console.error("Invalid filename: must be a non-empty string")
+                return
+
+            register_evaluator(filename)

--- a/src/uipath/_utils/constants.py
+++ b/src/uipath/_utils/constants.py
@@ -47,3 +47,6 @@ COMMUNITY_agents_SUFFIX = "-community-agents"
 
 # File names
 UIPATH_CONFIG_FILE = "uipath.json"
+
+# Evaluators
+CUSTOM_EVALUATOR_PREFIX = "file://"

--- a/src/uipath/eval/evaluators/__init__.py
+++ b/src/uipath/eval/evaluators/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 # Current coded evaluators
-from .base_evaluator import BaseEvaluator
+from .base_evaluator import BaseEvaluator, BaseEvaluationCriteria, BaseEvaluatorConfig
 from .contains_evaluator import ContainsEvaluator
 from .exact_match_evaluator import ExactMatchEvaluator
 from .json_similarity_evaluator import JsonSimilarityEvaluator
@@ -65,4 +65,6 @@ __all__ = [
     "ToolCallArgsEvaluator",
     "ToolCallCountEvaluator",
     "ToolCallOutputEvaluator",
+    "BaseEvaluationCriteria",
+    "BaseEvaluatorConfig"
 ]


### PR DESCRIPTION
- add support for custom evaluators
- refactored coded evaluator files pushing to deduplicate code
- push custom evaluators (.py files) and evaluators types files

# Add and register custom evaluator

1. (Optional) Add a new evaluator -> can be created manually in the evals/custom-evaluators directory
```
uipath add evaluator my_custom_evaluator
```
2. Implement the logic

3. Register the evaluator
```
uipath register evaluator my_custom_evaluator
```
4. Apply it to any dataset

> The custom evaluator is self registering when the code is pushed