### PR TITLE
feat(dev): improve build dev

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -71,9 +71,14 @@ jobs:
 
           Write-Output "Package version set to $DEV_VERSION"
 
+          $startMarker = "<!-- DEV_PACKAGE_START -->"
+          $endMarker = "<!-- DEV_PACKAGE_END -->"
+
           $dependencyMessage = @"
+          $startMarker
           ## Development Package
 
+          - Use ``uipath pack --nolock`` to get the latest dev build from this PR (requires version range).
           - Add this package as a dependency in your pyproject.toml:
 
           ``````toml
@@ -94,7 +99,13 @@ jobs:
 
           [tool.uv.sources]
           $PROJECT_NAME = { index = "testpypi" }
+
+          [tool.uv]
+          override-dependencies = [
+              "$PROJECT_NAME>=$MIN_VERSION,<$MAX_VERSION",
+          ]
           ``````
+          $endMarker
           "@
 
           # Get the owner and repo from the GitHub repository
@@ -112,10 +123,11 @@ jobs:
           $pr = Invoke-RestMethod -Uri $prUri -Method Get -Headers $headers
           $currentBody = $pr.body
 
-          # Check if there's already a development package section
-          if ($currentBody -match '## Development Package') {
-            # Replace the existing section with the new dependency message
-            $newBody = $currentBody -replace '## Development Package(\r?\n|.)*?(?=##|$)', $dependencyMessage
+          # Check if markers already exist in the PR description
+          $markerPattern = "(?s)$([regex]::Escape($startMarker)).*?$([regex]::Escape($endMarker))"
+          if ($currentBody -match $markerPattern) {
+            # Replace everything between markers (including markers)
+            $newBody = $currentBody -replace $markerPattern, $dependencyMessage
           } else {
             # Append the dependency message to the end of the description
             $newBody = if ($currentBody) { "$currentBody`n`n$dependencyMessage" } else { $dependencyMessage }


### PR DESCRIPTION
# Description

Use `[tool.uv] override-dependencies` to fix

```log
[Info ] Download and extract package
[Info ] Download and extract package - finished in 00:00:00.1570016
[Info ] Prepare Python environment
[Info ] Using CPython 3.11.14 interpreter at: /usr/bin/python3
[Info ] Creating virtual environment at: .venv
[Info ] Prepare Python environment - finished in 00:00:00.4060815
[Info ] Install package dependencies
[Info ]   × No solution found when resolving dependencies for split (markers:
[Info ]   │ python_full_version >= '3.13'):
[Info ]   ╰─▶ Because uipath-langchain>=0.1.25 depends on uipath>=2.2.28 and only the
[Info ]       following versions of uipath-langchain are available:
[Info ]           uipath-langchain<=0.1.25
[Info ]           uipath-langchain==0.1.26
[Info ]       we can conclude that uipath-langchain>=0.1.25 depends on uipath>=2.2.28.
[Info ]       And because your project depends on
[Info ]       uipath>=2.2.28.dev1010070000,<2.2.28.dev1010080000, we can conclude that
[Info ]       your project and uipath-langchain>=0.1.25 are incompatible.
[Info ]       And because your project depends on uipath-langchain>=0.1.25 and
[Info ]       your project requires chat-agent-env[dev], we can conclude that your
[Info ]       project's requirements are unsatisfiable.
[Info ]       hint: While the active Python version is 3.11, the resolution failed for
[Info ]       other Python versions supported by your project. Consider limiting your
[Info ]       project's supported Python versions using `requires-python`.
[Info ] Install package dependencies - finished in 00:00:01.7110285
```

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.30.dev1010103376",

  # Any version from PR
  "uipath>=2.2.30.dev1010100000,<2.2.30.dev1010110000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.2.30.dev1010100000,<2.2.30.dev1010110000",
]
```
<!-- DEV_PACKAGE_END -->