### PR TITLE
fix: add missing keys in agent json for serverless packager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.162"
+version = "2.1.163"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -465,6 +465,9 @@ class SwFileHandler:
             "bindings": uipath_config.get(
                 "bindings", {"version": "2.0", "resources": []}
             ),
+            "inputSchema": {},
+            "outputSchema": {},
+            "settings": {},
             # TODO: remove this after validation check gets removed on SW side
             "entryPoints": [{}],
         }

--- a/uv.lock
+++ b/uv.lock
@@ -3059,7 +3059,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.162"
+version = "2.1.163"
 source = { editable = "." }
 dependencies = [
     { name = "azure-monitor-opentelemetry" },


### PR DESCRIPTION
- add missing keys in agent json for serverless packager

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.163.dev1008892735",

  # Any version from PR
  "uipath>=2.1.163.dev1008890000,<2.1.163.dev1008900000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```