### PR TITLE
feat: add complete evals tracing hierarchy 

### DIFF
--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -5,10 +5,12 @@ import json
 import logging
 import os
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 from urllib.parse import urlparse
 
 from opentelemetry import trace
+from opentelemetry.trace import SpanContext, SpanKind, TraceFlags
 from pydantic import BaseModel
 from rich.console import Console
 
@@ -390,6 +392,10 @@ class StudioWebProgressReporter:
             if current_span.is_recording():
                 current_span.set_attribute("eval_set_run_id", eval_set_run_id)
 
+            # Create and send parent trace for the evaluation set run
+            if eval_set_run_id:
+                await self._send_parent_trace(eval_set_run_id, payload.eval_set_id)
+
             logger.debug(
                 f"Created eval set run with ID: {eval_set_run_id} (coded={is_coded})"
             )
@@ -411,6 +417,7 @@ class StudioWebProgressReporter:
                 if eval_run_id:
                     # Store eval_run_id with the individual eval run's execution_id
                     self.eval_run_ids[payload.execution_id] = eval_run_id
+
                     logger.debug(
                         f"Created eval run with ID: {eval_run_id} (coded={is_coded})"
                     )
@@ -422,11 +429,18 @@ class StudioWebProgressReporter:
 
     async def handle_update_eval_run(self, payload: EvalRunUpdatedEvent) -> None:
         try:
-            # Use the eval set execution ID for trace ID
-            if self.eval_set_execution_id:
-                self.spans_exporter.trace_id = self.eval_set_run_ids.get(
-                    self.eval_set_execution_id
-                )
+            eval_run_id = self.eval_run_ids.get(payload.execution_id)
+
+            # Use evalRunId as the trace_id for agent execution spans
+            # This makes all agent spans children of the eval run trace
+            if eval_run_id:
+                self.spans_exporter.trace_id = eval_run_id
+            else:
+                # Fallback to evalSetRunId if eval_run_id not available yet
+                if self.eval_set_execution_id:
+                    self.spans_exporter.trace_id = self.eval_set_run_ids.get(
+                        self.eval_set_execution_id
+                    )
 
             self.spans_exporter.export(payload.spans)
 
@@ -445,14 +459,17 @@ class StudioWebProgressReporter:
                         case ScoreType.ERROR:
                             self.evaluator_scores[evaluator_id].append(0)
 
-            # Use the individual eval run's execution_id to find its eval_run_id
-            eval_run_id = self.eval_run_ids.get(payload.execution_id)
             if eval_run_id and self.eval_set_execution_id:
                 # Get the is_coded flag for this execution
                 is_coded = self.is_coded_eval.get(self.eval_set_execution_id, False)
 
                 # Extract usage metrics from spans
                 self._extract_usage_from_spans(payload.spans)
+
+                # Send evaluator traces
+                await self._send_evaluator_traces(
+                    eval_run_id, payload.eval_results, payload.spans
+                )
 
                 await self.update_eval_run(
                     StudioWebProgressItem(
@@ -831,7 +848,6 @@ class StudioWebProgressReporter:
         }
 
         if is_coded:
-            # Source: 0 = cli, 1 = protegi
             payload["source"] = 0
 
         return RequestSpec(
@@ -897,3 +913,316 @@ class StudioWebProgressReporter:
                 f"{ENV_TENANT_ID} env var is not set. Please run 'uipath auth'."
             )
         return {HEADER_INTERNAL_TENANT_ID: tenant_id}  # type: ignore
+
+    async def _send_parent_trace(
+        self, eval_set_run_id: str, eval_set_name: str
+    ) -> None:
+        """Send the parent trace span for the evaluation set run.
+
+        Args:
+            eval_set_run_id: The ID of the evaluation set run
+            eval_set_name: The name of the evaluation set
+        """
+        try:
+            # Get the tracer
+            tracer = trace.get_tracer(__name__)
+
+            # Convert eval_set_run_id to trace ID format (128-bit integer)
+            trace_id_int = int(uuid.UUID(eval_set_run_id))
+
+            # Create a span context with the eval_set_run_id as the trace ID
+            span_context = SpanContext(
+                trace_id=trace_id_int,
+                span_id=trace_id_int,  # Use same ID for root span
+                is_remote=False,
+                trace_flags=TraceFlags(0x01),  # Sampled
+            )
+
+            # Create a non-recording span with our custom context
+            ctx = trace.set_span_in_context(trace.NonRecordingSpan(span_context))
+
+            # Start a new span with the custom trace ID
+            with tracer.start_as_current_span(
+                eval_set_name,
+                context=ctx,
+                kind=SpanKind.INTERNAL,
+                start_time=int(datetime.now(timezone.utc).timestamp() * 1_000_000_000),
+            ) as span:
+                # Set attributes for the evaluation set span
+                span.set_attribute("openinference.span.kind", "CHAIN")
+                span.set_attribute("span.type", "evaluationSet")
+                span.set_attribute("eval_set_run_id", eval_set_run_id)
+
+            logger.debug(f"Created parent trace for eval set run: {eval_set_run_id}")
+
+        except Exception as e:
+            logger.warning(f"Failed to create parent trace: {e}")
+
+    async def _send_eval_run_trace(
+        self, eval_run_id: str, eval_set_run_id: str, eval_name: str
+    ) -> None:
+        """Send the child trace span for an evaluation run.
+
+        Args:
+            eval_run_id: The ID of the evaluation run
+            eval_set_run_id: The ID of the parent evaluation set run
+            eval_name: The name of the evaluation
+        """
+        try:
+            # Get the tracer
+            tracer = trace.get_tracer(__name__)
+
+            # Convert IDs to trace format
+            trace_id_int = int(uuid.UUID(eval_run_id))
+            parent_span_id_int = int(uuid.UUID(eval_set_run_id))
+
+            # Create a parent span context
+            parent_context = SpanContext(
+                trace_id=trace_id_int,
+                span_id=parent_span_id_int,
+                is_remote=False,
+                trace_flags=TraceFlags(0x01),
+            )
+
+            # Create context with parent span
+            ctx = trace.set_span_in_context(trace.NonRecordingSpan(parent_context))
+
+            # Start a new span with the eval_run_id as trace ID
+            with tracer.start_as_current_span(
+                eval_name,
+                context=ctx,
+                kind=SpanKind.INTERNAL,
+                start_time=int(datetime.now(timezone.utc).timestamp() * 1_000_000_000),
+            ) as span:
+                # Set attributes for the evaluation run span
+                span.set_attribute("openinference.span.kind", "CHAIN")
+                span.set_attribute("span.type", "evaluation")
+                span.set_attribute("eval_run_id", eval_run_id)
+                span.set_attribute("eval_set_run_id", eval_set_run_id)
+
+            logger.debug(
+                f"Created trace for eval run: {eval_run_id} (parent: {eval_set_run_id})"
+            )
+
+        except Exception as e:
+            logger.warning(f"Failed to create eval run trace: {e}")
+
+    async def _send_evaluator_traces(
+        self, eval_run_id: str, eval_results: List[EvalItemResult], spans: list[Any]
+    ) -> None:
+        """Send trace spans for all evaluators.
+
+        Args:
+            eval_run_id: The ID of the evaluation run
+            eval_results: List of evaluator results
+            spans: List of spans that may contain evaluator LLM calls
+        """
+        try:
+            if not eval_results:
+                logger.debug(
+                    f"No evaluator results to trace for eval run: {eval_run_id}"
+                )
+                return
+
+            # First, export the agent execution spans so they appear in the trace
+            agent_readable_spans = []
+            if spans:
+                for span in spans:
+                    if hasattr(span, "_readable_span"):
+                        agent_readable_spans.append(span._readable_span())
+
+            if agent_readable_spans:
+                self.spans_exporter.export(agent_readable_spans)
+                logger.debug(
+                    f"Exported {len(agent_readable_spans)} agent execution spans for eval run: {eval_run_id}"
+                )
+
+            # Get the tracer
+            tracer = trace.get_tracer(__name__)
+
+            # Calculate overall start and end times for the evaluators parent span
+            # Since evaluators run sequentially, the parent span duration should be
+            # the sum of all individual evaluator times
+            now = datetime.now(timezone.utc)
+
+            # Sum all evaluator execution times for sequential execution
+            total_eval_time = (
+                sum(
+                    (
+                        r.result.evaluation_time
+                        for r in eval_results
+                        if r.result.evaluation_time
+                    )
+                )
+                or 0.0
+            )
+
+            # Parent span covers the sequential evaluation period
+            parent_end_time = now
+            parent_start_time = (
+                datetime.fromtimestamp(
+                    now.timestamp() - total_eval_time, tz=timezone.utc
+                )
+                if total_eval_time > 0
+                else now
+            )
+
+            # Find the root execution span from the agent spans
+            # The root span typically has no parent
+            root_span_uuid = None
+            if spans:
+                from uipath.tracing._utils import _SpanUtils
+
+                for span in spans:
+                    # Check if this span has no parent (indicating it's the root)
+                    if span.parent is None:
+                        # Get the span context and convert to UUID
+                        span_context = span.get_span_context()
+                        root_span_uuid = _SpanUtils.span_id_to_uuid4(
+                            span_context.span_id
+                        )
+                        break
+
+            # Convert eval_run_id to trace ID format
+            trace_id_int = int(uuid.UUID(eval_run_id))
+
+            # Create parent span context - child of root span if available
+            # The root span should be the eval span (the agent execution root)
+            if root_span_uuid:
+                # Convert root span UUID to integer for SpanContext
+                root_span_id_int = int(root_span_uuid)
+                parent_context = SpanContext(
+                    trace_id=trace_id_int,
+                    span_id=root_span_id_int,
+                    is_remote=False,
+                    trace_flags=TraceFlags(0x01),
+                )
+                ctx = trace.set_span_in_context(trace.NonRecordingSpan(parent_context))
+            else:
+                # No root span found, create as root span with eval_run_id as both trace and span
+                parent_context = SpanContext(
+                    trace_id=trace_id_int,
+                    span_id=trace_id_int,
+                    is_remote=False,
+                    trace_flags=TraceFlags(0x01),
+                )
+                ctx = trace.set_span_in_context(trace.NonRecordingSpan(parent_context))
+
+            # Create the evaluators parent span
+            parent_start_ns = int(parent_start_time.timestamp() * 1_000_000_000)
+            parent_end_ns = int(parent_end_time.timestamp() * 1_000_000_000)
+
+            # Start parent span manually (not using with statement) to control end time
+            parent_span = tracer.start_span(
+                "Evaluators",
+                context=ctx,
+                kind=SpanKind.INTERNAL,
+                start_time=parent_start_ns,
+            )
+
+            # Set attributes for the evaluators parent span
+            parent_span.set_attribute("openinference.span.kind", "CHAIN")
+            parent_span.set_attribute("span.type", "evaluators")
+            parent_span.set_attribute("eval_run_id", eval_run_id)
+
+            # Make this span the active span for child spans
+            parent_ctx = trace.set_span_in_context(parent_span, ctx)
+
+            # Track the current time for sequential execution
+            current_time = parent_start_time
+
+            # Collect all readable spans for export
+            readable_spans = []
+
+            # Create individual evaluator spans - running sequentially
+            for eval_result in eval_results:
+                # Get evaluator name from stored evaluators
+                evaluator = self.evaluators.get(eval_result.evaluator_id)
+                evaluator_name = evaluator.id if evaluator else eval_result.evaluator_id
+
+                # Each evaluator starts where the previous one ended (sequential execution)
+                eval_time = eval_result.result.evaluation_time or 0
+                eval_start = current_time
+                eval_end = datetime.fromtimestamp(
+                    current_time.timestamp() + eval_time, tz=timezone.utc
+                )
+
+                # Move current time forward for the next evaluator
+                current_time = eval_end
+
+                # Create timestamps
+                eval_start_ns = int(eval_start.timestamp() * 1_000_000_000)
+                eval_end_ns = int(eval_end.timestamp() * 1_000_000_000)
+
+                # Start evaluator span manually (not using with statement) to control end time
+                evaluator_span = tracer.start_span(
+                    evaluator_name,
+                    context=parent_ctx,
+                    kind=SpanKind.INTERNAL,
+                    start_time=eval_start_ns,
+                )
+
+                # Set attributes for the evaluator span
+                evaluator_span.set_attribute("openinference.span.kind", "EVALUATOR")
+                evaluator_span.set_attribute("span.type", "evaluator")
+                evaluator_span.set_attribute("evaluator_id", eval_result.evaluator_id)
+                evaluator_span.set_attribute("evaluator_name", evaluator_name)
+                evaluator_span.set_attribute("eval_run_id", eval_run_id)
+                evaluator_span.set_attribute("score", eval_result.result.score)
+                evaluator_span.set_attribute(
+                    "score_type", eval_result.result.score_type.name
+                )
+
+                # Add details/justification if available
+                if eval_result.result.details:
+                    if isinstance(eval_result.result.details, BaseModel):
+                        evaluator_span.set_attribute(
+                            "details",
+                            json.dumps(eval_result.result.details.model_dump()),
+                        )
+                    else:
+                        evaluator_span.set_attribute(
+                            "details", str(eval_result.result.details)
+                        )
+
+                # Add evaluation time if available
+                if eval_result.result.evaluation_time:
+                    evaluator_span.set_attribute(
+                        "evaluation_time", eval_result.result.evaluation_time
+                    )
+
+                # Set status based on score type
+                from opentelemetry.trace import Status, StatusCode
+
+                if eval_result.result.score_type == ScoreType.ERROR:
+                    evaluator_span.set_status(
+                        Status(StatusCode.ERROR, "Evaluation failed")
+                    )
+                else:
+                    evaluator_span.set_status(Status(StatusCode.OK))
+
+                # End the evaluator span at the correct time
+                evaluator_span.end(end_time=eval_end_ns)
+
+                # Convert to ReadableSpan for export
+                # The span object has a method to get the readable version
+                if hasattr(evaluator_span, "_readable_span"):
+                    readable_spans.append(evaluator_span._readable_span())
+
+            # End the parent span at the correct time after all children are created
+            parent_span.end(end_time=parent_end_ns)
+
+            # Convert parent span to ReadableSpan
+            if hasattr(parent_span, "_readable_span"):
+                # Add parent span at the beginning for proper ordering
+                readable_spans.insert(0, parent_span._readable_span())
+
+            # Export all evaluator spans together
+            if readable_spans:
+                self.spans_exporter.export(readable_spans)
+
+            logger.debug(
+                f"Created evaluator traces for eval run: {eval_run_id} ({len(eval_results)} evaluators)"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create evaluator traces: {e}")


### PR DESCRIPTION
## Summary
Implement comprehensive trace hierarchy that links evaluation sets, runs, 
agent execution, and evaluator results in a parent-child structure for improved observability.

<img width="1595" height="1182" alt="image" src="https://github.com/user-attachments/assets/d6389804-6e34-4417-af40-607985d27cbb" />


## Changes
- Add parent trace span for evaluation set runs (evalSetRunId as TraceId)
- Add child trace spans for individual eval runs (evalRunId as TraceId, evalSetRunId as ParentSpanId)
- Add "Evaluators" parent span under each eval run
- Add individual evaluator spans with scores, justification, and timing
- Update agent execution spans to use evalRunId as TraceId
- Use UiPathSpan class for proper span format (ISO timestamps, correct field names)

## Trace Hierarchy
```
EvalSetRun (TraceId: evalSetRunId)
├─ EvalRun 1 (TraceId: evalRunId1, ParentId: evalSetRunId)
│  ├─ Agent Execution Spans (TraceId: evalRunId1)
│  └─ Evaluators (ParentId: evalRunId1)
│     ├─ Evaluator 1 (score, details, timing)
│     ├─ Evaluator 2
│     └─ ...
├─ EvalRun 2 (TraceId: evalRunId2, ParentId: evalSetRunId)
│  └─ ...
└─ EvalRun 3
   └─ ...
```

## Benefits
- Complete observability from eval set down to individual evaluator results
- Proper parent-child relationships enable trace visualization
- Evaluator scores, justifications, and execution times visible in traces
- LLM gateway calls automatically linked to correct eval run

## Testing
- All trace creation returns 200 OK
- Verified hierarchy with 3 eval runs, 7 evaluators each
- No errors in trace creation or export

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.163.dev1008792741",

  # Any version from PR
  "uipath>=2.1.163.dev1008790000,<2.1.163.dev1008800000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```