### PR TITLE
feat: add get/list files to bucket service

### DIFF
--- a/tests/sdk/services/test_buckets_service.py
+++ b/tests/sdk/services/test_buckets_service.py
@@ -273,3 +273,697 @@ class TestBucketsService:
             assert sent_requests[2].method == "PUT"
             assert sent_requests[2].url == "https://test-storage.com/test-file.txt"
             assert sent_requests[2].content == b"test content"
+
+    class TestGetFiles:
+        def test_get_files_by_key(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles",
+                status_code=200,
+                json={
+                    "value": [
+                        {"FullPath": "file1.txt", "IsDirectory": False},
+                        {"FullPath": "file2.pdf", "IsDirectory": False},
+                        {"FullPath": "subfolder/", "IsDirectory": True},
+                        {"FullPath": "subfolder/file3.doc", "IsDirectory": False},
+                    ]
+                },
+            )
+
+            files = service.get_files(key=bucket_key)
+            assert len(files) == 3
+            assert "file1.txt" in files
+            assert "file2.pdf" in files
+            assert "subfolder/file3.doc" in files
+            assert "subfolder/" not in files
+
+        def test_get_files_by_name(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_name = "test-bucket"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets?$filter=Name eq '{bucket_name}'&$top=1",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles",
+                status_code=200,
+                json={
+                    "value": [
+                        {"FullPath": "file1.txt", "IsDirectory": False},
+                        {"FullPath": "file2.pdf", "IsDirectory": False},
+                    ]
+                },
+            )
+
+            files = service.get_files(name=bucket_name)
+            assert len(files) == 2
+            assert "file1.txt" in files
+            assert "file2.pdf" in files
+
+        def test_get_files_with_prefix(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            prefix = "documents/"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles?directory={prefix}",
+                status_code=200,
+                json={
+                    "value": [
+                        {"FullPath": "documents/report.pdf", "IsDirectory": False},
+                        {"FullPath": "documents/invoice.pdf", "IsDirectory": False},
+                        {"FullPath": "documents/archive/", "IsDirectory": True},
+                    ]
+                },
+            )
+
+            files = service.get_files(key=bucket_key, prefix=prefix)
+            assert len(files) == 2
+            assert "documents/report.pdf" in files
+            assert "documents/invoice.pdf" in files
+            assert "documents/archive/" not in files
+
+        def test_get_files_empty_bucket(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles",
+                status_code=200,
+                json={"value": []},
+            )
+
+            files = service.get_files(key=bucket_key)
+            assert len(files) == 0
+            assert files == []
+
+        @pytest.mark.asyncio
+        async def test_get_files_by_key_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles",
+                status_code=200,
+                json={
+                    "value": [
+                        {"FullPath": "file1.txt", "IsDirectory": False},
+                        {"FullPath": "file2.pdf", "IsDirectory": False},
+                        {"FullPath": "subfolder/", "IsDirectory": True},
+                        {"FullPath": "subfolder/file3.doc", "IsDirectory": False},
+                    ]
+                },
+            )
+
+            files = await service.get_files_async(key=bucket_key)
+            assert len(files) == 3
+            assert "file1.txt" in files
+            assert "file2.pdf" in files
+            assert "subfolder/file3.doc" in files
+            assert "subfolder/" not in files
+
+        @pytest.mark.asyncio
+        async def test_get_files_by_name_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_name = "test-bucket"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets?$filter=Name eq '{bucket_name}'&$top=1",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles",
+                status_code=200,
+                json={
+                    "value": [
+                        {"FullPath": "file1.txt", "IsDirectory": False},
+                        {"FullPath": "file2.pdf", "IsDirectory": False},
+                    ]
+                },
+            )
+
+            files = await service.get_files_async(name=bucket_name)
+            assert len(files) == 2
+            assert "file1.txt" in files
+            assert "file2.pdf" in files
+
+        @pytest.mark.asyncio
+        async def test_get_files_with_prefix_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            prefix = "documents/"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles?directory={prefix}",
+                status_code=200,
+                json={
+                    "value": [
+                        {"FullPath": "documents/report.pdf", "IsDirectory": False},
+                        {"FullPath": "documents/invoice.pdf", "IsDirectory": False},
+                        {"FullPath": "documents/archive/", "IsDirectory": True},
+                    ]
+                },
+            )
+
+            files = await service.get_files_async(key=bucket_key, prefix=prefix)
+            assert len(files) == 2
+            assert "documents/report.pdf" in files
+            assert "documents/invoice.pdf" in files
+            assert "documents/archive/" not in files
+
+        @pytest.mark.asyncio
+        async def test_get_files_empty_bucket_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets(123)/UiPath.Server.Configuration.OData.GetFiles",
+                status_code=200,
+                json={"value": []},
+            )
+
+            files = await service.get_files_async(key=bucket_key)
+            assert len(files) == 0
+            assert files == []
+
+    class TestListFiles:
+        def test_list_files_by_key(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "file1.txt", "size": 1024},
+                        {"fullPath": "file2.pdf", "size": 2048},
+                        {"fullPath": "subfolder/file3.doc", "size": 512},
+                    ],
+                    "continuationToken": None,
+                },
+            )
+
+            result = service.list_files(key=bucket_key)
+            assert isinstance(result, dict)
+            assert "files" in result
+            assert "continuation_token" in result
+            assert len(result["files"]) == 3
+            assert "file1.txt" in result["files"]
+            assert "file2.pdf" in result["files"]
+            assert "subfolder/file3.doc" in result["files"]
+            assert result["continuation_token"] is None
+
+        def test_list_files_by_name(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_name = "test-bucket"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets?$filter=Name eq '{bucket_name}'&$top=1",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "file1.txt"},
+                        {"fullPath": "file2.pdf"},
+                    ],
+                    "continuationToken": None,
+                },
+            )
+
+            result = service.list_files(name=bucket_name)
+            assert len(result["files"]) == 2
+            assert "file1.txt" in result["files"]
+            assert "file2.pdf" in result["files"]
+
+        def test_list_files_with_prefix(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            prefix = "documents/"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles?prefix={prefix}",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "documents/report.pdf"},
+                        {"fullPath": "documents/invoice.pdf"},
+                    ],
+                    "continuationToken": None,
+                },
+            )
+
+            result = service.list_files(key=bucket_key, prefix=prefix)
+            assert len(result["files"]) == 2
+            assert "documents/report.pdf" in result["files"]
+            assert "documents/invoice.pdf" in result["files"]
+
+        def test_list_files_with_continuation_token(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            continuation_token = "token-123"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles?continuationToken={continuation_token}",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "file10.txt"},
+                        {"fullPath": "file11.pdf"},
+                    ],
+                    "continuationToken": "token-456",
+                },
+            )
+
+            result = service.list_files(key=bucket_key, continuation_token=continuation_token)
+            assert len(result["files"]) == 2
+            assert "file10.txt" in result["files"]
+            assert "file11.pdf" in result["files"]
+            assert result["continuation_token"] == "token-456"
+
+        def test_list_files_with_take_hint(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            take_hint = 100
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles?takeHint={take_hint}",
+                status_code=200,
+                json={
+                    "items": [{"fullPath": f"file{i}.txt"} for i in range(100)],
+                    "continuationToken": "next-token",
+                },
+            )
+
+            result = service.list_files(key=bucket_key, take_hint=take_hint)
+            assert len(result["files"]) == 100
+            assert result["continuation_token"] == "next-token"
+
+        def test_list_files_empty_bucket(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles",
+                status_code=200,
+                json={"items": [], "continuationToken": None},
+            )
+
+            result = service.list_files(key=bucket_key)
+            assert len(result["files"]) == 0
+            assert result["files"] == []
+            assert result["continuation_token"] is None
+
+        @pytest.mark.asyncio
+        async def test_list_files_by_key_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "file1.txt", "size": 1024},
+                        {"fullPath": "file2.pdf", "size": 2048},
+                        {"fullPath": "subfolder/file3.doc", "size": 512},
+                    ],
+                    "continuationToken": None,
+                },
+            )
+
+            result = await service.list_files_async(key=bucket_key)
+            assert isinstance(result, dict)
+            assert "files" in result
+            assert "continuation_token" in result
+            assert len(result["files"]) == 3
+            assert "file1.txt" in result["files"]
+            assert "file2.pdf" in result["files"]
+            assert "subfolder/file3.doc" in result["files"]
+            assert result["continuation_token"] is None
+
+        @pytest.mark.asyncio
+        async def test_list_files_by_name_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_name = "test-bucket"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets?$filter=Name eq '{bucket_name}'&$top=1",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "file1.txt"},
+                        {"fullPath": "file2.pdf"},
+                    ],
+                    "continuationToken": None,
+                },
+            )
+
+            result = await service.list_files_async(name=bucket_name)
+            assert len(result["files"]) == 2
+            assert "file1.txt" in result["files"]
+            assert "file2.pdf" in result["files"]
+
+        @pytest.mark.asyncio
+        async def test_list_files_with_prefix_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            prefix = "documents/"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles?prefix={prefix}",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "documents/report.pdf"},
+                        {"fullPath": "documents/invoice.pdf"},
+                    ],
+                    "continuationToken": None,
+                },
+            )
+
+            result = await service.list_files_async(key=bucket_key, prefix=prefix)
+            assert len(result["files"]) == 2
+            assert "documents/report.pdf" in result["files"]
+            assert "documents/invoice.pdf" in result["files"]
+
+        @pytest.mark.asyncio
+        async def test_list_files_with_continuation_token_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            continuation_token = "token-123"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles?continuationToken={continuation_token}",
+                status_code=200,
+                json={
+                    "items": [
+                        {"fullPath": "file10.txt"},
+                        {"fullPath": "file11.pdf"},
+                    ],
+                    "continuationToken": "token-456",
+                },
+            )
+
+            result = await service.list_files_async(
+                key=bucket_key, continuation_token=continuation_token
+            )
+            assert len(result["files"]) == 2
+            assert "file10.txt" in result["files"]
+            assert "file11.pdf" in result["files"]
+            assert result["continuation_token"] == "token-456"
+
+        @pytest.mark.asyncio
+        async def test_list_files_empty_bucket_async(
+            self,
+            httpx_mock: HTTPXMock,
+            service: BucketsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ):
+            bucket_key = "bucket-key"
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets/UiPath.Server.Configuration.OData.GetByKey(identifier={bucket_key})",
+                status_code=200,
+                json={
+                    "value": [
+                        {"Id": 123, "Name": "test-bucket", "Identifier": "bucket-key"}
+                    ]
+                },
+            )
+
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/orchestrator_/api/Buckets/123/ListFiles",
+                status_code=200,
+                json={"items": [], "continuationToken": None},
+            )
+
+            result = await service.list_files_async(key=bucket_key)
+            assert len(result["files"]) == 0
+            assert result["files"] == []
+            assert result["continuation_token"] is None


### PR DESCRIPTION
Adding 2 new functions to bucker service
1. Get Files/Get Files Async
2. List Files/List Files Async

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.114.dev1007942234",

  # Any version from PR
  "uipath>=2.1.114.dev1007940000,<2.1.114.dev1007950000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```