### PR TITLE
fix: add Failed state for eval runs [AE-799]

### DIFF
--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -261,6 +261,7 @@ class EvaluationStatus(IntEnum):
     PENDING = 0
     IN_PROGRESS = 1
     COMPLETED = 2
+    FAILED = 3
 
 
 def _discriminate_eval_set(

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -260,7 +260,16 @@ class UiPathEvalRuntime:
         evaluator_averages: dict[str, float] = defaultdict(float)
         evaluator_count: dict[str, int] = defaultdict(int)
 
+        # Check if any eval runs failed
+        any_failed = False
         for eval_run_result in results.evaluation_set_results:
+            # Check if the agent execution had an error
+            if (
+                eval_run_result.agent_execution_output
+                and eval_run_result.agent_execution_output.result.error
+            ):
+                any_failed = True
+
             for result_dto in eval_run_result.evaluation_run_results:
                 evaluator_averages[result_dto.evaluator_id] += result_dto.result.score
                 evaluator_count[result_dto.evaluator_id] += 1
@@ -274,6 +283,7 @@ class UiPathEvalRuntime:
             EvalSetRunUpdatedEvent(
                 execution_id=self.execution_id,
                 evaluator_scores=evaluator_averages,
+                success=not any_failed,
             ),
             wait_for_completion=False,
         )

--- a/src/uipath/_events/_events.py
+++ b/src/uipath/_events/_events.py
@@ -62,6 +62,7 @@ class EvalRunUpdatedEvent(BaseModel):
 class EvalSetRunUpdatedEvent(BaseModel):
     execution_id: str
     evaluator_scores: dict[str, float]
+    success: bool = True
 
 
 ProgressEvent = Union[

--- a/src/uipath/tracing/_otel_exporters.py
+++ b/src/uipath/tracing/_otel_exporters.py
@@ -115,6 +115,10 @@ class LlmOpsHttpExporter(SpanExporter):
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         """Export spans to UiPath LLM Ops."""
+        if len(spans) == 0:
+            logger.warning("No spans to export")
+            return SpanExportResult.SUCCESS
+
         logger.debug(
             f"Exporting {len(spans)} spans to {self.base_url}/llmopstenant_/api/Traces/spans"
         )


### PR DESCRIPTION
Analogue of https://github.com/UiPath/Agents/pull/3896

Handles Failed state changes in as an analgoue for `Agents` backend.  

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.26.dev1009733316",

  # Any version from PR
  "uipath>=2.2.26.dev1009730000,<2.2.26.dev1009740000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```