### PR TITLE
feat(JITMetadata): dynamic JIT fetching for connections api metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.126"
+version = "2.1.127"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/models/connections.py
+++ b/src/uipath/models/connections.py
@@ -8,6 +8,7 @@ class ConnectionMetadata(BaseModel):
     """Metadata about a connection."""
 
     fields: dict[str, Any] = Field(default_factory=dict, alias="fields")
+    metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3047,7 +3047,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.126"
+version = "2.1.127"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
This PR adds dynamic just-in-time (JIT) metadata retrieval for the integration service connection, based on the [typescript implementation](https://github.com/UiPath/Agents/blob/ef030f2bc7ff2a52b0322a94f11f7cd31ab17567/frontend-sw/src/api/hooks/integration-service/external.ts#L156). This allows the schema to be dynamically determined from the input parameters.

How it works:

1. Initial metadata fetch: calls `/elements_/v3/element/instances/{id}/elements/{connector_key}/objects/{tool_path}/metadata` and parse into a `ConnectionMetadata` model (existing code).
2. If no parameters are provided, then return this static metadata.
3. Detect JIT trigger: look for a JIT action in the metadata (actionType == "api") and extract the dynamic URL containing placeholder fields like "/elements/uipath-atlassian-jira/objects/curated_create_issue/metadata?projectKey={fields.project.key}..."
4. Substitute parameter values into these placeholders, hit the JIT endpoint with dynamic params, and parse it into a final `ConnectionMetadata` model.

Testing - verified that the following metadata query to the Create Jira Ticket tool correctly includes all the custom fields.

```
metadata = await sdk.connections.metadata_async(
    element_instance_id=274403,
    connector_key="uipath-atlassian-jira",
    tool_path="curated_create_issue",
    schema_mode=True,
    parameters={"fields.issuetype.id": "10004", "fields.project.key": "KAN"},
)
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.127.dev1007962398",

  # Any version from PR
  "uipath>=2.1.127.dev1007960000,<2.1.127.dev1007970000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```