### PR TITLE
feat: save bindings to a dedicated file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.133"
+version = "2.1.134"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -39,7 +39,7 @@ from uipath._events._events import UiPathRuntimeEvent
 from uipath.agent.conversation import UiPathConversationEvent, UiPathConversationMessage
 from uipath.tracing import TracingManager
 
-from ..models.runtime_schema import BindingResource, Entrypoint
+from ..models.runtime_schema import Bindings, Entrypoint
 from ._logging import LogsInterceptor
 
 logger = logging.getLogger(__name__)
@@ -581,10 +581,10 @@ class UiPathBaseRuntime(ABC):
         runtime = cls(context)
         return runtime
 
-    async def get_binding_resources(self) -> List[BindingResource]:
+    async def get_bindings(self) -> Bindings:
         """Get binding resources for this runtime.
 
-        Returns: A list of binding resources.
+        Returns: A bindings object.
         """
         raise NotImplementedError()
 

--- a/src/uipath/_cli/_runtime/_runtime.py
+++ b/src/uipath/_cli/_runtime/_runtime.py
@@ -4,14 +4,14 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Awaitable, Callable, List, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 from typing_extensions import override
 
 from .._utils._console import ConsoleLogger
 from .._utils._input_args import generate_args
 from .._utils._parse_ast import generate_bindings  # type: ignore[attr-defined]
-from ..models.runtime_schema import BindingResource, Entrypoint
+from ..models.runtime_schema import Bindings, Entrypoint
 from ._contracts import (
     UiPathBaseRuntime,
     UiPathErrorCategory,
@@ -116,15 +116,15 @@ class UiPathScriptRuntime(UiPathRuntime):
         return UiPathScriptRuntime(context, context.entrypoint or "")
 
     @override
-    async def get_binding_resources(self) -> List[BindingResource]:
+    async def get_bindings(self) -> Bindings:
         """Get binding resources for script runtime.
 
-        Returns: A list of binding resources.
+        Returns: A bindings object.
         """
         working_dir = self.context.runtime_dir or os.getcwd()
         script_path = get_user_script(working_dir, entrypoint=self.context.entrypoint)
         bindings = generate_bindings(script_path)
-        return bindings.resources
+        return bindings
 
     @override
     async def get_entrypoint(self) -> Entrypoint:

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -141,7 +141,6 @@ async def read_resource_overwrites_from_file(
                 .get("internalArguments", {})
                 .get("resourceOverwrites", {})
             )
-
             for key, value in resource_overwrites.items():
                 overwrite = ResourceOverwrite.model_validate(value)
                 overwrites_dict[key] = overwrite

--- a/src/uipath/_cli/_utils/_parse_ast.py
+++ b/src/uipath/_cli/_utils/_parse_ast.py
@@ -1,10 +1,12 @@
 # type: ignore
 
 import ast
+import json
 import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..._config import UiPathConfig
 from ..._services import (
     AssetsService,
     BucketsService,
@@ -481,7 +483,7 @@ def convert_to_bindings_format(sdk_usage_data) -> Bindings:
             folder_path = folder_path.replace("EXPR$", "") if folder_path else None
             key = name
             if folder_path:
-                key = f"{folder_path}.{name}"
+                key = f"{name}.{folder_path}"
             resource_entry = BindingResource(
                 resource=service_name_resource_mapping[resource_type],
                 key=key,
@@ -556,6 +558,22 @@ def generate_bindings(file_path: str) -> Bindings:
         bindings = convert_to_bindings_format(sdk_usage)
 
         return bindings
-
     except Exception as e:
         raise Exception(f"Error generating bindings JSON: {e}") from e
+
+
+def write_bindings_file(bindings: Bindings) -> str:
+    """Write bindings to a JSON file.
+
+    Args:
+        bindings: The Bindings object to write to file
+
+    Returns:
+        str: The path to the written bindings file
+    """
+    bindings_file_path = UiPathConfig.bindings_file_path
+    with open(bindings_file_path, "w") as bindings_file:
+        json_object = bindings.model_dump(by_alias=True, exclude_unset=True)
+        json.dump(json_object, bindings_file, indent=4)
+
+    return bindings_file_path

--- a/src/uipath/_cli/cli_pack.py
+++ b/src/uipath/_cli/cli_pack.py
@@ -211,13 +211,21 @@ def pack_fn(
     operate_file = generate_operate_file(entryPoints, dependencies)
     entrypoints_file = generate_entrypoints_file(entryPoints)
 
-    # Get bindings from uipath.json if available
     config_path = os.path.join(directory, "uipath.json")
     if not os.path.exists(config_path):
         console.error("uipath.json not found, please run `uipath init`.")
 
     with open(config_path, "r") as f:
         config_data = TypeAdapter(RuntimeSchema).validate_python(json.load(f))
+
+    # for backwards compatibility. should be removed
+    if not len(config_data.bindings.resources):
+        # try to read bindings from bindings.json
+        bindings_path = os.path.join(directory, str(UiPathConfig.bindings_file_path))
+        if os.path.exists(bindings_path):
+            with open(bindings_path, "r") as f:
+                bindings_data = TypeAdapter(Bindings).validate_python(json.load(f))
+                config_data.bindings = bindings_data
 
     content_types_content = generate_content_types_content()
     [psmdcp_file_name, psmdcp_content] = generate_psmdcp_content(

--- a/src/uipath/_cli/models/runtime_schema.py
+++ b/src/uipath/_cli/models/runtime_schema.py
@@ -63,7 +63,9 @@ class RuntimeArguments(BaseModel):
 class RuntimeSchema(BaseModel):
     runtime: Optional[RuntimeArguments] = Field(default=None, alias="runtime")
     entrypoints: List[Entrypoint] = Field(..., alias="entryPoints")
-    bindings: Bindings = Field(
+
+    # left for backward compatibility with uipath-langchain and uipath-llamaindex libraries. should be removed on major release
+    bindings: Optional[Bindings] = Field(
         default=Bindings(version="2.0", resources=[]), alias="bindings"
     )
     settings: Optional[Dict[str, Any]] = Field(default=None, alias="setting")

--- a/src/uipath/_services/assets_service.py
+++ b/src/uipath/_services/assets_service.py
@@ -5,7 +5,7 @@ from httpx import Response
 from .._config import Config
 from .._execution_context import ExecutionContext
 from .._folder_context import FolderContext
-from .._utils import Endpoint, RequestSpec, header_folder, infer_bindings
+from .._utils import Endpoint, RequestSpec, header_folder, resource_override
 from ..models import Asset, UserAsset
 from ..tracing._traced import traced
 from ._base_service import BaseService
@@ -25,7 +25,7 @@ class AssetsService(FolderContext, BaseService):
     @traced(
         name="assets_retrieve", run_type="uipath", hide_input=True, hide_output=True
     )
-    @infer_bindings(resource_type="asset")
+    @resource_override(resource_type="asset")
     def retrieve(
         self,
         name: str,
@@ -81,7 +81,7 @@ class AssetsService(FolderContext, BaseService):
     @traced(
         name="assets_retrieve", run_type="uipath", hide_input=True, hide_output=True
     )
-    @infer_bindings(resource_type="asset")
+    @resource_override(resource_type="asset")
     async def retrieve_async(
         self,
         name: str,
@@ -128,7 +128,7 @@ class AssetsService(FolderContext, BaseService):
     @traced(
         name="assets_credential", run_type="uipath", hide_input=True, hide_output=True
     )
-    @infer_bindings(resource_type="asset")
+    @resource_override(resource_type="asset")
     def retrieve_credential(
         self,
         name: str,
@@ -183,7 +183,7 @@ class AssetsService(FolderContext, BaseService):
     @traced(
         name="assets_credential", run_type="uipath", hide_input=True, hide_output=True
     )
-    @infer_bindings(resource_type="asset")
+    @resource_override(resource_type="asset")
     async def retrieve_credential_async(
         self,
         name: str,

--- a/src/uipath/_services/buckets_service.py
+++ b/src/uipath/_services/buckets_service.py
@@ -9,7 +9,7 @@ import httpx
 from .._config import Config
 from .._execution_context import ExecutionContext
 from .._folder_context import FolderContext
-from .._utils import Endpoint, RequestSpec, header_folder, infer_bindings
+from .._utils import Endpoint, RequestSpec, header_folder, resource_override
 from .._utils._ssl_context import get_httpx_client_kwargs
 from ..models import Bucket, BucketFile
 from ..tracing._traced import traced
@@ -259,7 +259,7 @@ class BucketsService(FolderContext, BaseService):
         return bucket
 
     @traced(name="buckets_delete", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def delete(
         self,
         *,
@@ -294,7 +294,7 @@ class BucketsService(FolderContext, BaseService):
         )
 
     @traced(name="buckets_delete", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def delete_async(
         self,
         *,
@@ -315,7 +315,7 @@ class BucketsService(FolderContext, BaseService):
         )
 
     @traced(name="buckets_download", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def download(
         self,
         *,
@@ -370,7 +370,7 @@ class BucketsService(FolderContext, BaseService):
             file.write(file_content)
 
     @traced(name="buckets_download", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def download_async(
         self,
         *,
@@ -431,7 +431,7 @@ class BucketsService(FolderContext, BaseService):
         await asyncio.to_thread(Path(destination_path).write_bytes, file_content)
 
     @traced(name="buckets_upload", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def upload(
         self,
         *,
@@ -523,7 +523,7 @@ class BucketsService(FolderContext, BaseService):
                     )
 
     @traced(name="buckets_upload", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def upload_async(
         self,
         *,
@@ -620,7 +620,7 @@ class BucketsService(FolderContext, BaseService):
                 )
 
     @traced(name="buckets_retrieve", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def retrieve(
         self,
         *,
@@ -695,7 +695,7 @@ class BucketsService(FolderContext, BaseService):
         return bucket
 
     @traced(name="buckets_retrieve", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def retrieve_async(
         self,
         *,
@@ -774,7 +774,7 @@ class BucketsService(FolderContext, BaseService):
         return bucket
 
     @traced(name="buckets_list_files", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def list_files(
         self,
         *,
@@ -837,7 +837,7 @@ class BucketsService(FolderContext, BaseService):
                 break
 
     @traced(name="buckets_list_files", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def list_files_async(
         self,
         *,
@@ -902,7 +902,7 @@ class BucketsService(FolderContext, BaseService):
                 break
 
     @traced(name="buckets_exists_file", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def exists_file(
         self,
         *,
@@ -961,7 +961,7 @@ class BucketsService(FolderContext, BaseService):
         return False
 
     @traced(name="buckets_exists_file", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def exists_file_async(
         self,
         *,
@@ -1009,7 +1009,7 @@ class BucketsService(FolderContext, BaseService):
         return False
 
     @traced(name="buckets_delete_file", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def delete_file(
         self,
         *,
@@ -1045,7 +1045,7 @@ class BucketsService(FolderContext, BaseService):
         )
 
     @traced(name="buckets_delete_file", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def delete_file_async(
         self,
         *,
@@ -1081,7 +1081,7 @@ class BucketsService(FolderContext, BaseService):
         )
 
     @traced(name="buckets_get_files", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     def get_files(
         self,
         *,
@@ -1189,7 +1189,7 @@ class BucketsService(FolderContext, BaseService):
             skip += top
 
     @traced(name="buckets_get_files", run_type="uipath")
-    @infer_bindings(resource_type="bucket")
+    @resource_override(resource_type="bucket")
     async def get_files_async(
         self,
         *,

--- a/src/uipath/_services/connections_service.py
+++ b/src/uipath/_services/connections_service.py
@@ -7,7 +7,7 @@ from httpx import Response
 
 from .._config import Config
 from .._execution_context import ExecutionContext
-from .._utils import Endpoint, RequestSpec, header_folder, infer_bindings
+from .._utils import Endpoint, RequestSpec, header_folder, resource_override
 from ..models import Connection, ConnectionMetadata, ConnectionToken, EventArguments
 from ..models.connections import ConnectionTokenType
 from ..tracing._traced import traced
@@ -401,7 +401,7 @@ class ConnectionsService(BaseService):
         name="connections_retrieve_event_payload",
         run_type="uipath",
     )
-    @infer_bindings(resource_type="ignored", ignore=True)
+    @resource_override(resource_type="ignored", ignore=True)
     def retrieve_event_payload(self, event_args: EventArguments) -> Dict[str, Any]:
         """Retrieve event payload from UiPath Integration Service.
 
@@ -436,7 +436,7 @@ class ConnectionsService(BaseService):
         name="connections_retrieve_event_payload",
         run_type="uipath",
     )
-    @infer_bindings(resource_type="ignored", ignore=True)
+    @resource_override(resource_type="ignored", ignore=True)
     async def retrieve_event_payload_async(
         self, event_args: EventArguments
     ) -> Dict[str, Any]:

--- a/src/uipath/_services/context_grounding_service.py
+++ b/src/uipath/_services/context_grounding_service.py
@@ -8,7 +8,7 @@ from typing_extensions import deprecated
 from .._config import Config
 from .._execution_context import ExecutionContext
 from .._folder_context import FolderContext
-from .._utils import Endpoint, RequestSpec, header_folder, infer_bindings
+from .._utils import Endpoint, RequestSpec, header_folder, resource_override
 from .._utils.constants import (
     CONFLUENCE_DATA_SOURCE,
     DROPBOX_DATA_SOURCE,
@@ -51,7 +51,7 @@ class ContextGroundingService(FolderContext, BaseService):
         super().__init__(config=config, execution_context=execution_context)
 
     @traced(name="add_to_index", run_type="uipath")
-    @infer_bindings(resource_type="index")
+    @resource_override(resource_type="index")
     def add_to_index(
         self,
         name: str,
@@ -106,7 +106,7 @@ class ContextGroundingService(FolderContext, BaseService):
             self.ingest_data(index, folder_key=folder_key, folder_path=folder_path)
 
     @traced(name="add_to_index", run_type="uipath")
-    @infer_bindings(resource_type="index")
+    @resource_override(resource_type="index")
     async def add_to_index_async(
         self,
         name: str,
@@ -165,7 +165,7 @@ class ContextGroundingService(FolderContext, BaseService):
             )
 
     @traced(name="contextgrounding_retrieve", run_type="uipath")
-    @infer_bindings(resource_type="index")
+    @resource_override(resource_type="index")
     def retrieve(
         self,
         name: str,
@@ -207,7 +207,7 @@ class ContextGroundingService(FolderContext, BaseService):
             raise Exception("ContextGroundingIndex not found") from e
 
     @traced(name="contextgrounding_retrieve", run_type="uipath")
-    @infer_bindings(resource_type="index")
+    @resource_override(resource_type="index")
     async def retrieve_async(
         self,
         name: str,
@@ -319,7 +319,7 @@ class ContextGroundingService(FolderContext, BaseService):
         return response.json()
 
     @traced(name="contextgrounding_create_index", run_type="uipath")
-    @infer_bindings(resource_type="index")
+    @resource_override(resource_type="index")
     def create_index(
         self,
         name: str,
@@ -377,7 +377,7 @@ class ContextGroundingService(FolderContext, BaseService):
         return ContextGroundingIndex.model_validate(response.json())
 
     @traced(name="contextgrounding_create_index", run_type="uipath")
-    @infer_bindings(resource_type="index")
+    @resource_override(resource_type="index")
     async def create_index_async(
         self,
         name: str,
@@ -435,6 +435,7 @@ class ContextGroundingService(FolderContext, BaseService):
         return ContextGroundingIndex.model_validate(response.json())
 
     @traced(name="contextgrounding_search", run_type="uipath")
+    @resource_override(resource_type="index")
     def search(
         self,
         name: str,
@@ -482,6 +483,7 @@ class ContextGroundingService(FolderContext, BaseService):
         )
 
     @traced(name="contextgrounding_search", run_type="uipath")
+    @resource_override(resource_type="index")
     async def search_async(
         self,
         name: str,

--- a/src/uipath/_services/processes_service.py
+++ b/src/uipath/_services/processes_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 from .._config import Config
 from .._execution_context import ExecutionContext
 from .._folder_context import FolderContext
-from .._utils import Endpoint, RequestSpec, header_folder, infer_bindings
+from .._utils import Endpoint, RequestSpec, header_folder, resource_override
 from .._utils.constants import ENV_JOB_KEY, HEADER_JOB_KEY
 from ..models.job import Job
 from ..tracing._traced import traced
@@ -32,7 +32,7 @@ class ProcessesService(FolderContext, BaseService):
         super().__init__(config=config, execution_context=execution_context)
 
     @traced(name="processes_invoke", run_type="uipath")
-    @infer_bindings(resource_type="process")
+    @resource_override(resource_type="process")
     def invoke(
         self,
         name: str,
@@ -96,7 +96,7 @@ class ProcessesService(FolderContext, BaseService):
         return Job.model_validate(response.json()["value"][0])
 
     @traced(name="processes_invoke", run_type="uipath")
-    @infer_bindings(resource_type="process")
+    @resource_override(resource_type="process")
     async def invoke_async(
         self,
         name: str,

--- a/src/uipath/_utils/__init__.py
+++ b/src/uipath/_utils/__init__.py
@@ -1,4 +1,4 @@
-from ._bindings import get_inferred_bindings_names, infer_bindings
+from ._bindings import get_inferred_bindings_names, resource_override
 from ._endpoint import Endpoint
 from ._logs import setup_logging
 from ._request_override import header_folder
@@ -12,7 +12,7 @@ __all__ = [
     "RequestSpec",
     "header_folder",
     "get_inferred_bindings_names",
-    "infer_bindings",
+    "resource_override",
     "header_user_agent",
     "user_agent_value",
     "UiPathUrl",

--- a/src/uipath/_utils/_bindings.py
+++ b/src/uipath/_utils/_bindings.py
@@ -51,7 +51,7 @@ class ResourceOverwritesContext:
             _resource_overwrites.reset(self._token)
 
 
-def infer_bindings(
+def resource_override(
     resource_type: str,
     name: str = "name",
     folder_path: str = "folder_path",

--- a/tests/cli/models/test_runtime_schema.py
+++ b/tests/cli/models/test_runtime_schema.py
@@ -40,56 +40,6 @@ def test_runtime_schema_validation():
                 },
             }
         ],
-        "bindings": {
-            "version": "2.0",
-            "resources": [
-                {
-                    "resource": "process",
-                    "key": "process-key",
-                    "value": {
-                        "name": {
-                            "defaultValue": "process-name",
-                            "isExpression": False,
-                            "displayName": "Process name",
-                        }
-                    },
-                    "metadata": {
-                        "subType": "agent",
-                        "bindingsVersion": "2.2",
-                        "solutionsSupport": "true",
-                    },
-                },
-                {
-                    "resource": "connection",
-                    "key": "connection-key",
-                    "value": {
-                        "connectionId": {
-                            "defaultValue": "connection-id",
-                            "isExpression": False,
-                            "displayName": "Connection ID",
-                        }
-                    },
-                    "metadata": {
-                        "connector": "uipath-salesforce-slack",
-                        "useConnectionService": "true",
-                        "bindingsVersion": "2.2",
-                        "solutionsSupport": "true",
-                    },
-                },
-                {
-                    "resource": "app",
-                    "key": "ActionApp",
-                    "value": {
-                        "name": {
-                            "defaultValue": "ActionApp",
-                            "isExpression": False,
-                            "displayName": "App name",
-                        }
-                    },
-                    "metadata": {"bindingsVersion": "2.2", "solutionsSupport": "true"},
-                },
-            ],
-        },
     }
 
     # Act and Assert

--- a/tests/sdk/test_bindings.py
+++ b/tests/sdk/test_bindings.py
@@ -1,6 +1,6 @@
 import pytest
 
-from uipath._utils import infer_bindings
+from uipath._utils import resource_override
 from uipath._utils._bindings import (
     ResourceOverwrite,
     ResourceOverwritesContext,
@@ -17,7 +17,7 @@ class TestBindingsInference:
             )
         }
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def dummy_func(name, folder_path):
             return name, folder_path
 
@@ -37,7 +37,7 @@ class TestBindingsInference:
             )
         }
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def dummy_func(name, folder_path):
             return name, folder_path
 
@@ -52,7 +52,7 @@ class TestBindingsInference:
     def test_infer_bindings_skips_when_no_context(self):
         """Test that infer_bindings doesn't overwrite when context variable is not set."""
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def dummy_func(name, folder_path):
             return name, folder_path
 
@@ -67,7 +67,7 @@ class TestBindingsInference:
             )
         }
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def dummy_func(name, folder_path):
             return name, folder_path
 
@@ -87,7 +87,7 @@ class TestBindingsInference:
             )
         }
 
-        @infer_bindings(resource_type="asset")
+        @resource_override(resource_type="asset")
         def dummy_func(name, folder_path=None):
             return name, folder_path
 
@@ -110,7 +110,7 @@ class TestBindingsInference:
             ),
         }
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def dummy_func(name, folder_path):
             return name, folder_path
 
@@ -138,7 +138,7 @@ class TestResourceOverwritesContext:
                 )
             }
 
-        @infer_bindings(resource_type="asset")
+        @resource_override(resource_type="asset")
         def retrieve_asset(name, folder_path=None):
             return name, folder_path
 
@@ -169,7 +169,7 @@ class TestResourceOverwritesContext:
 
         client = MockClient()
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def use_bucket(name, folder_path):
             return name, folder_path
 
@@ -193,7 +193,7 @@ class TestResourceOverwritesContext:
                 )
             }
 
-        @infer_bindings(resource_type="process")
+        @resource_override(resource_type="process")
         def start_process(name, folder_path):
             return name, folder_path
 
@@ -221,11 +221,11 @@ class TestResourceOverwritesContext:
                 ),
             }
 
-        @infer_bindings(resource_type="asset")
+        @resource_override(resource_type="asset")
         def get_asset(name, folder_path):
             return name, folder_path
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def get_bucket(name, folder_path):
             return name, folder_path
 
@@ -251,7 +251,7 @@ class TestResourceOverwritesContext:
         async def get_overwrites():
             return {}
 
-        @infer_bindings(resource_type="asset")
+        @resource_override(resource_type="asset")
         def get_asset(name, folder_path):
             return name, folder_path
 
@@ -276,11 +276,11 @@ class TestResourceOverwritesContext:
                 ),
             }
 
-        @infer_bindings(resource_type="asset")
+        @resource_override(resource_type="asset")
         def get_config(name, folder_path):
             return name, folder_path
 
-        @infer_bindings(resource_type="bucket")
+        @resource_override(resource_type="bucket")
         def get_data(name, folder_path):
             return name, folder_path
 
@@ -306,7 +306,7 @@ class TestResourceOverwritesContext:
                 )
             }
 
-        @infer_bindings(resource_type="asset")
+        @resource_override(resource_type="asset")
         def get_asset(name, folder_path):
             return name, folder_path
 

--- a/uv.lock
+++ b/uv.lock
@@ -2636,6 +2636,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-trio"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3047,7 +3059,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.132"
+version = "2.1.134"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },
@@ -3087,6 +3099,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "pytest-trio" },
     { name = "ruff" },
     { name = "rust-just" },
@@ -3134,6 +3147,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-mock", specifier = ">=3.11.1" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-trio", specifier = ">=0.8.0" },
     { name = "ruff", specifier = ">=0.9.4" },
     { name = "rust-just", specifier = ">=1.39.0" },


### PR DESCRIPTION
- save bindings to a dedicated file
-  rename `infer_bindings` decorator
- kept backwards compatibility for already initialized projects
- compose bindings key using `{resource_name}.[{folder_path}]`
- apply overrides on context grounding search methods

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.134.dev1008202440",

  # Any version from PR
  "uipath>=2.1.134.dev1008200000,<2.1.134.dev1008210000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```