### PR TITLE
fix: add factory streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.95"
+version = "2.1.96"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -13,6 +13,7 @@ from uipath._cli._runtime._contracts import (
     UiPathBreakpointResult,
     UiPathRuntimeContext,
     UiPathRuntimeResult,
+    UiPathRuntimeStatus,
 )
 from uipath._events._events import UiPathAgentStateEvent
 
@@ -105,8 +106,7 @@ class ConsoleDebugBridge(UiPathDebugBridge):
 
     async def emit_execution_started(self, execution_id: str, **kwargs) -> None:
         """Print execution started."""
-        self.console.print("[green]▶ Started[/green] [dim]")
-        self.console.print()
+        self.console.print("[green]▶ START[/green] [dim]")
 
     async def emit_state_update(self, state_event: UiPathAgentStateEvent) -> None:
         """Print agent state update."""
@@ -144,20 +144,18 @@ class ConsoleDebugBridge(UiPathDebugBridge):
         """Print completion."""
         self.console.print()
 
-        status_upper = runtime_result.status.value.upper()
-        if status_upper == "SUCCESSFUL":
+        status: UiPathRuntimeStatus = runtime_result.status
+        if status == UiPathRuntimeStatus.SUCCESSFUL:
             color = "green"
-            symbol = "✓"
-        elif status_upper == "SUSPENDED":
+            symbol = "●"
+        elif status == UiPathRuntimeStatus.SUSPENDED:
             color = "yellow"
             symbol = "■"
         else:
             color = "blue"
             symbol = "●"
 
-        self.console.print(
-            f"[{color}]{symbol} Completed[/{color}] [bold]{status_upper}[/bold]"
-        )
+        self.console.print(f"[{color}]{symbol} END[/{color}]")
         if runtime_result.output:
             self._print_json(runtime_result.output, label="Output")
 
@@ -322,6 +320,7 @@ class SignalRDebugBridge(UiPathDebugBridge):
             "OnExecutionCompleted",
             {
                 "status": runtime_result.status,
+                "output": runtime_result.output,
             },
         )
 

--- a/src/uipath/_cli/_dev/_terminal/_components/_new.py
+++ b/src/uipath/_cli/_dev/_terminal/_components/_new.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Tuple, cast
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.reactive import reactive
-from textual.widgets import Button, Checkbox, Select, TabbedContent, TabPane, TextArea
+from textual.widgets import Button, Select, TabbedContent, TabPane, TextArea
 
 from ._json_input import JsonInput
 
@@ -48,7 +48,7 @@ class NewRunPanel(Container):
 
         self.entrypoints = data.get("entryPoints", [])
         self.entrypoint_paths = [ep["filePath"] for ep in self.entrypoints]
-
+        self.conversational = False
         self.selected_entrypoint = (
             self.entrypoint_paths[0] if self.entrypoint_paths else ""
         )
@@ -74,12 +74,6 @@ class NewRunPanel(Container):
                         id="entrypoint-select",
                         value=self.selected_entrypoint,
                         allow_blank=False,
-                    )
-
-                    yield Checkbox(
-                        "chat mode",
-                        value=False,
-                        id="conversational-toggle",
                     )
 
                     yield JsonInput(
@@ -114,16 +108,9 @@ class NewRunPanel(Container):
             mock_json_from_schema(ep.get("input", {})), indent=2
         )
 
-    async def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
-        """Hide JSON input if conversational is enabled."""
-        if event.checkbox.id == "conversational-toggle":
-            json_input = self.query_one("#json-input", TextArea)
-            json_input.display = not event.value
-
     def get_input_values(self) -> Tuple[str, str, bool]:
         json_input = self.query_one("#json-input", TextArea)
-        conversational = self.query_one("#conversational-toggle", Checkbox).value
-        return self.selected_entrypoint, json_input.text.strip(), conversational
+        return self.selected_entrypoint, json_input.text.strip(), self.conversational
 
     def reset_form(self):
         """Reset selection and JSON input to defaults."""

--- a/uv.lock
+++ b/uv.lock
@@ -2823,7 +2823,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.94"
+version = "2.1.95"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
## Description

This PR adds streaming support to the runtime factory pattern by implementing `stream()` and `stream_in_root_span()` methods, mirroring the existing execution methods. It also removes the conversational/chat mode toggle from the terminal UI and updates debug bridge output formatting.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.96.dev1007421943",

  # Any version from PR
  "uipath>=2.1.96.dev1007420000,<2.1.96.dev1007430000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```