### PR TITLE
fix: run/debug redirect stdout to file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath"
-version = "2.2.26"
+version = "2.2.27"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-  "uipath-runtime>=0.2.3, <0.3.0",
+  "uipath-runtime>=0.2.4, <0.3.0",
   "uipath-core>=0.1.0, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import signal
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Any, Literal
@@ -75,6 +76,7 @@ class ConsoleDebugBridge:
             verbose: If True, show state updates. If False, only show breakpoints.
         """
         self.console = Console(force_terminal=True)
+        self.is_terminal = sys.stdout.isatty()
         self.verbose = verbose
         self.state = DebuggerState()
 
@@ -372,6 +374,20 @@ class ConsoleDebugBridge:
 
     def _print_json(self, data: dict[str, Any] | str, label: str = "data") -> None:
         """Print JSON data with enhanced hierarchy."""
+        # Check if output is being redirected
+        if not self.is_terminal:
+            # Plain text output for file redirection
+            try:
+                json_str = json.dumps(data, indent=2, default=str)
+                print(f"\n{label}:")
+                print(json_str)
+                print()
+            except Exception:
+                print(f"\n{label}:")
+                print(str(data))
+                print()
+            return
+
         try:
             # Create a tree for nested structure
             tree = Tree(f"[bold cyan]{label}[/bold cyan]")

--- a/src/uipath/_cli/_utils/_console.py
+++ b/src/uipath/_cli/_utils/_console.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager
 from enum import Enum
 from typing import Any, Iterator, Type
@@ -83,6 +84,13 @@ class ConsoleLogger:
             level: The log level (determines the emoji)
             fg: Optional foreground color for the message
         """
+        # Check if stdout is closed or broken
+        try:
+            if sys.stdout.closed:
+                return
+        except (AttributeError, ValueError, OSError):
+            return
+
         # Stop any active spinner before logging
         self._stop_spinner_if_active()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.26"
+version = "2.2.27"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2542,7 +2542,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.1.0,<0.2.0" },
-    { name = "uipath-runtime", specifier = ">=0.2.3,<0.3.0" },
+    { name = "uipath-runtime", specifier = ">=0.2.4,<0.3.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2588,14 +2588,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/50/fe3da51da1426d49e73ae316b3f83ad9ceba942c2b45ecbd9919ef7fd719/uipath_runtime-0.2.3.tar.gz", hash = "sha256:d2c993586ad6bfc35de5a224f90589276f45105086b5fd955fe9be4a284ba5fd", size = 95481, upload-time = "2025-12-06T08:13:22.968Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/46/c035cf6464d5512f7a8e7ce85b6deab413c93f045c63c4df5eae8eb6449b/uipath_runtime-0.2.4.tar.gz", hash = "sha256:e402e7fd08de9c06a9584d56509187c2b0940da75dccdc55efc0726f7892b7f0", size = 95864, upload-time = "2025-12-07T12:47:10.811Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/a0/b1898a03c6a13edc98f7497a43edae342616e4084a7f49d51adfe0194be1/uipath_runtime-0.2.3-py3-none-any.whl", hash = "sha256:ae8f56de81f630ba719f832bd67ec548cea97540066820bb0a9bf77a592c5e63", size = 36468, upload-time = "2025-12-06T08:13:21.327Z" },
+    { url = "https://files.pythonhosted.org/packages/54/47/7610adecf30a44eedd96ebedcf400f5ec0dab8a055397ac8d4fb6f55eed4/uipath_runtime-0.2.4-py3-none-any.whl", hash = "sha256:01bcb68ec186521451a9bdca0736192cc62202b46b5df1226454fa282090b846", size = 36883, upload-time = "2025-12-07T12:47:09.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description


This PR enables stdout redirection to files for `uipath run` and `uipath debug` CLI commands by detecting when output is redirected (via `sys.stdout.isatty()`) and adjusting output formatting accordingly. This allows commands like `uipath run agent '{"messages": [...]}' > output.logs` to work properly by outputting plain text instead of rich-formatted/colored output when stdout is not a TTY.

Ref: https://github.com/UiPath/uipath-runtime-python/pull/46

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.27.dev1009983310",

  # Any version from PR
  "uipath>=2.2.27.dev1009980000,<2.2.27.dev1009990000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```