### PR TITLE
fix: do not delete coded evals folder on remote

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.136"
+version = "2.1.137"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_evals/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluator_factory.py
@@ -16,6 +16,7 @@ from uipath._cli._evals._models._evaluator import (
     TrajectoryEvaluatorParams,
 )
 from uipath._cli._evals._models._evaluator_base_params import EvaluatorBaseParams
+from uipath._cli._utils._constants import EVALS_DIRECTORY_NAME
 from uipath.eval.evaluators import (
     BaseEvaluator,
     LegacyBaseEvaluator,
@@ -156,7 +157,11 @@ class EvaluatorFactory:
         if not file_path.is_absolute():
             if not file_path.exists():
                 file_path = (
-                    Path.cwd() / "evals" / "evaluators" / "custom" / file_path_str
+                    Path.cwd()
+                    / EVALS_DIRECTORY_NAME
+                    / "evaluators"
+                    / "custom"
+                    / file_path_str
                 )
 
         if not file_path.exists():

--- a/src/uipath/_cli/_evals/_helpers.py
+++ b/src/uipath/_cli/_evals/_helpers.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 import click
 
 from uipath._cli._utils._console import ConsoleLogger
+from uipath._cli._utils._constants import EVALS_DIRECTORY_NAME
 from uipath._utils.constants import CUSTOM_EVALUATOR_PREFIX
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ def to_kebab_case(text: str) -> str:
 
 def find_evaluator_file(filename: str) -> Optional[Path]:
     """Find the evaluator file in evals/evaluators/custom folder."""
-    custom_evaluators_path = Path.cwd() / "evals" / "evaluators" / "custom"
+    custom_evaluators_path = Path.cwd() / EVALS_DIRECTORY_NAME / "evaluators" / "custom"
 
     if not custom_evaluators_path.exists():
         return None
@@ -150,7 +151,7 @@ def register_evaluator(filename: str) -> tuple[str, str]:
     evaluator_config = generate_evaluator_config(evaluator_class, class_name)
     evaluator_json_type = evaluator_class.generate_json_type()
 
-    evaluators_dir = Path.cwd() / "evals" / "evaluators"
+    evaluators_dir = Path.cwd() / EVALS_DIRECTORY_NAME / "evaluators"
     evaluators_dir.mkdir(parents=True, exist_ok=True)
 
     evaluator_types_dir = evaluators_dir / "custom" / "types"

--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -19,6 +19,7 @@ from .._utils._constants import (
     AGENT_STORAGE_VERSION,
     AGENT_TARGET_RUNTIME,
     AGENT_VERSION,
+    EVALS_DIRECTORY_NAME,
 )
 from .._utils._project_files import (  # type: ignore
     FileInfo,
@@ -672,7 +673,7 @@ class SwFileHandler:
             settings,
             self.directory,
             self.include_uv_lock,
-            directories_to_ignore=["evals"],
+            directories_to_ignore=[EVALS_DIRECTORY_NAME],
         )
 
         # Process all files and get updates (this includes HTTP calls for agent.json/entry-points.json)
@@ -713,7 +714,9 @@ class SwFileHandler:
         eval_set_files = []
 
         # Check {self.directory}/evals/evaluators/ for files with version property
-        evaluators_dir = os.path.join(self.directory, "evals", "evaluators")
+        evaluators_dir = os.path.join(
+            self.directory, EVALS_DIRECTORY_NAME, "evaluators"
+        )
         if os.path.exists(evaluators_dir):
             for file_name in os.listdir(evaluators_dir):
                 if file_name.endswith(".json"):
@@ -727,7 +730,7 @@ class SwFileHandler:
                         )
 
         # Check {self.directory}/evals/eval-sets/ for files with version property
-        eval_sets_dir = os.path.join(self.directory, "evals", "eval-sets")
+        eval_sets_dir = os.path.join(self.directory, EVALS_DIRECTORY_NAME, "eval-sets")
         if os.path.exists(eval_sets_dir):
             for file_name in os.listdir(eval_sets_dir):
                 if file_name.endswith(".json"):
@@ -927,6 +930,8 @@ class SwFileHandler:
             # Refresh structure to get the new folders
             structure = await self._studio_client.get_project_structure_async()
             coded_evals_folder = self._get_folder_by_name(structure, "coded-evals")
+        else:
+            return
 
         if not coded_evals_folder:
             return  # Nothing to sync

--- a/src/uipath/_cli/_utils/_constants.py
+++ b/src/uipath/_cli/_utils/_constants.py
@@ -58,6 +58,9 @@ BINARY_EXTENSIONS = (
     | SPECIAL_EXTENSIONS
 )
 
+# Directory names
+EVALS_DIRECTORY_NAME = "evals"
+
 
 def is_binary_file(file_extension: str) -> bool:
     """Determine if a file should be treated as binary."""

--- a/src/uipath/_cli/cli_add.py
+++ b/src/uipath/_cli/cli_add.py
@@ -8,6 +8,7 @@ import click
 
 from ..telemetry import track
 from ._utils._console import ConsoleLogger
+from ._utils._constants import EVALS_DIRECTORY_NAME
 from ._utils._resources import Resources
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ def generate_evaluator_template(evaluator_name: str) -> str:
 
 def create_evaluator(evaluator_name):
     cwd = Path.cwd()
-    custom_evaluators_dir = cwd / "evals" / "evaluators" / "custom"
+    custom_evaluators_dir = cwd / EVALS_DIRECTORY_NAME / "evaluators" / "custom"
 
     if not custom_evaluators_dir.exists():
         console.info(

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -18,6 +18,7 @@ import click
 from .._config import UiPathConfig
 from ..telemetry import track
 from ._utils._console import ConsoleLogger
+from ._utils._constants import EVALS_DIRECTORY_NAME
 from ._utils._project_files import (
     InteractiveConflictHandler,
     ProjectPullError,
@@ -58,7 +59,7 @@ def pull(root: Path) -> None:
 
     download_configuration = {
         "source_code": root,
-        "coded-evals": root / "evals",
+        "coded-evals": root / EVALS_DIRECTORY_NAME,
     }
 
     # Create interactive conflict handler for user confirmation

--- a/src/uipath/agent/_utils.py
+++ b/src/uipath/agent/_utils.py
@@ -8,6 +8,7 @@ from uipath._cli._evals._models._evaluation_set import (
     InputMockingStrategy,
     LLMMockingStrategy,
 )
+from uipath._cli._utils._constants import EVALS_DIRECTORY_NAME
 from uipath._cli._utils._studio_project import (
     ProjectFile,
     ProjectFolder,
@@ -48,7 +49,7 @@ async def load_agent_definition(project_id: str) -> AgentDefinition:
     evaluators = []
     try:
         evaluators_path = resolve_path(
-            project_structure, PurePath("evals", "evaluators")
+            project_structure, PurePath(EVALS_DIRECTORY_NAME, "evaluators")
         )
         if isinstance(evaluators_path, ProjectFolder):
             for file in evaluators_path.files:
@@ -71,7 +72,7 @@ async def load_agent_definition(project_id: str) -> AgentDefinition:
     evaluation_sets = []
     try:
         evaluation_sets_path = resolve_path(
-            project_structure, PurePath("evals", "eval-sets")
+            project_structure, PurePath(EVALS_DIRECTORY_NAME, "eval-sets")
         )
         if isinstance(evaluation_sets_path, ProjectFolder):
             for file in evaluation_sets_path.files:

--- a/uv.lock
+++ b/uv.lock
@@ -3059,7 +3059,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.135"
+version = "2.1.137"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- do not delete coded evals files on remote if eval files are not present locally
- added constant for evals folder