### PR TITLE
feat(CacheForMocks): folder-based caching for LLM and input mocking in evals

### DIFF
--- a/src/uipath/_cli/_evals/mocks/cache_manager.py
+++ b/src/uipath/_cli/_evals/mocks/cache_manager.py
@@ -1,0 +1,94 @@
+"""Cache manager for LLM and input mocker responses."""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Set
+
+
+class CacheManager:
+    """Manages caching for LLM and input mocker responses."""
+
+    def __init__(self, cache_dir: Optional[Path] = None):
+        """Initialize the cache manager with in-memory cache."""
+        self.cache_dir = cache_dir or (Path.cwd() / ".uipath" / "eval_cache")
+        self._memory_cache: Dict[str, Any] = {}
+        self._dirty_keys: Set[str] = set()
+
+    def _compute_cache_key(self, cache_key_data: Dict[str, Any]) -> str:
+        """Compute a hash from cache key data."""
+        serialized = json.dumps(cache_key_data, sort_keys=True)
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+    def _get_cache_key_string(
+        self,
+        mocker_type: str,
+        cache_key_data: Dict[str, Any],
+        function_name: str,
+    ) -> str:
+        """Generate unique cache key string for memory lookup."""
+        cache_key_hash = self._compute_cache_key(cache_key_data)
+        return f"{mocker_type}/{function_name}/{cache_key_hash}"
+
+    def _get_cache_path(
+        self,
+        cache_key_string: str,
+    ) -> Path:
+        """Get the file path for a cache entry from cache key string."""
+        return self.cache_dir / f"{cache_key_string}.json"
+
+    def get(
+        self,
+        mocker_type: str,
+        cache_key_data: Dict[str, Any],
+        function_name: str,
+    ) -> Optional[Any]:
+        """Retrieve a cached response from memory first, then disk."""
+        cache_key_string = self._get_cache_key_string(
+            mocker_type, cache_key_data, function_name
+        )
+
+        # Check memory cache first
+        if cache_key_string in self._memory_cache:
+            return self._memory_cache[cache_key_string]
+
+        # Check disk cache
+        cache_path = self._get_cache_path(cache_key_string)
+        if not cache_path.exists():
+            return None
+
+        with open(cache_path, "r") as f:
+            cached_response = json.load(f)
+
+        # Populate memory cache
+        self._memory_cache[cache_key_string] = cached_response
+        return cached_response
+
+    def set(
+        self,
+        mocker_type: str,
+        cache_key_data: Dict[str, Any],
+        response: Any,
+        function_name: str,
+    ) -> None:
+        """Store a response in memory cache and mark for later disk write."""
+        cache_key_string = self._get_cache_key_string(
+            mocker_type, cache_key_data, function_name
+        )
+
+        # Store in memory
+        self._memory_cache[cache_key_string] = response
+
+        # Mark as dirty for later flush
+        self._dirty_keys.add(cache_key_string)
+
+    def flush(self) -> None:
+        """Write all dirty cache entries to disk."""
+        for cache_key_string in self._dirty_keys:
+            cache_path = self._get_cache_path(cache_key_string)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with open(cache_path, "w") as f:
+                json.dump(self._memory_cache[cache_key_string], f)
+
+        self._dirty_keys.clear()

--- a/src/uipath/_cli/_evals/mocks/mocks.py
+++ b/src/uipath/_cli/_evals/mocks/mocks.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional
 
 from uipath._cli._evals._models._evaluation_set import EvaluationItem
 from uipath._cli._evals._span_collection import ExecutionSpanCollector
+from uipath._cli._evals.mocks.cache_manager import CacheManager
 from uipath._cli._evals.mocks.mocker import Mocker, UiPathNoMockFoundError
 from uipath._cli._evals.mocks.mocker_factory import MockerFactory
 
@@ -24,6 +25,11 @@ span_collector_context: ContextVar[Optional[ExecutionSpanCollector]] = ContextVa
 # Execution ID for the current evaluation item
 execution_id_context: ContextVar[Optional[str]] = ContextVar(
     "execution_id", default=None
+)
+
+# Cache manager for LLM and input mocker responses
+cache_manager_context: ContextVar[Optional[CacheManager]] = ContextVar(
+    "cache_manager", default=None
 )
 
 logger = logging.getLogger(__name__)

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -82,6 +82,12 @@ def setup_reporting_prereq(no_report: bool) -> bool:
     type=click.Path(exists=False),
     help="File path where the output will be written",
 )
+@click.option(
+    "--enable-mocker-cache",
+    is_flag=True,
+    default=False,
+    help="Enable caching for LLM mocker responses",
+)
 @track(when=lambda *_a, **_kw: os.getenv(ENV_JOB_ID) is None)
 def eval(
     entrypoint: Optional[str],
@@ -91,6 +97,7 @@ def eval(
     no_report: bool,
     workers: int,
     output_file: Optional[str],
+    enable_mocker_cache: bool,
 ) -> None:
     """Run an evaluation set against the agent.
 
@@ -101,6 +108,7 @@ def eval(
         eval_set_run_id: Custom evaluation set run ID (optional, will generate UUID if not specified)
         workers: Number of parallel workers for running evaluations
         no_report: Do not report the evaluation results
+        enable_mocker_cache: Enable caching for LLM mocker responses
     """
     context_args = {
         "entrypoint": entrypoint or auto_discover_entrypoint(),
@@ -110,6 +118,7 @@ def eval(
         "workers": workers,
         "no_report": no_report,
         "output_file": output_file,
+        "enable_mocker_cache": enable_mocker_cache,
     }
 
     should_register_progress_reporter = setup_reporting_prereq(no_report)
@@ -143,6 +152,7 @@ def eval(
         eval_context.no_report = no_report
         eval_context.workers = workers
         eval_context.eval_set_run_id = eval_set_run_id
+        eval_context.enable_mocker_cache = enable_mocker_cache
 
         # Load eval set to resolve the path
         eval_set_path = eval_set or EvalHelpers.auto_discover_eval_set()

--- a/tests/cli/eval/mocks/test_cache_manager.py
+++ b/tests/cli/eval/mocks/test_cache_manager.py
@@ -1,0 +1,162 @@
+"""Tests for CacheManager."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from uipath._cli._evals.mocks.cache_manager import CacheManager
+from uipath._cli._evals.mocks.mocks import cache_manager_context
+
+
+@pytest.fixture
+def cache_manager():
+    """Create a cache manager with a temp directory for tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cm = CacheManager(cache_dir=Path(tmpdir))
+        cache_manager_context.set(cm)
+        yield cm
+        cache_manager_context.set(None)
+
+
+def test_set_and_get_llm_mocker(cache_manager):
+    """Test setting and getting a cached response for LLM mocker."""
+    cache_key_data = {
+        "prompt_generation_args": {
+            "input": "test input",
+        },
+        "response_format": {"type": "json"},
+        "completion_kwargs": {"temperature": 0.7},
+    }
+
+    response = {"result": "test response"}
+
+    cache_manager.set(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data,
+        response=response,
+        function_name="test_function",
+    )
+
+    cached_response = cache_manager.get(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data,
+        function_name="test_function",
+    )
+
+    assert cached_response == response
+
+
+def test_set_and_get_input_mocker(cache_manager):
+    """Test setting and getting a cached response for input mocker."""
+    cache_key_data = {
+        "prompt_generation_args": {
+            "input": "test input",
+        },
+        "response_format": {"type": "json"},
+        "completion_kwargs": {"temperature": 0.7},
+    }
+
+    response = {"input": "test input"}
+
+    cache_manager.set(
+        mocker_type="input_mocker",
+        cache_key_data=cache_key_data,
+        response=response,
+        function_name="generate_llm_input",
+    )
+
+    cached_response = cache_manager.get(
+        mocker_type="input_mocker",
+        cache_key_data=cache_key_data,
+        function_name="generate_llm_input",
+    )
+
+    assert cached_response == response
+
+
+def test_cache_invalidation_on_prompt_args_change(cache_manager):
+    """Test that changing the prompt generation args invalidates the cache."""
+    cache_key_data1 = {
+        "prompt_generation_args": {
+            "input": "original input",
+        },
+        "response_format": {"type": "json"},
+        "completion_kwargs": {"temperature": 0.7},
+    }
+
+    cache_key_data2 = {
+        "prompt_generation_args": {
+            "input": "modified input",
+        },
+        "response_format": {"type": "json"},
+        "completion_kwargs": {"temperature": 0.7},
+    }
+
+    response1 = {"result": "response 1"}
+    response2 = {"result": "response 2"}
+
+    cache_manager.set(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data1,
+        response=response1,
+        function_name="test_function",
+    )
+
+    cache_manager.set(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data2,
+        response=response2,
+        function_name="test_function",
+    )
+
+    cached1 = cache_manager.get(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data1,
+        function_name="test_function",
+    )
+
+    cached2 = cache_manager.get(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data2,
+        function_name="test_function",
+    )
+
+    assert cached1 == response1
+    assert cached2 == response2
+
+
+def test_cache_invalidation_on_model_settings_change(cache_manager):
+    """Test that changing model settings invalidates the cache."""
+    cache_key_data1 = {
+        "prompt_generation_args": {
+            "input": "test input",
+        },
+        "response_format": {"type": "json"},
+        "completion_kwargs": {"temperature": 0.7},
+    }
+
+    cache_key_data2 = {
+        "prompt_generation_args": {
+            "input": "test input",
+        },
+        "response_format": {"type": "json"},
+        "completion_kwargs": {"temperature": 0.9},
+    }
+
+    response = {"result": "test response"}
+
+    cache_manager.set(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data1,
+        response=response,
+        function_name="test_function",
+    )
+
+    cached_response = cache_manager.get(
+        mocker_type="llm_mocker",
+        cache_key_data=cache_key_data2,
+        function_name="test_function",
+    )
+
+    assert cached_response is None

--- a/tests/cli/eval/mocks/test_input_mocker.py
+++ b/tests/cli/eval/mocks/test_input_mocker.py
@@ -9,6 +9,7 @@ from uipath._cli._evals._models._evaluation_set import (
     InputMockingStrategy,
     ModelSettings,
 )
+from uipath._cli._evals.mocks.cache_manager import CacheManager
 from uipath._cli._evals.mocks.input_mocker import generate_llm_input
 
 
@@ -19,6 +20,8 @@ async def test_generate_llm_input_with_model_settings(
 ):
     monkeypatch.setenv("UIPATH_URL", "https://example.com")
     monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "test-token")
+    monkeypatch.setattr(CacheManager, "get", lambda *args, **kwargs: None)
+    monkeypatch.setattr(CacheManager, "set", lambda *args, **kwargs: None)
 
     evaluation_item: dict[str, Any] = {
         "id": "test-eval-id",

--- a/tests/cli/eval/mocks/test_mocks.py
+++ b/tests/cli/eval/mocks/test_mocks.py
@@ -10,6 +10,7 @@ from uipath._cli._evals._models._evaluation_set import (
     LLMMockingStrategy,
     MockitoMockingStrategy,
 )
+from uipath._cli._evals.mocks.cache_manager import CacheManager
 from uipath._cli._evals.mocks.mocker import UiPathMockResponseGenerationError
 from uipath._cli._evals.mocks.mocks import set_execution_context
 from uipath.eval.mocks import mockable
@@ -136,6 +137,8 @@ async def test_mockito_mockable_async():
 def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
     monkeypatch.setenv("UIPATH_URL", "https://example.com")
     monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "1234567890")
+    monkeypatch.setattr(CacheManager, "get", lambda *args, **kwargs: None)
+    monkeypatch.setattr(CacheManager, "set", lambda *args, **kwargs: None)
 
     # Arrange
     @mockable()
@@ -220,6 +223,8 @@ def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
 async def test_llm_mockable_async(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
     monkeypatch.setenv("UIPATH_URL", "https://example.com")
     monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "1234567890")
+    monkeypatch.setattr(CacheManager, "get", lambda *args, **kwargs: None)
+    monkeypatch.setattr(CacheManager, "set", lambda *args, **kwargs: None)
 
     # Arrange
     @mockable()


### PR DESCRIPTION
This PR adds a file-based caching system for both LLM and input mocker responses used in evals. The hash of the prompt and model parameters are used as the cache key, and the LLM response is the cached value, using a hierarchical folder structure under `.uipath/eval_cache`.