### PR TITLE
chore: update uipath in samples

### DIFF
--- a/samples/asset-modifier-agent/pyproject.toml
+++ b/samples/asset-modifier-agent/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "UiPath agent to validate asset values via External Application integration with Orchestrator."
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 dependencies = [
-    "uipath>=2.1.45",
+    "uipath>=2.1.45, <2.2.0",
 ]
 requires-python = ">=3.10"

--- a/samples/calculator/pyproject.toml
+++ b/samples/calculator/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "calculator-agent"
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 dependencies = [
-    "uipath>=2.1.87",
+    "uipath>=2.1.87, <2.2.0",
 ]
 requires-python = ">=3.10"

--- a/samples/event-trigger/pyproject.toml
+++ b/samples/event-trigger/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.5"
 description = "event-agent"
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 dependencies = [
-    "uipath>=2.1.18",
+    "uipath>=2.1.18, <2.2.0",
 ]
 requires-python = ">=3.10"

--- a/samples/google-ADK-agent/pyproject.toml
+++ b/samples/google-ADK-agent/pyproject.toml
@@ -7,5 +7,5 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "google-adk>=1.4.2",
-    "uipath>=2.0.79",
+    "uipath>=2.0.79, <2.2.0",
 ]

--- a/samples/llm_chat_agent/pyproject.toml
+++ b/samples/llm_chat_agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "Sample agent demonstrating actual LLM calls with UiPath LLM Gateway"
 requires-python = ">=3.10"
 dependencies = [
-    "uipath>=2.0.79",
+    "uipath>=2.0.79, <2.2.0",
     "pydantic>=2.0.0",
 ]
 


### PR DESCRIPTION
Added upper version bounds (<2.2.0) to the `uipath` dependency across all sample projects to prevent breaking changes from future major versions.