### PR TITLE
fix: apply resource overrides local run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
 [project]
 name = "uipath"
-version = "2.2.5"
+version = "2.2.6"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.0.5, <0.1.0",
-  "uipath-runtime>=0.0.21, <0.1.0",
-  "click>=8.1.8",
+  "uipath-runtime>=0.0.23, <0.1.0",
+  "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",
   "python-dotenv>=1.0.1",
   "tenacity>=9.0.0",
   "pathlib>=1.0.1",
-  "rich>=13.0.0",
+  "rich>=14.2.0",
   "truststore>=0.10.1",
   "mockito>=1.5.4",
   "hydra-core>=1.3.2",

--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from enum import Enum
-from typing import Any, Literal, Set
+from typing import Any, Literal
 
 from pydantic import BaseModel
 from pysignalr.client import SignalRClient
@@ -40,7 +40,7 @@ class DebuggerState:
     """Maintains debugger state across execution."""
 
     def __init__(self):
-        self.breakpoints: Set[str] = set()
+        self.breakpoints: set[str] = set()
         self.step_mode: bool = False
 
     def add_breakpoint(self, node_name: str) -> None:
@@ -139,7 +139,7 @@ class ConsoleDebugBridge:
             symbol = "●"
 
         self.console.print(f"[{color}]{symbol} END[/{color}]")
-        output_data: dict[str, Any] = {}
+        output_data: dict[str, Any] | str = {}
         if runtime_result.output:
             if isinstance(runtime_result.output, BaseModel):
                 output_data = runtime_result.output.model_dump()
@@ -284,7 +284,7 @@ class ConsoleDebugBridge:
         self.console.print("  [yellow]q, quit[/yellow]         Exit debugger")
         self.console.print()
 
-    def _print_json(self, data: dict[str, Any], label: str = "data") -> None:
+    def _print_json(self, data: dict[str, Any] | str, label: str = "data") -> None:
         """Print JSON data with enhanced hierarchy."""
         try:
             # Create a tree for nested structure

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -612,7 +612,7 @@ class UiPathEvalRuntime:
         *,
         evaluation_criteria: Any,
     ) -> EvaluationResult:
-        output_data: dict[str, Any] = {}
+        output_data: dict[str, Any] | str = {}
         if execution_output.result.output:
             if isinstance(execution_output.result.output, BaseModel):
                 output_data = execution_output.result.output.model_dump()

--- a/src/uipath/eval/evaluators/output_evaluator.py
+++ b/src/uipath/eval/evaluators/output_evaluator.py
@@ -52,7 +52,9 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
 
     def _get_actual_output(self, agent_execution: AgentExecution) -> Any:
         """Get the actual output from the agent execution."""
-        if self.evaluator_config.target_output_key != "*":
+        if self.evaluator_config.target_output_key != "*" and isinstance(
+            agent_execution.agent_output, dict
+        ):
             try:
                 return agent_execution.agent_output[
                     self.evaluator_config.target_output_key

--- a/src/uipath/eval/models/models.py
+++ b/src/uipath/eval/models/models.py
@@ -15,7 +15,7 @@ class AgentExecution(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     agent_input: dict[str, Any] | None
-    agent_output: dict[str, Any]
+    agent_output: dict[str, Any] | str
     agent_trace: list[ReadableSpan]
     expected_agent_behavior: str | None = None
     simulation_instructions: str = ""

--- a/tests/cli/eval/test_evaluate.py
+++ b/tests/cli/eval/test_evaluate.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
+from pydantic import BaseModel
 from uipath.core.tracing import UiPathTraceManager
 from uipath.runtime import (
     UiPathExecuteOptions,
@@ -19,7 +20,6 @@ from uipath._events._event_bus import EventBus
 
 
 async def test_evaluate():
-    # Arrange
     event_bus = EventBus()
     trace_manager = UiPathTraceManager()
     context = UiPathEvalContext()
@@ -95,8 +95,11 @@ async def test_evaluate():
     UiPathEvalOutput.model_validate(result.output).model_dump_json()
     assert result.output
     output_dict = (
-        result.output if isinstance(result.output, dict) else result.output.model_dump()
+        result.output.model_dump()
+        if isinstance(result.output, BaseModel)
+        else result.output
     )
+    assert isinstance(output_dict, dict)
     assert (
         output_dict["evaluationSetResults"][0]["evaluationRunResults"][0]["result"][
             "score"

--- a/uv.lock
+++ b/uv.lock
@@ -2401,7 +2401,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.5"
+version = "2.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2451,7 +2451,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1.8" },
+    { name = "click", specifier = ">=8.3.1" },
     { name = "coverage", specifier = ">=7.8.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hydra-core", specifier = ">=1.3.2" },
@@ -2462,11 +2462,11 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pysignalr", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "rich", specifier = ">=13.0.0" },
+    { name = "rich", specifier = ">=14.2.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.0.5,<0.1.0" },
-    { name = "uipath-runtime", specifier = ">=0.0.21,<0.1.0" },
+    { name = "uipath-runtime", specifier = ">=0.0.23,<0.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2512,14 +2512,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.22"
+version = "0.0.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/fe/f4fa9383a7384d7a9704d5162869798c5384187c764a20401c1441fc8070/uipath_runtime-0.0.22.tar.gz", hash = "sha256:07d0eecfc805a02119aecae5b4e56552979e85745f5287ea48bebabf15e514ef", size = 88056, upload-time = "2025-11-27T13:34:28.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/fa/0813f32db1127b6a958f478b537dc864f5d16eadd640b21bef31081c0bca/uipath_runtime-0.0.23.tar.gz", hash = "sha256:59804772dadb5344fc12d785e04ed382db7205f1233dffa00c6ad34440f8477e", size = 88070, upload-time = "2025-11-28T14:58:30.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/78/3729b4492913a8ec23fbedcbdb0401d589fb1f2b9abda19440c97fa0c21a/uipath_runtime-0.0.22-py3-none-any.whl", hash = "sha256:b0a49c9a8ab7fae10242b17f5864498bcc4ed72c8b73882d2fae75df532c4885", size = 34272, upload-time = "2025-11-27T13:34:27.219Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/2da25d54fc2145376c4dff9ea62604392ee75222d3a1b87e30e261f83097/uipath_runtime-0.0.23-py3-none-any.whl", hash = "sha256:dcd65ca7a1ebe421f49213834361ec2ccdeb81b5c57326f4a7e1c27669c92e68", size = 34299, upload-time = "2025-11-28T14:58:29.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR fixes a bug where resource overwrites were not being applied during local/debug runs. Previously, the `ResourceOverwritesContext` was only wrapping the execution path when `ctx.job_id` was present (production runs), but not for debug runs. The fix refactors the code to ensure resource overwrites are applied consistently across both execution paths.