### PR TITLE
feat(publish): named folder argument to cli publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.147"
+version = "2.1.148"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3059,7 +3059,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.147"
+version = "2.1.148"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
# Description

## Add `--folder` option to `uipath publish` command

Adds a `--folder` / `-f` option to bypass interactive feed selection when publishing packages.

### Usage

```bash
# Direct folder selection (NEW)
uipath publish --folder "Ion Folder Feed"
uipath publish -f "some Folder name"

# Interactive (unchanged)
uipath publish

# Existing flags still work
uipath publish --tenant
uipath publish --my-workspace
```

Smart Matching
Given feed: `Orchestrator Ion Folder Feed Feed`
✅ --folder `Orchestrator Ion Folder Feed Feed` (exact match)
✅ --folder `Ion Folder Feed` (core name, strips prefix/suffix)
✅ --folder `ion folder feed` (case-insensitive)

For a folder named `Ion Folder Feed` you get the following response from orchestrator

```json
    {
        "name": "Orchestrator Ion Folder Feed Feed",
        "purpose": "Processes",
        "isShared": false,
        "isPublic": false,
        "isExternal": false,
        "authenticationType": "Secure",
        "apiKey": null,
        "basicUserName": null,
        "basicPassword": null,
        "folderId": 1234,
        "supportedProjectTypes": [
            "Process",
            "BusinessProcess",
            "TestAutomationProcess"
        ],
        "id": "123887f4-abcd-abcd-abcd-12307343c17e"
    },
```

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.148.dev1008612628",

  # Any version from PR
  "uipath>=2.1.148.dev1008610000,<2.1.148.dev1008620000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```