### PR TITLE
fix: dispose debug runtime

### DIFF
--- a/src/uipath/_cli/cli_debug.py
+++ b/src/uipath/_cli/cli_debug.py
@@ -104,6 +104,7 @@ def debug(
                     resume=resume,
                 ) as ctx:
                     runtime: UiPathRuntimeProtocol | None = None
+                    debug_runtime: UiPathRuntimeProtocol | None = None
                     factory: UiPathRuntimeFactoryProtocol | None = None
                     try:
                         trace_manager = UiPathTraceManager()
@@ -128,6 +129,8 @@ def debug(
                         )
 
                     finally:
+                        if debug_runtime:
+                            await debug_runtime.dispose()
                         if runtime:
                             await runtime.dispose()
                         if factory:


### PR DESCRIPTION
## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.3.dev1009533100",

  # Any version from PR
  "uipath>=2.2.3.dev1009530000,<2.2.3.dev1009540000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```