### PR TITLE
fix: rename runtime events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.92"
+version = "2.1.93"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -35,7 +35,7 @@ from opentelemetry.sdk.trace.export import (
 from opentelemetry.trace import Tracer
 from pydantic import BaseModel, Field
 
-from uipath._events._events import BaseEvent
+from uipath._events._events import UiPathRuntimeEvent
 from uipath.agent.conversation import UiPathConversationEvent, UiPathConversationMessage
 from uipath.tracing import TracingManager
 
@@ -156,7 +156,7 @@ class UiPathRuntimeResult(BaseModel):
         return result
 
 
-class UiPathRuntimeBreakpointResult(UiPathRuntimeResult):
+class UiPathBreakpointResult(UiPathRuntimeResult):
     """Result for execution suspended at a breakpoint."""
 
     # Force status to always be SUSPENDED
@@ -576,7 +576,7 @@ class UiPathBaseRuntime(ABC):
 
     async def stream(
         self,
-    ) -> AsyncGenerator[Union[BaseEvent, UiPathRuntimeResult], None]:
+    ) -> AsyncGenerator[Union[UiPathRuntimeEvent, UiPathRuntimeResult], None]:
         """Stream execution events in real-time.
 
         This is an optional method that runtimes can implement to support streaming.
@@ -586,9 +586,9 @@ class UiPathBaseRuntime(ABC):
         with the final event being UiPathRuntimeResult.
 
         Yields:
-            BaseEvent subclasses: Framework-agnostic events (MessageCreatedEvent,
-                                  AgentStateUpdatedEvent, etc.)
-            Final yield: UiPathRuntimeResult
+            UiPathRuntimeEvent subclasses: Framework-agnostic events (UiPathAgentMessageEvent,
+                                  UiPathAgentStateEvent, etc.)
+            Final yield: UiPathRuntimeResult (or its subclass UiPathBreakpointResult)
 
         Raises:
             NotImplementedError: If the runtime doesn't support streaming
@@ -600,10 +600,10 @@ class UiPathBaseRuntime(ABC):
                     # Last event - execution complete
                     print(f"Status: {event.status}")
                     break
-                elif isinstance(event, MessageCreatedEvent):
+                elif isinstance(event, UiPathAgentMessageEvent):
                     # Handle message event
                     print(f"Message: {event.payload}")
-                elif isinstance(event, AgentStateUpdatedEvent):
+                elif isinstance(event, UiPathAgentStateEvent):
                     # Handle state update
                     print(f"State updated by: {event.node_name}")
         """


### PR DESCRIPTION
## Description

This PR renames runtime event classes and enum values to improve naming consistency and clarity. The changes update event type names, and rename the base event class to `UiPathRuntimeEvent` to better reflect its purpose.

```python
# LangGraph
event = UiPathAgentStateEvent(
    payload={"messages": [...], "context": "..."},
    node_name="agent_node",
    metadata={"additional_prop": "123"}
)

# Access the state
state = event.payload  # dict
messages = state.get("messages", [])

# LangChain
event = UiPathAgentMessageEvent(
    payload=AIMessage(content="Hello"),
    metadata={"additional_prop": "123"}
)

# Access the message
message = event.payload  # BaseMessage
print(message.content)
```