### PR TITLE
feat(InputMocking): read input schema from entrypoint to pass to mocker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.110"
+version = "2.1.111"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/samples/calculator/evals/eval-sets/legacy.json
+++ b/samples/calculator/evals/eval-sets/legacy.json
@@ -90,6 +90,25 @@
       "evalSetId": "default-eval-set-id",
       "createdAt": "2025-09-04T18:54:58.378Z",
       "updatedAt": "2025-09-04T18:55:55.416Z"
+    },
+    {
+      "id": "test-with-llm-input-mocking",
+      "name": "Test with LLM input mocking",
+      "inputs": {},
+      "expectedOutput": {
+        "result": 35
+      },
+      "expectedAgentBehavior": "",
+      "inputMockingStrategy": {
+        "prompt": "Generate a multiplication calculation where the first number is 5 and the second number is 7",
+        "model": {
+          "model": "gpt-4o-mini-2024-07-18",
+          "temperature": 0.3
+        }
+      },
+      "evalSetId": "default-eval-set-id",
+      "createdAt": "2025-09-04T18:54:58.378Z",
+      "updatedAt": "2025-09-04T18:55:55.416Z"
     }
   ],
   "modelSettings": [],

--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -142,6 +142,10 @@ class LegacyEvaluationItem(BaseModel):
         default=None,
         alias="mockingStrategy",
     )
+    input_mocking_strategy: Optional[InputMockingStrategy] = Field(
+        default=None,
+        alias="inputMockingStrategy",
+    )
 
 
 class EvaluationSet(BaseModel):

--- a/tests/cli/eval/test_evaluate.py
+++ b/tests/cli/eval/test_evaluate.py
@@ -5,6 +5,7 @@ from uipath._cli._evals._evaluate import evaluate
 from uipath._cli._evals._runtime import UiPathEvalContext
 from uipath._cli._runtime._contracts import UiPathRuntimeContext, UiPathRuntimeFactory
 from uipath._cli._runtime._runtime import UiPathRuntime
+from uipath._cli.models.runtime_schema import Entrypoint
 from uipath._events._event_bus import EventBus
 
 
@@ -18,12 +19,22 @@ async def test_evaluate():
     async def identity(input: Any) -> Any:
         return input
 
-    class MyFactory(UiPathRuntimeFactory[UiPathRuntime, UiPathRuntimeContext]):
+    class TestRuntime(UiPathRuntime):
+        async def get_entrypoint(self) -> Entrypoint:
+            return Entrypoint(
+                file_path="test.py",  # type: ignore[call-arg]
+                unique_id="test",
+                type="workflow",
+                input={"type": "object", "properties": {}},
+                output={"type": "object", "properties": {}},
+            )
+
+    class MyFactory(UiPathRuntimeFactory[TestRuntime, UiPathRuntimeContext]):
         def __init__(self):
             super().__init__(
-                UiPathRuntime,
+                TestRuntime,
                 UiPathRuntimeContext,
-                runtime_generator=lambda context: UiPathRuntime(
+                runtime_generator=lambda context: TestRuntime(
                     context, executor=identity
                 ),
             )

--- a/uv.lock
+++ b/uv.lock
@@ -2823,7 +2823,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.109"
+version = "2.1.111"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
This PR reads the input schema from `get_entrypoint()` to use for input mocking.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.111.dev1007392178",

  # Any version from PR
  "uipath>=2.1.111.dev1007390000,<2.1.111.dev1007400000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```