### PR TITLE
fix: id selection was broken for eval run

### DIFF
--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -214,12 +214,13 @@ class EvaluationSet(BaseModel):
 
     def extract_selected_evals(self, eval_ids) -> None:
         selected_evals: list[EvaluationItem] = []
+        remaining_ids = set(eval_ids)
         for evaluation in self.evaluations:
-            if evaluation.id in eval_ids:
+            if evaluation.id in remaining_ids:
                 selected_evals.append(evaluation)
-                eval_ids.remove(evaluation.id)
-        if len(eval_ids) > 0:
-            raise ValueError("Unknown evaluation ids: {}".format(eval_ids))
+                remaining_ids.remove(evaluation.id)
+        if len(remaining_ids) > 0:
+            raise ValueError("Unknown evaluation ids: {}".format(remaining_ids))
         self.evaluations = selected_evals
 
 
@@ -246,12 +247,13 @@ class LegacyEvaluationSet(BaseModel):
 
     def extract_selected_evals(self, eval_ids) -> None:
         selected_evals: list[LegacyEvaluationItem] = []
+        remaining_ids = set(eval_ids)
         for evaluation in self.evaluations:
-            if evaluation.id in eval_ids:
+            if evaluation.id in remaining_ids:
                 selected_evals.append(evaluation)
-                eval_ids.remove(evaluation.id)
-        if len(eval_ids) > 0:
-            raise ValueError("Unknown evaluation ids: {}".format(eval_ids))
+                remaining_ids.remove(evaluation.id)
+        if len(remaining_ids) > 0:
+            raise ValueError("Unknown evaluation ids: {}".format(remaining_ids))
         self.evaluations = selected_evals
 
 


### PR DESCRIPTION
 ---
  Summary

  - Fixed bug in extract_selected_evals() where ID selection was broken due to mutating the input list during iteration
  - Changed to use a separate remaining_ids set to track unmatched IDs instead of modifying the input list directly

  Problem

  The extract_selected_evals() method was calling eval_ids.remove() directly on the input list parameter while iterating through evaluations. This caused issues because:
  1. Mutating the input parameter is a side effect
  2. The list comparison in error handling used the mutated list

  Solution

  - Created a local remaining_ids set initialized from eval_ids
  - Check membership and remove from remaining_ids instead of the input list
  - Use remaining_ids for the final validation check

  This fix applies to both EvaluationSet and LegacyEvaluationSet classes in src/uipath/_cli/_evals/_models/_evaluation_set.py:214 and src/uipath/_cli/_evals/_models/_evaluation_set.py:247.

  Test plan

  - Run eval commands with ID selection to verify evaluations are correctly filtered
  - Test with invalid IDs to ensure proper error messages
  - Verify that the input eval_ids list is no longer mutated


## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.166.dev1008982766",

  # Any version from PR
  "uipath>=2.1.166.dev1008980000,<2.1.166.dev1008990000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```