### PR TITLE
ci: pin release branch for langchain cross tests

### DIFF
--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'UiPath/uipath-langchain-python'
+          ref: 'release/v0.0.x'
           path: 'uipath-langchain-python'
 
       - name: Update uipath-python version
@@ -65,6 +66,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'UiPath/uipath-langchain-python'
+          ref: 'release/v0.0.x'
           path: 'uipath-langchain-python'
 
       - name: Discover testcases
@@ -113,6 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'UiPath/uipath-langchain-python'
+          ref: 'release/v0.0.x'
           path: 'uipath-langchain-python'
 
       - name: Update uipath-python version

--- a/.github/workflows/test-uipath-llamaindex.yml
+++ b/.github/workflows/test-uipath-llamaindex.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'UiPath/uipath-llamaindex-python'
+          ref: 'release/0.0.x'
           path: 'uipath-llamaindex-python'
 
       - name: Update uipath-python version
@@ -65,6 +66,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'UiPath/uipath-llamaindex-python'
+          ref: 'release/0.0.x'
           path: 'uipath-llamaindex-python'
 
       - name: Discover testcases
@@ -112,6 +114,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'UiPath/uipath-llamaindex-python'
+          ref: 'release/0.0.x'
           path: 'uipath-llamaindex-python'
 
       - name: Update uipath-python version


### PR DESCRIPTION
Pin `uipath-langchain-python` cross-repo tests to `release/v0.0.x` branch for compatibility with `release/v2.1.x`.