### PR TITLE
fix: set trace_manager on context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.2.3"
+version = "2.2.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.0.5, <0.1.0",
-  "uipath-runtime>=0.0.20, <0.1.0",
+  "uipath-runtime>=0.0.21, <0.1.0",
   "click>=8.1.8",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -161,11 +161,13 @@ def eval(
                 console_reporter = ConsoleProgressReporter()
                 await console_reporter.subscribe_to_eval_runtime_events(event_bus)
 
+                trace_manager = UiPathTraceManager()
+
                 with UiPathRuntimeContext.with_defaults(
                     output_file=output_file,
+                    trace_manager=trace_manager,
+                    command="eval",
                 ) as ctx:
-                    trace_manager = UiPathTraceManager()
-
                     if ctx.job_id:
                         trace_manager.add_span_exporter(LlmOpsHttpExporter())
 
@@ -179,10 +181,7 @@ def eval(
 
                             async with ResourceOverwritesContext(
                                 lambda: studio_client.get_resource_overwrites()
-                            ) as rcs_ctx:
-                                console.info(
-                                    f"Applied {rcs_ctx.overwrites_count} resource overwrite(s)"
-                                )
+                            ):
                                 ctx.result = await evaluate(
                                     runtime_factory,
                                     trace_manager,

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -158,6 +158,8 @@ def run(
                             await factory.dispose()
 
             async def execute() -> None:
+                trace_manager = UiPathTraceManager()
+
                 ctx = UiPathRuntimeContext.with_defaults(
                     entrypoint=entrypoint,
                     input=input,
@@ -165,9 +167,9 @@ def run(
                     output_file=output_file,
                     trace_file=trace_file,
                     resume=resume,
+                    command="run",
+                    trace_manager=trace_manager,
                 )
-
-                trace_manager = UiPathTraceManager()
 
                 if ctx.trace_file:
                     trace_manager.add_span_exporter(
@@ -179,10 +181,7 @@ def run(
 
                     async with ResourceOverwritesContext(
                         lambda: read_resource_overwrites_from_file(ctx.runtime_dir)
-                    ) as rcs_ctx:
-                        console.info(
-                            f"Applied {rcs_ctx.overwrites_count} resource overwrite(s)"
-                        )
+                    ):
                         await execute_runtime(ctx)
 
                 else:

--- a/tests/resource_overrides/test_resource_overrides.py
+++ b/tests/resource_overrides/test_resource_overrides.py
@@ -176,7 +176,6 @@ class TestResourceOverrides:
         # Verify execution was successful
         print(result.output)
         assert result.exit_code == 0
-        assert "Applied 6 resource overwrite(s)" in result.output
 
         # Now verify that overridden values were used in API calls
         # Get all requests made

--- a/uv.lock
+++ b/uv.lock
@@ -2326,7 +2326,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.3"
+version = "2.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2390,7 +2390,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.0.5,<0.1.0" },
-    { name = "uipath-runtime", specifier = ">=0.0.20,<0.1.0" },
+    { name = "uipath-runtime", specifier = ">=0.0.21,<0.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2435,14 +2435,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.20"
+version = "0.0.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/9a/e528f60cf248b62cb7828005e4957ad5d21ae509eeaf5a5eddfb38d4f118/uipath_runtime-0.0.20.tar.gz", hash = "sha256:eb4e83e50ef48b2cd4010d805853a03de470dd046626f1f0faa4af49d545278d", size = 87689, upload-time = "2025-11-26T09:03:18.184Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/f8/2128bfd7add45e2f596955c03161ed69a365bab68a5d3c6238dcf5e2a548/uipath_runtime-0.0.21.tar.gz", hash = "sha256:9e25051f9168101cceb5e553149519f7d05764a847fea3fa0f4ec25d42e56fcb", size = 87722, upload-time = "2025-11-26T14:44:11.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/04/6428eb4569600533aa47f8593a3a59842f9735630a2d568988e2fa8e4ea3/uipath_runtime-0.0.20-py3-none-any.whl", hash = "sha256:c8b3b2945f10db8781510c3f923fe14e0c325154cd747acaabfd07b7a3f82901", size = 33919, upload-time = "2025-11-26T09:03:16.628Z" },
+    { url = "https://files.pythonhosted.org/packages/de/fa/677a787cc6d02791d3c0a25ec0b83dd575e331dcd81bcae92fc668013aac/uipath_runtime-0.0.21-py3-none-any.whl", hash = "sha256:6459c451e707e9bf3308a9cd126a1dde11b9f752af7b2914f2df85561199ee7a", size = 33953, upload-time = "2025-11-26T14:44:09.988Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.4.dev1009523110",

  # Any version from PR
  "uipath>=2.2.4.dev1009520000,<2.2.4.dev1009530000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```