### PR TITLE
refactor(mypy): removing mypy ignores 4

### DIFF
--- a/samples/calculator/evaluations/evaluators/custom/correct_operator.py
+++ b/samples/calculator/evaluations/evaluators/custom/correct_operator.py
@@ -16,7 +16,7 @@ class CorrectOperatorEvaluatorConfig(BaseEvaluatorConfig[CorrectOperatorEvaluati
     negated: bool = False
     default_evaluation_criteria: CorrectOperatorEvaluationCriteria = CorrectOperatorEvaluationCriteria(operator="+")
 
-class CorrectOperatorEvaluator(BaseEvaluator[CorrectOperatorEvaluationCriteria, CorrectOperatorEvaluatorConfig, type(None)]):
+class CorrectOperatorEvaluator(BaseEvaluator[CorrectOperatorEvaluationCriteria, CorrectOperatorEvaluatorConfig, None]):
     """A custom evaluator that checks if the correct operator is being used by the agent """
 
     def extract_operator_from_spans(self, agent_trace: list[ReadableSpan]) -> str:

--- a/src/uipath/_cli/_auth/_portal_service.py
+++ b/src/uipath/_cli/_auth/_portal_service.py
@@ -91,7 +91,7 @@ class PortalService:
             f"Failed to get tenants and organizations: {response.status_code} {response.text}"
         )
 
-    def refresh_access_token(self, refresh_token: str) -> TokenData:  # type: ignore
+    def refresh_access_token(self, refresh_token: str) -> TokenData:
         url = build_service_url(self.domain, "/identity_/connect/token")
         client_id = OidcUtils.get_auth_config(self.domain).get("client_id")
 
@@ -110,6 +110,7 @@ class PortalService:
             self._console.error("Unauthorized")
 
         self._console.error(f"Failed to refresh token: {response.status_code}")
+        raise Exception(f"Failed to refresh token: {response.status_code}")
 
     def ensure_valid_token(self):
         """Ensure the access token is valid and refresh it if necessary.
@@ -201,8 +202,9 @@ class PortalService:
         tenant = next((t for t in tenants if t["name"] == tenant_name), None)
         if not tenant:
             self._console.error(f"Tenant '{tenant_name}' not found.")
+            raise Exception(f"Tenant '{tenant_name}' not found.")
 
-        return self._set_tenant(tenant, organization)  # type: ignore
+        return self._set_tenant(tenant, organization)
 
     def resolve_tenant_info(self, tenant: Optional[str] = None):
         if tenant:

--- a/src/uipath/_cli/_dev/_terminal/__init__.py
+++ b/src/uipath/_cli/_dev/_terminal/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, cast
 from uuid import uuid4
 
-import pyperclip  # type: ignore[import-untyped]
+import pyperclip  # type: ignore[import-untyped] # explicit ignore
 from rich.traceback import Traceback
 from textual import on
 from textual.app import App, ComposeResult

--- a/src/uipath/_cli/_dev/_terminal/_utils/_logger.py
+++ b/src/uipath/_cli/_dev/_terminal/_utils/_logger.py
@@ -64,7 +64,7 @@ def patch_textual_stderr(dispatch_log: DispatchLog) -> int:
     read_fd, write_fd = os.pipe()
 
     # Patch fileno() so subprocesses can write to our pipe
-    _PrintCapture.fileno = lambda self: write_fd  # type: ignore[method-assign]
+    _PrintCapture.fileno = lambda self: write_fd  # type: ignore[method-assign] # explicit ignore
 
     def read_stderr_pipe() -> None:
         with os.fdopen(read_fd, "r", buffering=1) as pipe_reader:

--- a/src/uipath/_cli/_evals/_console_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_console_progress_reporter.py
@@ -150,7 +150,10 @@ class ConsoleProgressReporter:
                 error_msg = self._extract_error_message(payload)
                 self._display_failed_evaluation(payload.eval_item.name)
 
-                if payload.exception_details.runtime_exception:  # type: ignore
+                if (
+                    payload.exception_details
+                    and payload.exception_details.runtime_exception
+                ):
                     self._display_logs_panel(
                         payload.eval_item.name, payload.logs, error_msg
                     )

--- a/src/uipath/_cli/_evals/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluator_factory.py
@@ -5,7 +5,9 @@ from typing import Any, Dict
 
 from pydantic import TypeAdapter
 
-from uipath._cli._evals._helpers import try_extract_file_and_class_name  # type: ignore
+from uipath._cli._evals._helpers import (  # type: ignore # Remove after gnarly fix
+    try_extract_file_and_class_name,
+)
 from uipath._cli._evals._models._evaluator import (
     EqualsEvaluatorParams,
     EvaluatorConfig,
@@ -167,10 +169,12 @@ class EvaluatorFactory:
         evaluator_id = data.get("id")
         if not evaluator_id or not isinstance(evaluator_id, str):
             raise ValueError("Evaluator 'id' must be a non-empty string")
-        return ContainsEvaluator(
-            id=evaluator_id,
-            config=EvaluatorFactory._prepare_evaluator_config(data),
-        )  # type: ignore
+        return TypeAdapter(ContainsEvaluator).validate_python(
+            {
+                "id": evaluator_id,
+                "config": EvaluatorFactory._prepare_evaluator_config(data),
+            }
+        )
 
     @staticmethod
     def _create_coded_evaluator_internal(
@@ -247,10 +251,12 @@ class EvaluatorFactory:
         evaluator_id = data.get("id")
         if not evaluator_id or not isinstance(evaluator_id, str):
             raise ValueError("Evaluator 'id' must be a non-empty string")
-        return evaluator_class(
-            id=evaluator_id,
-            config=EvaluatorFactory._prepare_evaluator_config(data),
-        )  # type: ignore
+        return TypeAdapter(evaluator_class).validate_python(
+            {
+                "id": evaluator_id,
+                "config": EvaluatorFactory._prepare_evaluator_config(data),
+            }
+        )
 
     @staticmethod
     def _create_exact_match_evaluator(

--- a/src/uipath/_cli/_evals/_helpers.py
+++ b/src/uipath/_cli/_evals/_helpers.py
@@ -1,4 +1,4 @@
-# type: ignore
+# type: ignore # Gnarly issue
 import ast
 import importlib.util
 import json

--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -906,13 +906,13 @@ class StudioWebProgressReporter:
             headers=self._tenant_header(),
         )
 
-    def _tenant_header(self) -> dict[str, str]:
+    def _tenant_header(self) -> dict[str, str | None]:
         tenant_id = os.getenv(ENV_TENANT_ID, None)
         if not tenant_id:
             self._console.error(
                 f"{ENV_TENANT_ID} env var is not set. Please run 'uipath auth'."
             )
-        return {HEADER_INTERNAL_TENANT_ID: tenant_id}  # type: ignore
+        return {HEADER_INTERNAL_TENANT_ID: tenant_id}
 
     async def _send_parent_trace(
         self, eval_set_run_id: str, eval_set_name: str

--- a/src/uipath/_cli/_evals/mocks/mockito_mocker.py
+++ b/src/uipath/_cli/_evals/mocks/mockito_mocker.py
@@ -6,7 +6,10 @@ https://mockito-python.readthedocs.io/en/latest/
 from typing import Any, Callable
 
 from hydra.utils import instantiate
-from mockito import invocation, mocking  # type: ignore[import-untyped]
+from mockito import (  # type: ignore[import-untyped] # explicit ignore
+    invocation,
+    mocking,
+)
 
 from uipath._cli._evals._models._evaluation_set import (
     EvaluationItem,

--- a/src/uipath/_cli/_runtime/_contracts.py
+++ b/src/uipath/_cli/_runtime/_contracts.py
@@ -25,8 +25,10 @@ from uuid import uuid4
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
+from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined] # explicit ignore
+    BaseInstrumentor,
+)
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
     SimpleSpanProcessor,
@@ -1003,12 +1005,15 @@ class UiPathExecutionTraceProcessorMixin:
             parent_span = trace.get_current_span()
 
         if parent_span and parent_span.is_recording():
-            execution_id = parent_span.attributes.get("execution.id")  # type: ignore[attr-defined]
-            if execution_id:
-                span.set_attribute("execution.id", execution_id)
-            evaluation_id = parent_span.attributes.get("evaluation.id")  # type: ignore[attr-defined]
-            if evaluation_id:
-                span.set_attribute("evaluation.id", evaluation_id)
+            if isinstance(parent_span, ReadableSpan):
+                attributes = parent_span.attributes
+                if attributes:
+                    execution_id = attributes.get("execution.id")
+                    if execution_id:
+                        span.set_attribute("execution.id", execution_id)
+                    evaluation_id = attributes.get("evaluation.id")
+                    if evaluation_id:
+                        span.set_attribute("evaluation.id", evaluation_id)
 
 
 class UiPathExecutionBatchTraceProcessor(

--- a/src/uipath/_cli/_utils/_debug.py
+++ b/src/uipath/_cli/_utils/_debug.py
@@ -26,7 +26,7 @@ def setup_debugging(debug: bool, debug_port: int = 5678) -> bool:
 
     # Try to import debugpy, log warning if not available
     try:
-        import debugpy  # type: ignore[import-not-found]
+        import debugpy  # type: ignore[import-not-found] # explicit ignore
     except ImportError:
         console.warning(
             "debugpy not found, please install it and retry: '[uv] pip install debugpy'"

--- a/src/uipath/_cli/_utils/_project_files.py
+++ b/src/uipath/_cli/_utils/_project_files.py
@@ -21,7 +21,7 @@ from ._studio_project import (
 )
 
 try:
-    import tomllib  # type: ignore[import-not-found]
+    import tomllib  # type: ignore[import-not-found] # explicit ignore
 except ImportError:
     import tomli as tomllib
 logger = logging.getLogger(__name__)

--- a/src/uipath/_cli/_utils/_studio_project.py
+++ b/src/uipath/_cli/_utils/_studio_project.py
@@ -768,7 +768,7 @@ class StudioClient:
         self,
         *,
         local_file_path: Optional[str] = None,
-        file_content: Optional[str] = None,
+        file_content: Optional[str | bytes] = None,
         file_name: str,
         folder: Optional[ProjectFolder] = None,
         remote_file: Optional[ProjectFile] = None,
@@ -776,7 +776,7 @@ class StudioClient:
     ) -> tuple[str, str]:
         if local_file_path:
             with open(local_file_path, "rb") as f:
-                file_content = f.read()  # type: ignore
+                file_content = f.read()
         files_data = {"file": (file_name, file_content, "application/octet-stream")}
 
         if remote_file:

--- a/src/uipath/_cli/cli_invoke.py
+++ b/src/uipath/_cli/cli_invoke.py
@@ -9,7 +9,7 @@ import httpx
 from ._utils._console import ConsoleLogger
 
 try:
-    import tomllib  # type: ignore[import-not-found]
+    import tomllib  # type: ignore[import-not-found] # explicit ignore
 except ImportError:
     import tomli as tomllib
 

--- a/src/uipath/_cli/cli_register.py
+++ b/src/uipath/_cli/cli_register.py
@@ -2,7 +2,9 @@ import logging
 
 import click
 
-from ._evals._helpers import register_evaluator  # type: ignore[attr-defined]
+from ._evals._helpers import (  # type: ignore[attr-defined] # Remove after gnarly fix
+    register_evaluator,
+)
 from ._utils._console import ConsoleLogger
 from ._utils._resources import Resources
 

--- a/src/uipath/_cli/middlewares.py
+++ b/src/uipath/_cli/middlewares.py
@@ -116,7 +116,7 @@ class Middlewares:
                 else:
                     middlewares = list(entry_points.get("uipath.middlewares", []))
             except Exception:
-                middlewares = list(importlib.metadata.entry_points())  # type: ignore
+                middlewares = list(importlib.metadata.entry_points())  # type: ignore # explicit ignore
                 middlewares = [
                     ep for ep in middlewares if ep.group == "uipath.middlewares"
                 ]

--- a/src/uipath/_cli/services/_buckets_metadata.py
+++ b/src/uipath/_cli/services/_buckets_metadata.py
@@ -45,7 +45,7 @@ BUCKETS_METADATA = ServiceMetadata(
 BUCKETS_METADATA.validate_types()
 
 try:
-    from uipath.sdk import SDK  # type: ignore[import-not-found]
+    from uipath.sdk import SDK  # type: ignore[import-not-found] # explicit ignore
 
     sdk = SDK()
     validate_service_protocol(sdk.client.buckets, "buckets")

--- a/src/uipath/_services/__init__.py
+++ b/src/uipath/_services/__init__.py
@@ -6,7 +6,9 @@ from .buckets_service import BucketsService
 from .connections_service import ConnectionsService
 from .context_grounding_service import ContextGroundingService
 from .conversations_service import ConversationsService
-from .documents_service import DocumentsService  # type: ignore[attr-defined]
+from .documents_service import (  # type: ignore[attr-defined] # gnarly issue
+    DocumentsService,
+)
 from .entities_service import EntitiesService
 from .external_application_service import ExternalApplicationService
 from .folder_service import FolderService

--- a/src/uipath/_utils/_bindings.py
+++ b/src/uipath/_utils/_bindings.py
@@ -180,8 +180,8 @@ def resource_override(
 
             return func(**all_args)
 
-        wrapper._should_infer_bindings = True  # type: ignore[attr-defined]
-        wrapper._infer_bindings_mappings = {  # type: ignore[attr-defined]
+        wrapper._should_infer_bindings = True  # type: ignore[attr-defined] # probably a better way to do this
+        wrapper._infer_bindings_mappings = {  # type: ignore[attr-defined] # probably a better way to do this
             "name": resource_identifier,
             "folder_path": folder_identifier,
         }
@@ -194,6 +194,6 @@ def get_inferred_bindings_names(cls: T):
     inferred_bindings = {}
     for name, method in inspect.getmembers(cls, inspect.isfunction):
         if hasattr(method, "_should_infer_bindings") and method._should_infer_bindings:
-            inferred_bindings[name] = method._infer_bindings_mappings  # type: ignore
+            inferred_bindings[name] = method._infer_bindings_mappings  # type: ignore # probably a better way to do this
 
     return inferred_bindings

--- a/src/uipath/eval/evaluators/base_evaluator.py
+++ b/src/uipath/eval/evaluators/base_evaluator.py
@@ -3,6 +3,7 @@
 import json
 import warnings
 from abc import ABC, abstractmethod
+from types import NoneType
 from typing import Any, Generic, TypeVar, Union, cast, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -96,8 +97,8 @@ class BaseEvaluator(BaseModel, Generic[T, C, J], ABC):
             cls.evaluate, "_has_metrics_decorator", False
         ):
             new_evaluation_method = track_evaluation_metrics(cls.evaluate)
-            new_evaluation_method._has_metrics_decorator = True  # type: ignore[attr-defined]
-            cls.evaluate = new_evaluation_method  # type: ignore[method-assign]
+            new_evaluation_method._has_metrics_decorator = True  # type: ignore[attr-defined] # probably a better way to do this
+            cls.evaluate = new_evaluation_method  # type: ignore[method-assign] # probably a better way to do this
 
     @property
     def name(self) -> str:
@@ -377,8 +378,10 @@ class BaseEvaluator(BaseModel, Generic[T, C, J], ABC):
             justification_type = args[0]
 
             # Validate the justification type - must be str, type(None), or BaseEvaluatorJustification subclass
-            if justification_type is str or justification_type is type(None):
+            if justification_type is str:
                 return cast(type[J], justification_type)
+            elif justification_type is None:
+                return cast(type[J], NoneType)
             elif isinstance(justification_type, type) and issubclass(
                 justification_type, BaseEvaluatorJustification
             ):

--- a/src/uipath/eval/evaluators/legacy_base_evaluator.py
+++ b/src/uipath/eval/evaluators/legacy_base_evaluator.py
@@ -110,10 +110,5 @@ class LegacyBaseEvaluator(
 
         Returns:
             EvaluationResult containing the score and details
-
-        Note:
-            The type: ignore[override] is necessary because legacy evaluators accept
-            evaluation_criteria of any type T, while the base class expects BaseEvaluationCriteria.
-            This is intentional to maintain backward compatibility with legacy evaluators.
         """
         pass

--- a/src/uipath/eval/mocks/mockable.py
+++ b/src/uipath/eval/mocks/mockable.py
@@ -8,7 +8,9 @@ import threading
 from typing import Any, List, Optional
 
 from pydantic import TypeAdapter
-from pydantic_function_models import ValidatedFunction  # type: ignore[import-untyped]
+from pydantic_function_models import (  # type: ignore[import-untyped] # explicit ignore
+    ValidatedFunction,
+)
 
 from uipath._cli._evals._models._mocks import ExampleCall
 from uipath._cli._evals.mocks.mocker import UiPathNoMockFoundError

--- a/src/uipath/models/entities.py
+++ b/src/uipath/models/entities.py
@@ -238,7 +238,7 @@ class EntityRecord(BaseModel):
         # Dynamically create the Pydantic model class
         dynamic_model = create_model(
             f"Dynamic_{user_class.__name__}",
-            **pydantic_fields,  # type: ignore
+            **pydantic_fields,  # type: ignore[call-overload] # __base__ causes an issue. type checker cannot know that the key does not contain "__base__"
         )
 
         # Validate input data

--- a/src/uipath/utils/dynamic_schema.py
+++ b/src/uipath/utils/dynamic_schema.py
@@ -54,7 +54,7 @@ def jsonschema_to_pydantic(
                 class DynamicEnum(base_type, Enum):
                     pass
 
-                type_ = DynamicEnum(prop.get("title", "DynamicEnum"), dynamic_members)  # type: ignore[call-arg]
+                type_ = DynamicEnum(prop.get("title", "DynamicEnum"), dynamic_members)  # type: ignore[call-arg] # explicit ignore
                 return type_
             elif type_ == "array":
                 item_type: Any = convert_type(prop.get("items", {}))

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -184,12 +184,12 @@ class TestAuth:
                 "organization_id": "org-id",
             }
             portal.selected_tenant = "MyTenantName"
+            with runner.isolated_filesystem():
+                result = runner.invoke(
+                    cli, ["auth", "--alpha", "--tenant", "MyTenantName", "--force"]
+                )
 
-            result = runner.invoke(
-                cli, ["auth", "--alpha", "--tenant", "MyTenantName", "--force"]
-            )
+                assert result.exit_code == 0, result.output
+                mock_open.assert_called_once()
 
-            assert result.exit_code == 0, result.output
-            mock_open.assert_called_once()
-
-            portal.resolve_tenant_info.assert_called_once_with("MyTenantName")
+                portal.resolve_tenant_info.assert_called_once_with("MyTenantName")


### PR DESCRIPTION
# type: ignore is bad, m'kay?

The only ones remaining are:

1. Gnarly issues that takes a long time to fix.
2. Call-assignment issues
3. Explicit ignores which have no clean solution

Also fixing a unit test (un-isolated test writes `.env` file)