### PR TITLE
feat(ReturnAgentExecution): return agent execution details as part of evaluation output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.112"
+version = "2.1.113"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/samples/calculator/evals/eval-sets/legacy.json
+++ b/samples/calculator/evals/eval-sets/legacy.json
@@ -21,7 +21,7 @@
       "expectedOutput": {
         "result": 2
       },
-      "expectedAgentBehavior": "",
+      "expectedAgentBehavior": "The operation should produce the right output.",
       "evalSetId": "default-eval-set-id",
       "createdAt": "2025-09-04T18:54:58.378Z",
       "updatedAt": "2025-09-04T18:55:55.416Z"
@@ -37,7 +37,7 @@
       "expectedOutput": {
         "result": 2
       },
-      "expectedAgentBehavior": "",
+      "expectedAgentBehavior": "The operation should produce the right output.",
       "mockingStrategy": {
         "type": "mockito",
         "behaviors": [
@@ -73,7 +73,7 @@
       "expectedOutput": {
         "result": 2
       },
-      "expectedAgentBehavior": "",
+      "expectedAgentBehavior": "The operation should produce the right output.",
       "mockingStrategy": {
         "type": "llm",
         "prompt": "The random operator is '+'.",
@@ -98,7 +98,7 @@
       "expectedOutput": {
         "result": 35
       },
-      "expectedAgentBehavior": "",
+      "expectedAgentBehavior": "The operation should produce the right output.",
       "inputMockingStrategy": {
         "prompt": "Generate a multiplication calculation where the first number is 5 and the second number is 7",
         "model": {

--- a/samples/calculator/evals/evaluators/legacy-trajectory.json
+++ b/samples/calculator/evals/evaluators/legacy-trajectory.json
@@ -6,7 +6,7 @@
   "category": 3,
   "type": 7,
   "prompt": "Evaluate the agent's execution trajectory based on the expected behavior.\n\nExpected Agent Behavior: {{ExpectedAgentBehavior}}\nAgent Run History: {{AgentRunHistory}}\n\nProvide a score from 0-100 based on how well the agent followed the expected trajectory.",
-  "model": "gpt-4o-mini",
+  "model": "gpt-4.1-2025-04-14",
   "targetOutputKey": "*",
   "createdAt": "2025-06-26T17:45:39.651Z",
   "updatedAt": "2025-06-26T17:45:39.651Z"

--- a/tests/cli/eval/test_evaluate.py
+++ b/tests/cli/eval/test_evaluate.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 
 from uipath._cli._evals._evaluate import evaluate
+from uipath._cli._evals._models._output import UiPathEvalOutput
 from uipath._cli._evals._runtime import UiPathEvalContext
 from uipath._cli._runtime._contracts import UiPathRuntimeContext, UiPathRuntimeFactory
 from uipath._cli._runtime._runtime import UiPathRuntime
@@ -42,11 +43,18 @@ async def test_evaluate():
     # Act
     result = await evaluate(MyFactory(), context, event_bus)
 
-    # Assert
+    # Assert that the output is json-serializable
+    UiPathEvalOutput.model_validate(result.output).model_dump_json()
     assert result.output
     assert (
         result.output["evaluationSetResults"][0]["evaluationRunResults"][0]["result"][
             "score"
         ]
         == 100.0
+    )
+    assert (
+        result.output["evaluationSetResults"][0]["evaluationRunResults"][0][
+            "evaluatorId"
+        ]
+        == "equality"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2823,7 +2823,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.111"
+version = "2.1.113"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Specifically,
1. adding `agent_execution_output` to `EvaluationRunResult`
2. keeping `evaluatorId` in `EvaluationRunResultDto`, so that the object can be reconstructed after serialization.
3. refactored entrypoint to be a cached property so that it's evaluated lazily.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.113.dev1007872222",

  # Any version from PR
  "uipath>=2.1.113.dev1007870000,<2.1.113.dev1007880000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```