### PR TITLE
fix: setup logging

### DIFF
--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -5,6 +5,7 @@ import click
 
 from uipath.functions import register_default_runtime_factory
 
+from .._utils._logs import setup_logging
 from ._utils._common import add_cwd_to_path, load_environment_variables
 from ._utils._context import CliContext
 from .cli_add import add as add
@@ -87,6 +88,8 @@ def cli(
         output_format=format,
         debug=debug,
     )
+
+    setup_logging(should_debug=debug)
 
     if lv:
         try:

--- a/src/uipath/_utils/_logs.py
+++ b/src/uipath/_utils/_logs.py
@@ -5,9 +5,17 @@ logger: logging.Logger = logging.getLogger("uipath")
 
 
 def setup_logging(should_debug: Optional[bool] = None) -> None:
-    if not logging.root.handlers and not logger.handlers:
-        logging.basicConfig(
-            format="%(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
+    """Configure logging for the CLI."""
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter(
+                fmt="%(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
         )
+        logger.addHandler(handler)
         logger.setLevel(logging.DEBUG if should_debug else logging.INFO)
+
+        # Prevent propagation to root logger to avoid duplicate logs
+        logger.propagate = False

--- a/src/uipath/platform/_uipath.py
+++ b/src/uipath/platform/_uipath.py
@@ -26,7 +26,6 @@ from .._services import (
     UiPathOpenAIService,
 )
 from .._utils._auth import resolve_config
-from .._utils._logs import setup_logging
 from .errors import BaseUrlMissingError, SecretMissingError
 
 
@@ -55,7 +54,6 @@ class UiPath:
                     raise BaseUrlMissingError() from e
                 elif error["loc"][0] == "secret":
                     raise SecretMissingError() from e
-        setup_logging(should_debug=debug)
         self._execution_context = ExecutionContext()
 
     @property


### PR DESCRIPTION
## Description

This PR refactors logging setup to separate CLI concerns from SDK initialization. The `setup_logging` function is moved from the UiPath class constructor to the CLI entry point, ensuring that logging configuration only occurs when using the CLI, not when using the SDK programmatically. Additionally, the implementation is updated to configure a specific logger instance rather than using `logging.basicConfig`, which prevents interference with the root logger.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.3.dev1009573108",

  # Any version from PR
  "uipath>=2.2.3.dev1009570000,<2.2.3.dev1009580000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```