### PR TITLE
chore(Agents.md): override the AGENTS.md files on init

### DIFF
--- a/src/uipath/_resources/CLI_REFERENCE.md
+++ b/src/uipath/_resources/CLI_REFERENCE.md
@@ -27,6 +27,7 @@ The UiPath Python SDK provides a comprehensive CLI for managing coded agents and
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--infer-bindings` | flag | false | Infer bindings from the script. |
+| `--no-agents-md-override` | flag | false | Won't override existing .agent files and AGENTS.md file. |
 
 **Usage Examples:**
 


### PR DESCRIPTION
# Override AGENTS.md and Related Files on Init

## Summary

This PR updates the `uipath init` command to override existing agent documentation files (AGENTS.md, CLAUDE.md, and reference files) instead of skipping them when they already exist. This ensures users always get the latest version of these files when running `uipath init`.

## Motivation

Previously, when users ran `uipath init`, the command would skip creating AGENTS.md and related files if they already existed in the project directory. This meant that users would not receive updates to these important documentation files when:
- The SDK is updated with new features or CLI commands
- Reference documentation is improved or corrected
- New services or methods are added to the SDK

By overriding these files on each `uipath init` run, users automatically get the most up-to-date documentation that matches their installed SDK version.

## Impact

**User-facing changes:**
- Users running `uipath init` will now receive updated documentation files automatically
- Any manual edits to these files will be overwritten (users should not edit these auto-generated files)

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.98.dev1007232014",

  # Any version from PR
  "uipath>=2.1.98.dev1007230000,<2.1.98.dev1007240000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```