### PR TITLE
fix: add missing runtime error status

### DIFF
--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -536,6 +536,7 @@ class UiPathRuntimeError(UiPathBaseRuntimeError):
         title: str,
         detail: str,
         category: UiPathErrorCategory = UiPathErrorCategory.UNKNOWN,
+        status: Optional[int] = None,
         prefix: str = "Python",
         include_traceback: bool = True,
     ):
@@ -544,6 +545,7 @@ class UiPathRuntimeError(UiPathBaseRuntimeError):
             title=title,
             detail=detail,
             category=category,
+            status=status,
             prefix=prefix,
             include_traceback=include_traceback,
         )


### PR DESCRIPTION
## Description

This PR adds a missing status parameter to the `__init__` method of the runtime error class, allowing callers to specify an optional HTTP status code when creating error instances.

- Added optional status parameter to error initialization
- Bumped package version from 2.1.111 to 2.1.112