### PR TITLE
fix: num_workers > 1 breaks reporting

### DIFF
--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -371,7 +371,7 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
         await event_bus.publish(
             EvaluationEvents.CREATE_EVAL_RUN,
             EvalRunCreatedEvent(
-                execution_id=self.execution_id,
+                execution_id=execution_id,
                 eval_item=eval_item,
             ),
         )
@@ -466,7 +466,7 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
             await event_bus.publish(
                 EvaluationEvents.UPDATE_EVAL_RUN,
                 EvalRunUpdatedEvent(
-                    execution_id=self.execution_id,
+                    execution_id=execution_id,
                     eval_item=eval_item,
                     eval_results=evaluation_item_results,
                     success=not agent_execution_output.result.error,
@@ -491,7 +491,7 @@ class UiPathEvalRuntime(UiPathBaseRuntime, Generic[T, C]):
                 )
 
             eval_run_updated_event = EvalRunUpdatedEvent(
-                execution_id=self.execution_id,
+                execution_id=execution_id,
                 eval_item=eval_item,
                 eval_results=[],
                 success=False,


### PR DESCRIPTION
The issue

When we execute in parallel mode, individual eval results don't seem to be reported.

```
✓  Authentication successful.
(uipath-python) (kind-kind-cloudgen/default) 
 ➜  calculator git:(main)  uipath eval main.py  evaluations/eval-sets/default.json --workers 2
Applied 0 resource overwrite(s)
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalSetRun "HTTP/1.1 200 OK"
→ Running Evaluations
  ○ Add - Running...
  ○ Multiply - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalRun "HTTP/1.1 200 OK"
HTTP Request: GET https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/capabilities "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalRun "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
+
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
*
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=43f0d8ca-68cf-4fff-6874-08de22d1e09e&source=Robots "HTTP/1.1 200 OK"
▌ Multiply
  JsonSimilarityEvaluator                        1.0  
  TrajectoryEvaluator                            1.0  
  CorrectOperatorEvaluator                       1.0  
  ExactMatchEvaluator                            1.0  
  LLMJudgeOutputEvaluator                        1.0  
  LLMJudgeStrictJSONSimilarityOutputEvaluator    1.0  
  ContainsEvaluator                              1.0  
────────────────────────────────────────────────────────────────────────────────────────── Execution Logs: Multiply ───────────────────────────────────────────────────────────────────────────────────────────
  No execution logs
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ○ Skip denial code check - Running...
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalRun "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=43f0d8ca-68cf-4fff-6874-08de22d1e09e&source=Robots "HTTP/1.1 200 OK"
  ✓ Skip denial code check - No evaluators
─────────────────────────────────────────────────────────────────────────────────── Execution Logs: Skip denial code check ────────────────────────────────────────────────────────────────────────────────────
  No execution logs
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
HTTP Request: PUT https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalRun "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: PUT https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalRun "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/agenthub_/llm/api/chat/completions?api-version=2024-08-01-preview "HTTP/1.1 200 OK"
HTTP Request: POST https://alpha.uipath.com/uipathmj/DefaultTenant/llmopstenant_/api/Traces/spans?traceId=43f0d8ca-68cf-4fff-6874-08de22d1e09e&source=Robots "HTTP/1.1 200 OK"
▌ Add
  JsonSimilarityEvaluator                        1.0  
  TrajectoryEvaluator                            1.0  
  CorrectOperatorEvaluator                       1.0  
  ExactMatchEvaluator                            1.0  
  LLMJudgeOutputEvaluator                        1.0  
  LLMJudgeStrictJSONSimilarityOutputEvaluator    1.0  
  ContainsEvaluator                              1.0  
───────────────────────────────────────────────────────────────────────────────────────────── Execution Logs: Add ─────────────────────────────────────────────────────────────────────────────────────────────
  No execution logs
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Evaluation Results
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃  Evaluation              ┃  JsonSimilarityEvaluat…  ┃  TrajectoryEvaluator  ┃  CorrectOperatorEvalua…  ┃  ExactMatchEvaluator  ┃  LLMJudgeOutputEvaluator  ┃  LLMJudgeStrictJSONSim…  ┃  ContainsEvaluator  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│  Multiply                │                     1.0  │                  1.0  │                     1.0  │                  1.0  │                      1.0  │                     1.0  │                1.0  │
│  Skip denial code check  │                       -  │                    -  │                       -  │                    -  │                        -  │                       -  │                  -  │
│  Add                     │                     1.0  │                  1.0  │                     1.0  │                  1.0  │                      1.0  │                     1.0  │                1.0  │
├──────────────────────────┼──────────────────────────┼───────────────────────┼──────────────────────────┼───────────────────────┼───────────────────────────┼──────────────────────────┼─────────────────────┤
│  Average                 │                     1.0  │                  1.0  │                     1.0  │                  1.0  │                      1.0  │                     1.0  │                1.0  │
└──────────────────────────┴──────────────────────────┴───────────────────────┴──────────────────────────┴───────────────────────┴───────────────────────────┴──────────────────────────┴─────────────────────┘
HTTP Request: PUT https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalSetRun "HTTP/1.1 200 OK"
HTTP Request: PUT https://alpha.uipath.com/uipathmj/DefaultTenant/agentsruntime_/api/execution/agents/b36a7b49-c543-4e12-9498-ba71bf40bfcd/coded/evalRun "HTTP/1.1 200 OK"
(uipath-python) (kind-kind-cloudgen/default) 
```

<img width="1428" height="592" alt="image" src="https://github.com/user-attachments/assets/e40fa445-0b8c-42c8-90e2-fb8ca6fdbb19" />
