### PR TITLE
fix: trace studio web operations

### DIFF
--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -319,7 +319,7 @@ class SwFileHandler:
         if existing:
             try:
                 entry_points_json = (
-                    await self._studio_client.download_file_async(existing.id)
+                    await self._studio_client.download_project_file_async(existing)
                 ).json()
                 entry_points_json["entryPoints"] = uipath_config["entryPoints"]
 
@@ -417,7 +417,7 @@ class SwFileHandler:
         if existing:
             try:
                 existing_agent_json = (
-                    await self._studio_client.download_file_async(existing.id)
+                    await self._studio_client.download_project_file_async(existing)
                 ).json()
                 version_parts = existing_agent_json["metadata"]["codeVersion"].split(
                     "."

--- a/src/uipath/_cli/_utils/_project_files.py
+++ b/src/uipath/_cli/_utils/_project_files.py
@@ -557,7 +557,7 @@ async def download_folder_files(
         local_path = base_path / file_path
         local_path.parent.mkdir(parents=True, exist_ok=True)
 
-        response = await studio_client.download_file_async(remote_file.id)
+        response = await studio_client.download_project_file_async(remote_file)
         remote_content = response.read().decode("utf-8")
         remote_hash = compute_normalized_hash(remote_content)
 

--- a/src/uipath/agent/_utils.py
+++ b/src/uipath/agent/_utils.py
@@ -29,7 +29,7 @@ async def get_file(
 ) -> Response:
     resolved = resolve_path(folder, path)
     assert isinstance(resolved, ProjectFile), "Path file not found."
-    return await studio_client.download_file_async(resolved.id)
+    return await studio_client.download_project_file_async(resolved)
 
 
 async def create_agent_project(solution_id: str, project_name: str) -> str:


### PR DESCRIPTION
## Description

Adds tracing spans around key Studio Web client operations to improve observability of project and file actions.

<img width="1486" height="686" alt="image" src="https://github.com/user-attachments/assets/7182b2a1-81b2-4a76-80bc-07e02c093a54" />

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.91.dev1007271889",

  # Any version from PR
  "uipath>=2.1.91.dev1007270000,<2.1.91.dev1007280000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```