### PR TITLE
fix: debug suspend resume

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.30"
+version = "2.2.31"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/cli_debug.py
+++ b/src/uipath/_cli/cli_debug.py
@@ -119,9 +119,11 @@ def debug(
 
                         factory = UiPathRuntimeFactoryRegistry.get(context=ctx)
 
-                        runtime = await factory.new_runtime(
-                            entrypoint, ctx.conversation_id or ctx.job_id or "default"
+                        runtime_id = ctx.conversation_id or ctx.job_id or "default"
+                        print(
+                            f"Starting debug session for runtime ID: {runtime_id} resume: {resume}"
                         )
+                        runtime = await factory.new_runtime(entrypoint, runtime_id)
 
                         if ctx.job_id:
                             trace_manager.add_span_exporter(LlmOpsHttpExporter())

--- a/src/uipath/_cli/cli_run.py
+++ b/src/uipath/_cli/cli_run.py
@@ -163,9 +163,13 @@ def run(
                         factory: UiPathRuntimeFactoryProtocol | None = None
                         try:
                             factory = UiPathRuntimeFactoryRegistry.get(context=ctx)
+                            runtime_id = ctx.conversation_id or ctx.job_id or "default"
+                            print(
+                                f"Starting run session for runtime ID: {runtime_id} resume: {resume}"
+                            )
                             runtime = await factory.new_runtime(
                                 entrypoint,
-                                ctx.conversation_id or ctx.job_id or "default",
+                                runtime_id,
                             )
 
                             if ctx.job_id:

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.30"
+version = "2.2.31"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.2.31.dev1010203404",

  # Any version from PR
  "uipath>=2.2.31.dev1010200000,<2.2.31.dev1010210000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.2.31.dev1010200000,<2.2.31.dev1010210000",
]
```
<!-- DEV_PACKAGE_END -->