### PR TITLE
fix: here tha api is returning tags that is not strictly str, could dict as well

### DIFF
--- a/src/uipath/models/buckets.py
+++ b/src/uipath/models/buckets.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
@@ -73,4 +73,4 @@ class Bucket(BaseModel):
     folders_count: Optional[int] = Field(default=None, alias="FoldersCount")
     encrypted: Optional[bool] = Field(default=None, alias="Encrypted")
     id: Optional[int] = Field(default=None, alias="Id")
-    tags: Optional[List[str]] = Field(default=None, alias="Tags")
+    tags: Optional[List[Any]] = Field(default=None, alias="Tags")


### PR DESCRIPTION
The change from List[str] to List[Any] was made because the UiPath API's actual response for the Tags field doesn't strictly return a list of strings.

API documentation says it a object https://staging.uipath.com/engbankpoc/SUNCOAST_LOAN_QC_POC_EU_DEV/orchestrator_/swagger/index.html#/Buckets/Buckets_Post

 When Pydantic tried to validate the API response with List[str], it would fail validation if the actual data didn't match that strict type, causing the SDK to throw an error when parsing the response.

 By changing to List[Any], the field now accepts whatever structure the API actually returns, preventing validation errors. 