### PR TITLE
fix(LegacyEvaluations): fix legacy evaluation item types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.157"
+version = "2.1.158"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -183,13 +183,16 @@ class LegacyEvaluationItem(BaseModel):
     eval_set_id: str = Field(alias="evalSetId")
     created_at: str = Field(alias="createdAt")
     updated_at: str = Field(alias="updatedAt")
-    mocking_strategy: Optional[MockingStrategy] = Field(
-        default=None,
-        alias="mockingStrategy",
+    simulate_input: Optional[bool] = Field(default=None, alias="simulateInput")
+    input_generation_instructions: Optional[str] = Field(
+        default=None, alias="inputGenerationInstructions"
     )
-    input_mocking_strategy: Optional[InputMockingStrategy] = Field(
-        default=None,
-        alias="inputMockingStrategy",
+    simulate_tools: Optional[bool] = Field(default=None, alias="simulateInput")
+    simulation_instructions: Optional[str] = Field(
+        default=None, alias="simulationInstructions"
+    )
+    tools_to_simulate: list[EvaluationSimulationTool] = Field(
+        default_factory=list, alias="toolsToSimulate"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3059,7 +3059,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.154"
+version = "2.1.158"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
Specifically, mocking details are represented differently in legacy evaluations.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.158.dev1008802701",

  # Any version from PR
  "uipath>=2.1.158.dev1008800000,<2.1.158.dev1008810000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```