### PR TITLE
fix: decouple interactive mode from pull project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.88"
+version = "2.1.89"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_logging.py
+++ b/src/uipath/_cli/_runtime/_logging.py
@@ -266,6 +266,10 @@ class LogsInterceptor:
             def writable(self) -> bool:
                 return True
 
+            def __getattr__(self, name):
+                # Delegate any unknown attributes to the original file
+                return getattr(self.sys_file, name)
+
         # Set up stdout and stderr loggers
         stdout_logger = logging.getLogger("stdout")
         stderr_logger = logging.getLogger("stderr")

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -24,6 +24,20 @@ from ._utils._project_files import pull_project
 console = ConsoleLogger()
 
 
+class InteractiveConflictHandler:
+    """Handler that prompts user for each conflict."""
+
+    def __init__(self, console: ConsoleLogger):
+        self.console = console
+
+    def should_overwrite(
+        self, file_path: str, local_hash: str, remote_hash: str
+    ) -> bool:
+        self.console.warning(f" File {file_path} differs from remote version.")
+        response = click.confirm("Do you want to overwrite it?", default=False)
+        return response
+
+
 @click.command()
 @click.argument(
     "root",
@@ -56,4 +70,11 @@ def pull(root: Path) -> None:
         "source_code": root,
         "evals": root / "evals",
     }
-    asyncio.run(pull_project(project_id, default_download_configuration))
+    with console.spinner("Pulling UiPath project files..."):
+        asyncio.run(
+            pull_project(
+                project_id,
+                default_download_configuration,
+                InteractiveConflictHandler(console),
+            )
+        )

--- a/tests/cli/test_pull.py
+++ b/tests/cli/test_pull.py
@@ -197,9 +197,9 @@ class TestPull:
             assert result.exit_code == 0
 
             # Verify source code files
-            assert "Downloaded main.py" in result.output
-            assert "Downloaded pyproject.toml" in result.output
-            assert "Downloaded uipath.json" in result.output
+            assert "Downloaded 'main.py'" in result.output
+            assert "Downloaded 'pyproject.toml'" in result.output
+            assert "Downloaded 'uipath.json'" in result.output
 
             # Verify source code file contents
             with open("main.py", "r") as f:
@@ -282,13 +282,13 @@ class TestPull:
             os.environ["UIPATH_PROJECT_ID"] = project_id
 
             # Mock user input to confirm override
-            monkeypatch.setattr("click.prompt", lambda *args, **kwargs: "y")
+            monkeypatch.setattr("click.confirm", lambda *args, **kwargs: True)
 
             # Run pull
             result = runner.invoke(cli, ["pull", "./"])
             assert result.exit_code == 0
             assert "differs from remote version" in result.output
-            assert "Updated main.py" in result.output
+            assert "Updated 'main.py'" in result.output
 
             # Verify file was updated
             with open("main.py", "r") as f:
@@ -356,13 +356,13 @@ class TestPull:
             os.environ["UIPATH_PROJECT_ID"] = project_id
 
             # Mock user input to reject override
-            monkeypatch.setattr("click.prompt", lambda *args, **kwargs: "n")
+            monkeypatch.setattr("click.confirm", lambda *args, **kwargs: False)
 
             # Run pull
             result = runner.invoke(cli, ["pull", "./"])
             assert result.exit_code == 0
             assert "differs from remote version" in result.output
-            assert "Skipped main.py" in result.output
+            assert "Skipped 'main.py'" in result.output
 
             # Verify file was not updated
             with open("main.py", "r") as f:

--- a/tests/cli/test_push.py
+++ b/tests/cli/test_push.py
@@ -258,12 +258,12 @@ class TestPush:
             # Run push
             result = runner.invoke(cli, ["push", "./"])
             assert result.exit_code == 0
-            assert "Updating main.py" in result.output
-            assert "Updating pyproject.toml" in result.output
-            assert "Updating uipath.json" in result.output
-            assert "Uploading uv.lock" in result.output
-            assert "Updating agent.json" in result.output
-            assert "Updating entry-points.json" in result.output
+            assert "Updating 'main.py'" in result.output
+            assert "Updating 'pyproject.toml'" in result.output
+            assert "Updating 'uipath.json'" in result.output
+            assert "Uploading 'uv.lock'" in result.output
+            assert "Updating 'agent.json'" in result.output
+            assert "Updating 'entry-points.json'" in result.output
 
             # check incremented code version via StructuralMigration payload
             structural_migration_request = httpx_mock.get_request(
@@ -359,12 +359,12 @@ class TestPush:
             # Run push
             result = runner.invoke(cli, ["push", "./"])
             assert result.exit_code == 0
-            assert "Uploading main.py" in result.output
-            assert "Uploading pyproject.toml" in result.output
-            assert "Uploading uipath.json" in result.output
-            assert "Uploading uv.lock" in result.output
-            assert "Uploading agent.json" in result.output
-            assert "Uploading entry-points.json" in result.output
+            assert "Uploading 'main.py'" in result.output
+            assert "Uploading 'pyproject.toml'" in result.output
+            assert "Uploading 'uipath.json'" in result.output
+            assert "Uploading 'uv.lock'" in result.output
+            assert "Uploading 'agent.json'" in result.output
+            assert "Uploading 'entry-points.json'" in result.output
 
             # check expected agent.json fields
             structural_migration_request = httpx_mock.get_request(
@@ -516,9 +516,9 @@ class TestPush:
             # Run push with --nolock flag
             result = runner.invoke(cli, ["push", "./", "--nolock"])
             assert result.exit_code == 0
-            assert "Updating main.py" in result.output
-            assert "Uploading pyproject.toml" in result.output
-            assert "Updating uipath.json" in result.output
+            assert "Updating 'main.py'" in result.output
+            assert "Uploading 'pyproject.toml'" in result.output
+            assert "Updating 'uipath.json'" in result.output
             assert "uv.lock" not in result.output
 
     def _mock_lock_retrieval(
@@ -614,8 +614,8 @@ class TestPush:
             # Verify that excluded file was not mentioned in output
             assert "config.json" not in result.output
             # Verify that other files were uploaded
-            assert "Uploading other.json" in result.output
-            assert "Uploading main.py" in result.output
+            assert "Uploading 'other.json'" in result.output
+            assert "Uploading 'main.py'" in result.output
 
     def test_push_files_excluded_takes_precedence_over_included(
         self,
@@ -697,7 +697,7 @@ class TestPush:
             # File should be excluded (exclusion takes precedence)
             assert "conflicting.txt" not in result.output
             # Verify other files were uploaded
-            assert "Uploading main.py" in result.output
+            assert "Uploading 'main.py'" in result.output
 
     def test_push_filename_vs_path_exclusion(
         self,
@@ -797,7 +797,7 @@ class TestPush:
             assert (
                 "settings.json" in result.output
             )  # At least some settings.json should be present
-            assert "Uploading main.py" in result.output
+            assert "Uploading 'main.py'" in result.output
 
     def test_push_filename_vs_path_inclusion(
         self,
@@ -899,7 +899,7 @@ class TestPush:
             assert (
                 "data.txt" in result.output or "config.txt" in result.output
             )  # At least one should be present
-            assert "Uploading main.py" in result.output
+            assert "Uploading 'main.py'" in result.output
 
     def test_push_directory_name_vs_path_exclusion(
         self,
@@ -1000,4 +1000,4 @@ class TestPush:
             assert (
                 "config.json" in result.output
             )  # Some config.json should be present from allowed directories
-            assert "Uploading main.py" in result.output
+            assert "Uploading 'main.py'" in result.output


### PR DESCRIPTION
## Description

This PR decouples interactive conflict prompts from the core pull logic by introducing a pluggable conflict handler and moving UI interactions to the CLI layer.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.89.dev1007221816",

  # Any version from PR
  "uipath>=2.1.89.dev1007220000,<2.1.89.dev1007230000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```