### PR TITLE
fix: debug step by step interrupt

### DIFF
--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -382,7 +382,7 @@ class UiPathRuntimeContext(BaseModel):
     log_handler: Optional[logging.Handler] = None
     chat_handler: Optional[UiPathConversationHandler] = None
     is_conversational: Optional[bool] = None
-    breakpoints: Optional[List[str]] = None
+    breakpoints: Optional[List[str] | Literal["*"]] = None
 
     model_config = {"arbitrary_types_allowed": True, "extra": "allow"}
 


### PR DESCRIPTION
## Description

This PR fixes debug step-by-step interrupt functionality by improving breakpoint handling and error reporting in the debugger.

Key changes:

- Changed breakpoint type to allow a wildcard `"*"` value for step mode instead of returning a list `["*"]`
- Improved error handling and execution id management in the debug runtime
- Fixed command parsing to reset step mode when continuing and properly handle quit commands