### PR TITLE
feat(mcp_config_schema): add outputschema property

### DIFF
--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -189,6 +189,7 @@ class AgentMcpTool(BaseCfg):
     name: str = Field(..., alias="name")
     description: str = Field(..., alias="description")
     input_schema: Dict[str, Any] = Field(..., alias="inputSchema")
+    output_schema: Optional[Dict[str, Any]] = Field(None, alias="outputSchema")
 
 
 class AgentMcpResourceConfig(BaseAgentResourceConfig):


### PR DESCRIPTION
This pull request adds support for an optional `output_schema` field to MCP tools in the agent model, ensuring that tools can now specify output schemas if needed. It also includes comprehensive tests to verify correct loading and handling of this new field, both when present and absent in the input data.
