### PR TITLE
feat: refactor runtime system for extensible multi-entrypoint support

### DIFF
--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -836,6 +836,14 @@ class UiPathRuntimeFactory(Generic[T, C]):
             return self.runtime_generator(context)
         return self.runtime_class.from_context(context)
 
+    def discover_all_runtimes(self) -> List[T]:
+        """Get a list of all available runtimes."""
+        return []
+
+    def get_runtime(self, entrypoint: str) -> Optional[T]:
+        """Get a specific runtime by entrypoint."""
+        return None
+
     async def execute(self, context: C) -> Optional[UiPathRuntimeResult]:
         """Execute runtime with context."""
         async with self.from_context(context) as runtime:

--- a/src/uipath/_cli/_runtime/_runtime_factory.py
+++ b/src/uipath/_cli/_runtime/_runtime_factory.py
@@ -1,21 +1,53 @@
+import os
+from typing import List, Optional
+
 from uipath._cli._runtime._contracts import (
-    UiPathBaseRuntime,
     UiPathRuntimeContext,
     UiPathRuntimeFactory,
 )
-from uipath._cli._runtime._runtime import UiPathScriptRuntime
+from uipath._cli._runtime._runtime import UiPathScriptRuntime, get_user_scripts
 
 
-def generate_runtime_factory() -> UiPathRuntimeFactory[
-    UiPathBaseRuntime, UiPathRuntimeContext
-]:
-    runtime_factory: UiPathRuntimeFactory[UiPathBaseRuntime, UiPathRuntimeContext] = (
-        UiPathRuntimeFactory(
+class UiPathScriptRuntimeFactory(
+    UiPathRuntimeFactory[UiPathScriptRuntime, UiPathRuntimeContext]
+):
+    """Factory for Python script runtimes."""
+
+    def __init__(self):
+        super().__init__(
             UiPathScriptRuntime,
             UiPathRuntimeContext,
             context_generator=lambda **kwargs: UiPathRuntimeContext.with_defaults(
                 **kwargs
             ),
         )
-    )
-    return runtime_factory
+
+    def discover_all_runtimes(self) -> List[UiPathScriptRuntime]:
+        """Get a list of all available Python script runtimes."""
+        scripts = get_user_scripts(os.getcwd())
+
+        runtimes = []
+        for script_path in scripts:
+            runtime = self._create_runtime(script_path)
+            if runtime:
+                runtimes.append(runtime)
+
+        return runtimes
+
+    def get_runtime(self, entrypoint: str) -> Optional[UiPathScriptRuntime]:
+        """Get runtime for a specific Python script."""
+        if not os.path.isabs(entrypoint):
+            script_path = os.path.abspath(entrypoint)
+        else:
+            script_path = entrypoint
+
+        if not os.path.isfile(script_path) or not script_path.endswith(".py"):
+            return None
+
+        return self._create_runtime(script_path)
+
+    def _create_runtime(self, script_path: str) -> Optional[UiPathScriptRuntime]:
+        """Create runtime instance for a script path."""
+        context = self.new_context(entrypoint=script_path)
+        runtime = self.from_context(context)
+        return runtime

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -12,7 +12,6 @@ from uipath._cli._evals._runtime import (
     UiPathEvalContext,
     UiPathEvalRuntime,
 )
-from uipath._cli._runtime._runtime_factory import generate_runtime_factory
 from uipath._cli._utils._constants import UIPATH_PROJECT_ID
 from uipath._cli._utils._folders import get_personal_workspace_key_async
 from uipath._cli.middlewares import Middlewares
@@ -138,7 +137,9 @@ def eval(
         asyncio.run(console_reporter.subscribe_to_eval_runtime_events(event_bus))
 
         try:
-            runtime_factory = generate_runtime_factory()
+            # Last one is the Python script runtime factory
+            runtime_factory = Middlewares._runtime_factories[-1]
+
             if eval_context.job_id:
                 runtime_factory.add_span_exporter(LlmOpsHttpExporter())
 

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import click
 
-from uipath._cli._runtime._runtime_factory import generate_runtime_factory
 from uipath._cli._utils._debug import setup_debugging
 from uipath.tracing import LlmOpsHttpExporter
 
@@ -106,7 +105,8 @@ def run(
         try:
 
             async def execute() -> None:
-                runtime_factory = generate_runtime_factory()
+                # Last one is the Python script runtime factory
+                runtime_factory = Middlewares._runtime_factories[-1]
                 context = runtime_factory.new_context(**context_args)
                 if context.job_id:
                     runtime_factory.add_span_exporter(LlmOpsHttpExporter())

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -66,11 +66,8 @@ class TestInit:
                 f.write("def main(input): return input")
 
             result = runner.invoke(cli, ["init"])
-            assert result.exit_code == 1
-            assert (
-                "Multiple python files found in the current directory" in result.output
-            )
-            assert "Please specify the entrypoint" in result.output
+            assert result.exit_code == 0
+            assert os.path.exists("uipath.json")
 
     def test_init_with_entrypoint(self, runner: CliRunner, temp_dir: str) -> None:
         """Test init with specified entrypoint."""
@@ -78,7 +75,7 @@ class TestInit:
             # Test with non-existent file
             result = runner.invoke(cli, ["init", "nonexistent.py"])
             assert result.exit_code == 1
-            assert "does not exist in the current directory" in result.output
+            assert "error" in result.output.lower()
 
             # Test with valid Python file
             with open("script.py", "w") as f:


### PR DESCRIPTION
This PR refactors the runtime architecture to support multiple entrypoints in a project and a pluggable runtime factory system using `Middlewares.register_runtime_factory()` to retrieve a generic runtime factory and updates init, run, and eval to use the new runtime factory.

The corresponding change in the langchain repo registers the runtime factory for langgraph scripts: https://github.com/UiPath/uipath-langchain-python/pull/231