### PR TITLE
feat(IterableEvals): evals are now iterable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.33"
+version = "2.2.34"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_utils/_parallelization.py
+++ b/src/uipath/_cli/_utils/_parallelization.py
@@ -1,0 +1,60 @@
+import asyncio
+from typing import Awaitable, Iterable, TypeVar
+
+T = TypeVar("T")
+
+
+async def execute_parallel(
+    evaluation_result_iterable: Iterable[Awaitable[T]],
+    workers: int,
+) -> list[T]:
+    # Create a queue with max concurrency
+    queue: asyncio.Queue[tuple[int, Awaitable[T]] | None] = asyncio.Queue(
+        maxsize=workers
+    )
+
+    # Dictionary to store results with their original indices
+    results_dict: dict[int, T] = {}
+
+    # Producer task to fill the queue
+    async def producer() -> None:
+        for index, eval_item in enumerate(evaluation_result_iterable):
+            await queue.put((index, eval_item))
+        # Signal completion by putting None markers
+        for _ in range(workers):
+            await queue.put(None)
+
+    # Worker function to process items from the queue
+    async def worker(worker_id: int) -> None:
+        while True:
+            item = await queue.get()
+
+            # Check for termination signal
+            if item is None:
+                queue.task_done()
+                break
+
+            index, eval_item = item
+
+            try:
+                # Execute the evaluation
+                result = await eval_item
+
+                # Store result with its index to maintain order
+                results_dict[index] = result
+            finally:
+                # Mark the task as done
+                queue.task_done()
+
+    # Start producer
+    producer_task = asyncio.create_task(producer())
+
+    # Create worker tasks based on workers
+    worker_tasks = [asyncio.create_task(worker(i)) for i in range(workers)]
+
+    # Wait for producer and all workers to complete
+    await producer_task
+    await asyncio.gather(*worker_tasks)
+
+    # Return results in the original order
+    return [results_dict[i] for i in range(len(results_dict))]

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.33"
+version = "2.2.34"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This is useful for piping all evals through single bottleneck (such as in a gym environment).

Also minor bugfix in test.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.29.dev1010093365",

  # Any version from PR
  "uipath>=2.2.29.dev1010090000,<2.2.29.dev1010100000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.34.dev1010093425",

  # Any version from PR
  "uipath>=2.2.34.dev1010090000,<2.2.34.dev1010100000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.2.34.dev1010090000,<2.2.34.dev1010100000",
]
```
<!-- DEV_PACKAGE_END -->