### PR TITLE
fix: add events streaming to runtime contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.91"
+version = "2.1.92"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_events/_events.py
+++ b/src/uipath/_events/_events.py
@@ -1,15 +1,15 @@
-import enum
 import logging
-from typing import Any, List, Optional, Union
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
 
 from opentelemetry.sdk.trace import ReadableSpan
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from uipath._cli._evals._models._evaluation_set import EvaluationItem
 from uipath.eval.models import EvalItemResult
 
 
-class EvaluationEvents(str, enum.Enum):
+class EvaluationEvents(str, Enum):
     CREATE_EVAL_SET_RUN = "create_eval_set_run"
     CREATE_EVAL_RUN = "create_eval_run"
     UPDATE_EVAL_SET_RUN = "update_eval_set_run"
@@ -67,3 +67,81 @@ ProgressEvent = Union[
     EvalRunUpdatedEvent,
     EvalSetRunUpdatedEvent,
 ]
+
+
+class EventType(str, Enum):
+    """Types of events that can be emitted during execution."""
+
+    MESSAGE_CREATED = "message_created"
+    AGENT_STATE_UPDATED = "agent_state_updated"
+    ERROR = "error"
+
+
+class BaseEvent(BaseModel):
+    """Base class for all UiPath events."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    event_type: EventType
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None, description="Additional event context"
+    )
+
+
+class MessageCreatedEvent(BaseEvent):
+    """Event emitted when a message is created or streamed.
+
+    Wraps framework-specific message objects (e.g., LangChain BaseMessage,
+    CrewAI messages, AutoGen messages, etc.) without converting them.
+
+    Attributes:
+        payload: The framework-specific message object
+        event_type: Automatically set to MESSAGE_CREATED
+        metadata: Additional context (conversation_id, exchange_id, etc.)
+
+    Example:
+        # LangChain
+        event = MessageCreatedEvent(
+            payload=AIMessage(content="Hello"),
+            metadata={"conversation_id": "123"}
+        )
+
+        # Access the message
+        message = event.payload  # BaseMessage
+        print(message.content)
+    """
+
+    payload: Any = Field(description="Framework-specific message object")
+    event_type: EventType = Field(default=EventType.MESSAGE_CREATED, frozen=True)
+
+
+class AgentStateUpdatedEvent(BaseEvent):
+    """Event emitted when agent state is updated.
+
+    Wraps framework-specific state update objects, preserving the original
+    structure and data from the framework.
+
+    Attributes:
+        payload: The framework-specific state update (e.g., LangGraph state dict)
+        node_name: Name of the node/agent that produced this update (if available)
+        event_type: Automatically set to AGENT_STATE_UPDATED
+        metadata: Additional context
+
+    Example:
+        # LangGraph
+        event = AgentStateUpdatedEvent(
+            payload={"messages": [...], "context": "..."},
+            node_name="agent_node",
+            metadata={"conversation_id": "123"}
+        )
+
+        # Access the state
+        state = event.payload  # dict
+        messages = state.get("messages", [])
+    """
+
+    payload: Dict[str, Any] = Field(description="Framework-specific state update")
+    node_name: Optional[str] = Field(
+        default=None, description="Name of the node/agent that caused this update"
+    )
+    event_type: EventType = Field(default=EventType.AGENT_STATE_UPDATED, frozen=True)


### PR DESCRIPTION
## Description

This PR adds events streaming functionality to the runtime contract by introducing new event types and a streaming interface. The changes enable real-time event emission during execution with framework-agnostic event objects.

- Added new event classes (`EventType`, `BaseEvent`, `MessageCreatedEvent`, `AgentStateUpdatedEvent`) for streaming support
- Extended the `UiPathRuntimeContract` with an optional `stream()` method for real-time execution events

```python
async for event in runtime.stream():
    if isinstance(event, UiPathRuntimeResult):
        # Last event - execution complete
        print(f"Status: {event.status}")
        break
    elif isinstance(event, MessageCreatedEvent):
        # Handle message event
        print(f"Message: {event.payload}")
    elif isinstance(event, AgentStateUpdatedEvent):
        # Handle state update
        print(f"State updated by: {event.node_name}")
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.92.dev1007331890",

  # Any version from PR
  "uipath>=2.1.92.dev1007330000,<2.1.92.dev1007340000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```