### PR TITLE
fix: properly close async generator on debug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.94"
+version = "2.1.95"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -114,6 +114,8 @@ class ConsoleDebugBridge(UiPathDebugBridge):
             return
 
         self.console.print(f"[yellow]●[/yellow] [bold]{state_event.node_name}[/bold]")
+        if state_event.payload:
+            self._print_json(state_event.payload, label="State")
 
     async def emit_breakpoint_hit(
         self, breakpoint_result: UiPathBreakpointResult

--- a/src/uipath/_cli/_debug/_runtime.py
+++ b/src/uipath/_cli/_debug/_runtime.py
@@ -105,15 +105,11 @@ class UiPathDebugRuntime(UiPathBaseRuntime, Generic[T, C]):
                         await self.debug_bridge.emit_breakpoint_hit(event)
                         await self.debug_bridge.wait_for_resume()
                         self._inner_runtime.context.resume = True
-                        # Break out of stream loop to restart streaming from resume point
-                        break
                     else:
                         # Normal completion or suspension with dynamic interrupt
                         execution_completed = True
-
                         # Handle dynamic interrupts if present
                         # Maybe poll for resume trigger completion here in future
-                        break
 
                 # Handle state update events - send to debug bridge
                 elif isinstance(event, UiPathAgentStateEvent):


### PR DESCRIPTION
## Description

This PR fixes an issue with async generator cleanup during debug operations by removing premature break statements that were preventing proper generator closure. The changes ensure the debug event stream completes naturally rather than being interrupted.