### PR TITLE
fix: add eval-set-run-id to middleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.178"
+version = "2.1.179"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -125,6 +125,7 @@ def eval(
         entrypoint,
         eval_set,
         eval_ids,
+        eval_set_run_id=eval_set_run_id,
         no_report=no_report,
         workers=workers,
         execution_output_file=output_file,


### PR DESCRIPTION
## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.1.179.dev1009252913",

  # Any version from PR
  "uipath>=2.1.179.dev1009250000,<2.1.179.dev1009260000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```