### PR TITLE
fix: validate coded agent project on push/pull

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.1.183"
+version = "2.1.184"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath/_cli/_push/sw_file_handler.py
+++ b/src/uipath/_cli/_push/sw_file_handler.py
@@ -334,7 +334,7 @@ class SwFileHandler:
         2. Recursively finds all empty folders
         3. Deletes each empty folder
         """
-        structure = await self._studio_client.get_project_structure_async()
+        structure = await self._studio_client.get_project_structure_async(force=True)
 
         empty_folders = self._find_empty_folders(structure)
 

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -12,7 +12,11 @@ from ..._utils._bindings import ResourceOverwrite, ResourceOverwriteParser
 from ..._utils.constants import DOTENV_FILE, ENV_UIPATH_ACCESS_TOKEN
 from ..spinner import Spinner
 from ._console import ConsoleLogger
-from ._studio_project import StudioClient, StudioProjectMetadata
+from ._studio_project import (
+    NonCodedAgentProjectException,
+    StudioClient,
+    StudioProjectMetadata,
+)
 
 
 def get_claim_from_token(claim_name: str) -> Optional[str]:
@@ -131,6 +135,16 @@ def clean_directory(directory: str) -> None:
 
 def load_environment_variables():
     load_dotenv(dotenv_path=os.path.join(os.getcwd(), DOTENV_FILE), override=True)
+
+
+async def ensure_coded_agent_project(studio_client: StudioClient):
+    try:
+        await studio_client.ensure_coded_agent_project_async()
+    except NonCodedAgentProjectException:
+        console = ConsoleLogger()
+        console.error(
+            "The targeted Studio Web project is not of type coded agent. Please check the UIPATH_PROJECT_ID environment variable."
+        )
 
 
 async def may_override_files(

--- a/src/uipath/_cli/_utils/_project_files.py
+++ b/src/uipath/_cli/_utils/_project_files.py
@@ -541,7 +541,7 @@ async def pull_project(
     download_configuration: dict[str | None, Path],
     studio_client: StudioClient,
 ) -> AsyncIterator[UpdateEvent]:
-    """Pull project with configurable conflict handling.
+    """Pull project files.
 
     Yields:
         FileOperationUpdate: Progress updates for each file operation

--- a/src/uipath/_cli/cli_pull.py
+++ b/src/uipath/_cli/cli_pull.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 
 from .._config import UiPathConfig
-from ._utils._common import may_override_files
+from ._utils._common import ensure_coded_agent_project, may_override_files
 from ._utils._console import ConsoleLogger
 from ._utils._project_files import (
     ProjectPullError,
@@ -51,6 +51,8 @@ def pull(root: Path, overwrite: bool) -> None:
         return
 
     studio_client = StudioClient(project_id=project_id)
+
+    asyncio.run(ensure_coded_agent_project(studio_client))
 
     if not overwrite:
         may_override = asyncio.run(may_override_files(studio_client, "local"))

--- a/src/uipath/_cli/cli_push.py
+++ b/src/uipath/_cli/cli_push.py
@@ -10,7 +10,7 @@ from .._config import UiPathConfig
 from ..models import ResourceType
 from ..models.errors import FolderNotFoundException
 from ._push.sw_file_handler import SwFileHandler
-from ._utils._common import may_override_files
+from ._utils._common import ensure_coded_agent_project, may_override_files
 from ._utils._console import ConsoleLogger
 from ._utils._project_files import (
     Severity,
@@ -257,6 +257,8 @@ def push(root: str, ignore_resources: bool, nolock: bool, overwrite: bool) -> No
         return
 
     studio_client = StudioClient(project_id=project_id)
+
+    asyncio.run(ensure_coded_agent_project(studio_client))
 
     if not overwrite:
         may_override = asyncio.run(may_override_files(studio_client, "remote"))

--- a/src/uipath/_utils/constants.py
+++ b/src/uipath/_utils/constants.py
@@ -62,6 +62,7 @@ TEMP_ATTACHMENTS_FOLDER = "uipath_attachments"
 COMMUNITY_agents_SUFFIX = "-community-agents"
 
 # File names
+PYTHON_CONFIGURATION_FILE = "pyproject.toml"
 UIPATH_CONFIG_FILE = "uipath.json"
 UIPATH_BINDINGS_FILE = "bindings.json"
 ENTRY_POINTS_FILE = "entry-points.json"

--- a/uv.lock
+++ b/uv.lock
@@ -2614,7 +2614,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.1.183"
+version = "2.1.184"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- validate coded agent project on push/pull
- added in memory caching for get_project_structure method