### PR TITLE
fix: add polling when debugging locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.2.6"
+version = "2.2.7"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.0.5, <0.1.0",
-  "uipath-runtime>=0.0.23, <0.1.0",
+  "uipath-runtime>=0.1.0, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/src/uipath/_cli/cli_debug.py
+++ b/src/uipath/_cli/cli_debug.py
@@ -112,8 +112,13 @@ def debug(
                     factory: UiPathRuntimeFactoryProtocol | None = None
 
                     try:
+                        trigger_poll_interval: float = 5.0
+
                         if ctx.job_id:
                             trace_manager.add_span_exporter(LlmOpsHttpExporter())
+                            trigger_poll_interval = (
+                                0.0  # Polling disabled for production jobs
+                            )
 
                         factory = UiPathRuntimeFactoryRegistry.get(context=ctx)
 
@@ -126,6 +131,7 @@ def debug(
                         debug_runtime = UiPathDebugRuntime(
                             delegate=runtime,
                             debug_bridge=debug_bridge,
+                            trigger_poll_interval=trigger_poll_interval,
                         )
 
                         project_id = UiPathConfig.project_id

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -114,7 +114,9 @@ class TestHitlReader:
         job_error_info = JobErrorInfo(code="error code")
         job_id = 1234
 
-        mock_job = Job(id=job_id, key=job_key, state="Failed", job_error=job_error_info)
+        mock_job = Job(
+            id=job_id, key=job_key, state="Faulted", job_error=job_error_info
+        )
         mock_retrieve_async = AsyncMock(return_value=mock_job)
 
         with patch(

--- a/uv.lock
+++ b/uv.lock
@@ -2401,7 +2401,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.6"
+version = "2.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2466,7 +2466,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.0.5,<0.1.0" },
-    { name = "uipath-runtime", specifier = ">=0.0.23,<0.1.0" },
+    { name = "uipath-runtime", specifier = ">=0.1.0,<0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2512,14 +2512,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.0.23"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/fa/0813f32db1127b6a958f478b537dc864f5d16eadd640b21bef31081c0bca/uipath_runtime-0.0.23.tar.gz", hash = "sha256:59804772dadb5344fc12d785e04ed382db7205f1233dffa00c6ad34440f8477e", size = 88070, upload-time = "2025-11-28T14:58:30.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/5f/b48eaa87501ccffb067878ff99773fa89fbc1cafa8ab736d8fd5ae099b59/uipath_runtime-0.1.0.tar.gz", hash = "sha256:2a262eb29faeb1d62158ccaf1d1ec44752813625fdbcab5671a625c999c433ac", size = 87980, upload-time = "2025-11-29T13:10:32.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/6f/2da25d54fc2145376c4dff9ea62604392ee75222d3a1b87e30e261f83097/uipath_runtime-0.0.23-py3-none-any.whl", hash = "sha256:dcd65ca7a1ebe421f49213834361ec2ccdeb81b5c57326f4a7e1c27669c92e68", size = 34299, upload-time = "2025-11-28T14:58:29.385Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2a/39364e985269ac27b6b78d0323e6f516e25287bca87938a2088442b5cf06/uipath_runtime-0.1.0-py3-none-any.whl", hash = "sha256:997b53737fc6f22bb2e80700fd45c6b0a7912af6843fd4a103c58bdcf30f7fdd", size = 34207, upload-time = "2025-11-29T13:10:31.127Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR adds polling capability for local debugging by introducing a configurable `trigger_poll_interval` parameter to the `UiPathDebugRuntime`. When debugging locally (without a `job_id`), the runtime now polls for trigger events every 5 seconds. For production jobs with a `job_id`, polling is disabled (set to 0.0). 

Ref: https://github.com/UiPath/uipath-runtime-python/pull/36

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.7.dev1009623132",

  # Any version from PR
  "uipath>=2.2.7.dev1009620000,<2.2.7.dev1009630000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```