### PR TITLE
fix(traces): set parent span id only to roots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.28"
+version = "2.2.29"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/tracing/_utils.py
+++ b/src/uipath/tracing/_utils.py
@@ -214,11 +214,11 @@ class _SpanUtils:
         parent_id = None
         if otel_span.parent is not None:
             parent_id = _SpanUtils.span_id_to_uuid4(otel_span.parent.span_id)
-
-        parent_span_id_str = env.get("UIPATH_PARENT_SPAN_ID")
-
-        if parent_span_id_str:
-            parent_id = uuid.UUID(parent_span_id_str)
+        else:
+            # Only set UIPATH_PARENT_SPAN_ID for root spans (spans without a parent)
+            parent_span_id_str = env.get("UIPATH_PARENT_SPAN_ID")
+            if parent_span_id_str:
+                parent_id = uuid.UUID(parent_span_id_str)
 
         # Build attributes dict efficiently
         # Use the otel attributes as base - we only add new keys, don't modify existing

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.28"
+version = "2.2.29"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# Description
Set parent span id only to roots

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.29.dev1010073353",

  # Any version from PR
  "uipath>=2.2.29.dev1010070000,<2.2.29.dev1010080000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```