### PR TITLE
fix: posting eval runs to sw was broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.155"
+version = "2.1.156"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes the 400 bad request for the call to https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/62a9847c-7172-4a93-81d9-15cec998bfbe/coded/evalSetRun
```
 ➜  calculator git:(main) ✗  uipath eval main.py  evaluations/eval-sets/default.json                   
Applied 0 resource overwrite(s)
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/62a9847c-7172-4a93-81d9-15cec998bfbe/coded/evalSetRun "HTTP/1.1 400 Bad Request"
Cannot report progress to SW. Function: create_eval_set_run_sw, Error type: EnrichedException, Details: 
Request URL: https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/62a9847c-7172-4a93-81d9-15cec998bfbe/coded/evalSetRun
HTTP Method: POST
Status Code: 400
Response Content: {"type":"https://tools.ietf.org/html/rfc9110#section-15.5.1","title":"One or more validation errors occurred.","status":400,"errors":{"$":["JSON deserialization for type 'UiPath.Agents.Common.Evals.Cr... (truncated)
Cannot create eval run: eval_set_run_id not available
→ Running Evaluations
  ○ Add - Running...
HTTP Request: GET https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/capabilities "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=4bc0f169-2bbc-45c4-aaca-c0fa930a374a&source=Robots "HTTP/1.1 200 OK"
    • ⚠  StudioWeb reporting error: '806d471b-666f-4076-9d9b-57ce24fd2724'
▌ Add
  JsonSimilarityEvaluator                        1.0  
  TrajectoryEvaluator                            1.0  
  CorrectOperatorEvaluator                       0.0  
  ExactMatchEvaluator                            1.0  
  LLMJudgeOutputEvaluator                        1.0  
  LLMJudgeStrictJSONSimilarityOutputEvaluator    1.0  
  ContainsEvaluator                              1.0  
──────────────────────────────────────────────────────────────────────────────────────────────── Execution Logs: Add ────────────────────────────────────────────────────────────────────────────────────────────────
  No execution logs
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Cannot create eval run: eval_set_run_id not available
```