### PR TITLE
chore: ensure `uv.lock` is up-to-date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Lint
 
-on:
-  workflow_call
+on: workflow_call
 
 jobs:
   lint:
@@ -25,7 +24,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Check static types
         run: uv run mypy --config-file pyproject.toml .
@@ -35,7 +34,6 @@ jobs:
 
       - name: Check formatting
         run: uv run ruff format --check .
-      
+
       - name: Check httpx.Client() usage
         run: uv run python scripts/lint_httpx_client.py
-


### PR DESCRIPTION
Add --locked flag during lint action to ensure the lock file has been updated.