### PR TITLE
fix: agent tool custom discriminator

### DIFF
--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -437,7 +437,8 @@ class AgentEscalationResourceConfig(BaseAgentResourceConfig):
 def custom_discriminator(data: Any) -> str:
     """Discriminator for resource types. This is required due to multi-key discrimination requirements for resources."""
     if isinstance(data, dict):
-        resource_type = data.get("$resourceType")
+        # Handle both JSON format ($resourceType) and Python format (resource_type)
+        resource_type = data.get("$resourceType") or data.get("resource_type")
         if resource_type == AgentResourceType.CONTEXT:
             return "AgentContextResourceConfig"
         elif resource_type == AgentResourceType.ESCALATION:


### PR DESCRIPTION
## Description

Fix Pydantic discriminator serialization warnings in LangGraph state transitions 

- Updated `custom_discriminator()` to handle both JSON format (`$resourceType`) and Python format (`resource_type`) field names. 

This resolves serialization warnings when :

- Deserialization (JSON → Python): reads `$resourceType`
- Serialization (Python → JSON → Python): reads `resource_type`


## Issue

```
C:\Users\cristian.pufu\Documents\GitHub\system-agents-python\low-code-convert-agent\.venv\Lib\site-packages\pydantic\main.py:464: UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=AgentProcessToolResourceC...88a4dd', isEnabled=True), input_type=AgentProcessToolResourceConfig])
  PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=AgentProcessToolResourceC...58a91a', isEnabled=True), input_type=AgentProcessToolResourceConfig])
  PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=AgentIntegrationToolResou...07727', isPreview=False), input_type=AgentIntegrationToolResourceConfig])
  PydanticSerializationUnexpectedValue(Defaulting to left to right union serialization - failed to get discriminator value for tagged union serialization [input_value=AgentContextResourceConfi...4347-4393-08de1779f876'), input_type=AgentContextResourceConfig])
  return self.__pydantic_serializer__.to_python(
```