### PR TITLE
feat(SupportNonRecordingTraces): support non-recording traces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.121"
+version = "2.1.122"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_evals/mocks/input_mocker.py
+++ b/src/uipath/_cli/_evals/mocks/input_mocker.py
@@ -52,7 +52,7 @@ Based on the above information, provide a realistic input to the LLM agent. Your
 OUTPUT: ONLY the simulated agent input in the exact format of the INPUT_SCHEMA in valid JSON. Do not include any explanations, quotation marks, or markdown."""
 
 
-@traced(name="__mocker__")
+@traced(name="__mocker__", recording=False)
 async def generate_llm_input(
     evaluation_item: AnyEvaluationItem,
     input_schema: Dict[str, Any],

--- a/src/uipath/_cli/_evals/mocks/llm_mocker.py
+++ b/src/uipath/_cli/_evals/mocks/llm_mocker.py
@@ -82,7 +82,7 @@ class LLMMocker(Mocker):
         self.evaluation_item = evaluation_item
         assert isinstance(self.evaluation_item.mocking_strategy, LLMMockingStrategy)
 
-    @traced(name="__mocker__")
+    @traced(name="__mocker__", recording=False)
     async def response(
         self, func: Callable[[T], R], params: dict[str, Any], *args: T, **kwargs
     ) -> R:

--- a/src/uipath/tracing/_utils.py
+++ b/src/uipath/tracing/_utils.py
@@ -365,33 +365,11 @@ class _SpanUtils:
             return {"args": args, "kwargs": kwargs}
 
     @staticmethod
-    def _has_ancestor_with_name(
-        span: ReadableSpan, ancestor_name: str, span_map: Dict[int, ReadableSpan]
-    ) -> bool:
-        """Check if this span or any of its ancestors has a given name."""
-        if span.name == ancestor_name:
-            return True
-
-        current = span
-        while current.parent is not None:
-            parent_span = span_map.get(current.parent.span_id)
-            if parent_span is None:
-                break
-            if parent_span.name == ancestor_name:
-                return True
-            current = parent_span
-
-        return False
-
-    @staticmethod
     def spans_to_llm_context(spans: list[ReadableSpan]) -> str:
         """Convert spans to a formatted conversation history string suitable for LLM context.
 
         Includes function calls (including LLM calls) with their inputs and outputs.
         """
-        # Build span_id -> span map for parent chain traversal
-        span_map = {span.get_span_context().span_id: span for span in spans}
-
         history = []
         for span in spans:
             attributes = dict(span.attributes) if span.attributes else {}
@@ -400,10 +378,6 @@ class _SpanUtils:
             output_value = attributes.get("output.value")
 
             if not input_value or not output_value:
-                continue
-
-            # Skip spans that are internal LLM calls (eg. for tool mocking in evals)
-            if _SpanUtils._has_ancestor_with_name(span, "__mocker__", span_map):
                 continue
 
             history.append(f"Function: {span.name}")

--- a/uv.lock
+++ b/uv.lock
@@ -3047,7 +3047,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.121"
+version = "2.1.122"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Customers can disable tracing in spans by using recording flag. Children of NonRecordingSpans are also NonRecording. By taking this approach, LLM judges do not see mocking internal spans.

To use this, just mark the traced attribute with `recording=False`.

```
@traced(name="bar", recording=True)
def bar():
    return

@traced(name="foo", recording=False)
def foo():
    bar()
```

If a method invokes `foo()`, none of the traces (neither `foo` nor `bar`) will be captured.


## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.122.dev1008032340",

  # Any version from PR
  "uipath>=2.1.122.dev1008030000,<2.1.122.dev1008040000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```