### PR TITLE
fix(remove_llm_logic): remove the LLMGateway logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.132"
+version = "2.1.133"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
@@ -72,6 +72,7 @@ dev = [
   "toml>=0.10.2",
   "inflection>=0.5.1",
   "types-toml>=0.10.8",
+  "pytest-timeout>=2.4.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/cli/eval/mocks/test_input_mocker.py
+++ b/tests/cli/eval/mocks/test_input_mocker.py
@@ -67,7 +67,8 @@ async def test_generate_llm_input_with_model_settings(
     )
 
     httpx_mock.add_response(
-        url="https://example.com/api/chat/completions?api-version=2024-08-01-preview",
+        url="https://example.com/llm/api/chat/completions"
+        "?api-version=2024-08-01-preview",
         status_code=200,
         json={
             "role": "assistant",

--- a/tests/cli/eval/mocks/test_mocks.py
+++ b/tests/cli/eval/mocks/test_mocks.py
@@ -179,7 +179,8 @@ def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
     )
 
     httpx_mock.add_response(
-        url="https://example.com/api/chat/completions?api-version=2024-08-01-preview",
+        url="https://example.com/llm/api/chat/completions"
+        "?api-version=2024-08-01-preview",
         status_code=200,
         json={
             "id": "response-id",
@@ -211,7 +212,8 @@ def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
     with pytest.raises(NotImplementedError):
         assert foofoo()
     httpx_mock.add_response(
-        url="https://example.com/api/chat/completions?api-version=2024-08-01-preview",
+        url="https://example.com/llm/api/chat/completions"
+        "?api-version=2024-08-01-preview",
         status_code=200,
         json={},
     )
@@ -220,6 +222,7 @@ def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 async def test_llm_mockable_async(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
     monkeypatch.setenv("UIPATH_URL", "https://example.com")
     monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "1234567890")
@@ -251,8 +254,21 @@ async def test_llm_mockable_async(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatc
     evaluation = LegacyEvaluationItem(**evaluation_item)
     assert isinstance(evaluation.mocking_strategy, LLMMockingStrategy)
 
+    # Mock capability checks
     httpx_mock.add_response(
-        url="https://example.com/api/chat/completions?api-version=2024-08-01-preview",
+        url="https://example.com/agenthub_/llm/api/capabilities",
+        status_code=200,
+        json={},
+    )
+    httpx_mock.add_response(
+        url="https://example.com/orchestrator_/llm/api/capabilities",
+        status_code=200,
+        json={},
+    )
+
+    httpx_mock.add_response(
+        url="https://example.com/llm/api/chat/completions"
+        "?api-version=2024-08-01-preview",
         status_code=200,
         json={
             "id": "response-id",
@@ -285,7 +301,8 @@ async def test_llm_mockable_async(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatc
         assert await foofoo()
 
     httpx_mock.add_response(
-        url="https://example.com/api/chat/completions?api-version=2024-08-01-preview",
+        url="https://example.com/llm/api/chat/completions"
+        "?api-version=2024-08-01-preview",
         status_code=200,
         json={},
     )

--- a/tests/sdk/services/test_uipath_llm_integration.py
+++ b/tests/sdk/services/test_uipath_llm_integration.py
@@ -5,10 +5,7 @@ import pytest
 
 from uipath._config import Config
 from uipath._execution_context import ExecutionContext
-from uipath._services.llm_gateway_service import (
-    ChatModels,
-    UiPathLlmChatService,
-)
+from uipath._services.llm_gateway_service import ChatModels, UiPathLlmChatService
 from uipath.models.llm_gateway import (
     AutoToolChoice,
     SpecificToolChoice,
@@ -278,7 +275,7 @@ class TestUiPathLLMServiceMocked:
 
         # Verify the correct endpoint and payload
         args, kwargs = mock_request.call_args
-        assert "/llmgateway_/api/chat/completions" in args[1]
+        assert "/orchestrator_/llm/api/chat/completions" in args[1]
         assert kwargs["json"]["messages"] == messages
         assert kwargs["json"]["max_tokens"] == 50
         assert kwargs["json"]["temperature"] == 0


### PR DESCRIPTION
- removed llm_gw logic and kept just or and ahub in EndpointManager

- Fixed both [test_llm_mockable_sync] and [test_llm_mockable_async] vfunctions
- Updated all chat completions URLs to use /llm/api/chat/completions instead of /agenthub_/llm/api/chat/completions
- Added the @pytest.mark.httpx_mock(assert_all_responses_were_requested=False) decorator to allow unused mocks for capability endpoints