### PR TITLE
refactor(UseRuntimeSchema): use runtime schema definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.90"
+version = "2.1.91"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/samples/calculator/uipath.json
+++ b/samples/calculator/uipath.json
@@ -2,7 +2,7 @@
     "entryPoints": [
         {
             "filePath": "main.py",
-            "uniqueId": "cb9d5d2b-1f16-420f-baeb-cf3d80269248",
+            "uniqueId": "f62a1945-cb6f-48b2-b575-9d802e3f90c1",
             "type": "agent",
             "input": {
                 "type": "object",

--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -453,7 +453,7 @@ class SwFileHandler:
             )
             logger.info("Uploading 'agent.json'")
 
-    async def upload_source_files(self, config_data: dict[str, Any]) -> None:
+    async def upload_source_files(self, settings: Optional[dict[str, Any]]) -> None:
         """Main method to upload source files to the UiPath project.
 
         - Gets project structure
@@ -462,7 +462,7 @@ class SwFileHandler:
         - Deletes removed files
 
         Args:
-            config_data: Project configuration data
+            settings: File handling settings
 
         Returns:
             Dict[str, ProjectFileExtended]: Root level files for agent.json handling
@@ -493,7 +493,7 @@ class SwFileHandler:
 
         # Get files to upload and process them
         files = files_to_include(
-            config_data,
+            settings,
             self.directory,
             self.include_uv_lock,
             directories_to_ignore=["evals"],

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -1,7 +1,7 @@
 # type: ignore
 import asyncio
 import os
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 import click
@@ -32,7 +32,7 @@ def get_org_scoped_url(base_url: str) -> str:
 
 async def upload_source_files_to_project(
     project_id: str,
-    config_data: dict[Any, str],
+    settings: Optional[dict[str, Any]],
     directory: str,
     include_uv_lock: bool = True,
 ) -> None:
@@ -50,7 +50,7 @@ async def upload_source_files_to_project(
         include_uv_lock=include_uv_lock,
     )
 
-    await sw_file_handler.upload_source_files(config_data)
+    await sw_file_handler.upload_source_files(settings)
 
 
 @click.command()
@@ -99,7 +99,7 @@ def push(root: str, nolock: bool) -> None:
             asyncio.run(
                 upload_source_files_to_project(
                     os.getenv(UIPATH_PROJECT_ID),
-                    config,
+                    config.get("settings", {}),
                     root,
                     include_uv_lock=not nolock,
                 )

--- a/src/uipath/_cli/models/runtime_schema.py
+++ b/src/uipath/_cli/models/runtime_schema.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -12,14 +11,10 @@ COMMON_MODEL_SCHEMA = ConfigDict(
 )
 
 
-class EntrypointType(str, Enum):
-    AGENT = "agent"
-
-
 class Entrypoint(BaseModel):
     file_path: str = Field(..., alias="filePath")
     unique_id: str = Field(..., alias="uniqueId")
-    type: EntrypointType = EntrypointType.AGENT
+    type: str = Field(..., alias="type")
     input: Dict[str, Any] = Field(..., alias="input")
     output: Dict[str, Any] = Field(..., alias="output")
 
@@ -44,7 +39,7 @@ class BindingResource(BaseModel):
     model_config = COMMON_MODEL_SCHEMA
 
 
-class Binding(BaseModel):
+class Bindings(BaseModel):
     version: str = Field(..., alias="version")
     resources: List[BindingResource] = Field(..., alias="resources")
 
@@ -68,6 +63,9 @@ class RuntimeArguments(BaseModel):
 class RuntimeSchema(BaseModel):
     runtime: Optional[RuntimeArguments] = Field(default=None, alias="runtime")
     entrypoints: List[Entrypoint] = Field(..., alias="entryPoints")
-    bindings: Binding = Field(..., alias="bindings")
+    bindings: Bindings = Field(
+        default=Bindings(version="2.0", resources=[]), alias="bindings"
+    )
+    settings: Optional[Dict[str, Any]] = Field(default=None, alias="setting")
 
     model_config = COMMON_MODEL_SCHEMA

--- a/tests/cli/test_pack.py
+++ b/tests/cli/test_pack.py
@@ -212,8 +212,8 @@ class TestPack:
     ) -> None:
         """Test generating operate.json and its content."""
         bindings_data = cli_pack.generate_bindings_content()
-        assert bindings_data["version"] == "2.0"
-        assert bindings_data["resources"] == []
+        assert bindings_data.version == "2.0"
+        assert bindings_data.resources == []
 
     def test_generate_bindings_content(
         self, runner: CliRunner, temp_dir: str, uipath_json: UiPathJson

--- a/uv.lock
+++ b/uv.lock
@@ -2146,7 +2146,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.90"
+version = "2.1.91"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Use strongly typed runtime schema definition for internal usage.

I was able to successfully test: init , pack , push , pull , publish , run , eval , invoke.
Also verified that the bindings are still being generated correctly.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.91.dev1007291878",

  # Any version from PR
  "uipath>=2.1.91.dev1007290000,<2.1.91.dev1007300000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```