### PR TITLE
fix: make get_entrypoint async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.109"
+version = "2.1.110"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -577,16 +577,14 @@ class UiPathBaseRuntime(ABC):
         runtime = cls(context)
         return runtime
 
-    @property
-    def get_binding_resources(self) -> List[BindingResource]:
+    async def get_binding_resources(self) -> List[BindingResource]:
         """Get binding resources for this runtime.
 
         Returns: A list of binding resources.
         """
         raise NotImplementedError()
 
-    @property
-    def get_entrypoint(self) -> Entrypoint:
+    async def get_entrypoint(self) -> Entrypoint:
         """Get entrypoint for this runtime.
 
         Returns: A entrypoint for this runtime.

--- a/src/uipath/_cli/_runtime/_runtime.py
+++ b/src/uipath/_cli/_runtime/_runtime.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import uuid
-from functools import cached_property
 from pathlib import Path
 from typing import Any, Awaitable, Callable, List, Optional, TypeVar
 
@@ -116,9 +115,8 @@ class UiPathScriptRuntime(UiPathRuntime):
         """Create runtime instance from context."""
         return UiPathScriptRuntime(context, context.entrypoint or "")
 
-    @cached_property
     @override
-    def get_binding_resources(self) -> List[BindingResource]:
+    async def get_binding_resources(self) -> List[BindingResource]:
         """Get binding resources for script runtime.
 
         Returns: A list of binding resources.
@@ -128,9 +126,8 @@ class UiPathScriptRuntime(UiPathRuntime):
         bindings = generate_bindings(script_path)
         return bindings.resources
 
-    @cached_property
     @override
-    def get_entrypoint(self) -> Entrypoint:
+    async def get_entrypoint(self) -> Entrypoint:
         working_dir = self.context.runtime_dir or os.getcwd()
         script_path = get_user_script(working_dir, entrypoint=self.context.entrypoint)
         if not script_path:

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -1,4 +1,5 @@
 # type: ignore
+import asyncio
 import importlib.resources
 import json
 import logging
@@ -218,15 +219,15 @@ def init(entrypoint: str, infer_bindings: bool, no_agents_md_override: bool) -> 
             "entrypoint": script_path,
         }
 
-        def initialize() -> None:
+        async def initialize() -> None:
             try:
                 runtime = generate_runtime_factory().new_runtime(**context_args)
                 bindings = Bindings(
                     version="2.0",
-                    resources=runtime.get_binding_resources,
+                    resources=await runtime.get_binding_resources(),
                 )
                 config_data = RuntimeSchema(
-                    entryPoints=[runtime.get_entrypoint],
+                    entryPoints=[await runtime.get_entrypoint()],
                     bindings=bindings,
                 )
                 config_path = write_config_file(config_data)
@@ -234,4 +235,4 @@ def init(entrypoint: str, infer_bindings: bool, no_agents_md_override: bool) -> 
             except Exception as e:
                 console.error(f"Error creating configuration file:\n {str(e)}")
 
-        initialize()
+        asyncio.run(initialize())


### PR DESCRIPTION
Best to make the change to avoid threading hackery here: https://github.com/UiPath/uipath-langchain-python/pull/231

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.110.dev1007822171",

  # Any version from PR
  "uipath>=2.1.110.dev1007820000,<2.1.110.dev1007830000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```