### PR TITLE
Debug: Via RemoteDebug signalrHub in  orchestrator

### DIFF
--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -434,7 +434,8 @@ def get_remote_debug_bridge(context: UiPathRuntimeContext) -> UiPathDebugBridge:
     if not context.trace_context:
         raise ValueError("trace_context is required for remote debugging")
 
-    signalr_url = uipath_url + "/agenthub_/wsstunnel?jobId=" + context.job_id
+    signalr_url = f"{uipath_url.rstrip('/')}/orchestrator_/signalr/robotdebug?sessionId={context.job_id}"
+
     return SignalRDebugBridge(
         hub_url=signalr_url,
         access_token=os.environ.get("UIPATH_ACCESS_TOKEN"),


### PR DESCRIPTION
# Description
- Use orchestrator remote debugging hub.
- We need to add UIPATH_FOLDER_KEY.
- Test the connection via serverless with a studio web rpa project(we will not use this in production). 

# How to test
- Set a workspace with all python packages. just uipath-python is actually needed for this.
[Archive.zip](https://github.com/user-attachments/files/23064317/Archive.zip)
- Start debugging in studio web for an rpa project.
<img width="898" height="675" alt="image" src="https://github.com/user-attachments/assets/d94f5157-0e0f-4265-8bed-4a5e06abfc1b" />
- go to orchestrator personal workspace. Find the debugging job. Retrieve the session id
<img width="2138" height="491" alt="image" src="https://github.com/user-attachments/assets/3a76dcfd-a244-4e4e-bcb4-defcd3e7ec95" />
- override the debug configuration env UIPATH_JOB_KEY with the retrieved session id.
<img width="1387" height="600" alt="image" src="https://github.com/user-attachments/assets/4e44b652-1291-4739-afd6-faf5317223a3" />
- Start local/remote debugging configuration from workspace profile Debug: SignalRDebugBridge (uipath-python)
- put breakpoints in _bridge.py 
<img width="1617" height="655" alt="image" src="https://github.com/user-attachments/assets/9a79484c-49ab-4ab5-8fbe-023e075e7713" />

