### PR TITLE
feat(AnyArgs): allow any additional args and kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.33"
+version = "2.2.34"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -103,6 +103,12 @@ class InputMockingStrategy(BaseModel):
 class MockingArgument(BaseModel):
     args: list[Any] = Field(default_factory=lambda: [], alias="args")
     kwargs: dict[str, Any] = Field(default_factory=lambda: {}, alias="kwargs")
+    match_any_additional_args: bool = Field(
+        default=False, alias="matchAnyAdditionalArgs"
+    )
+    match_any_additional_kwargs: bool = Field(
+        default=False, alias="matchAnyAdditionalKwargs"
+    )
 
 
 class MockingAnswerType(str, Enum):

--- a/src/uipath/_cli/_evals/mocks/mockito_mocker.py
+++ b/src/uipath/_cli/_evals/mocks/mockito_mocker.py
@@ -4,6 +4,8 @@ import importlib
 from typing import Any, Callable
 
 from mockito import (  # type: ignore[import-untyped] # explicit ignore
+    ARGS,
+    KWARGS,
     invocation,
     mocking,
 )
@@ -77,6 +79,11 @@ class MockitoMocker(Mocker):
 
             args = resolved_args if resolved_args is not None else []
             kwargs = resolved_kwargs if resolved_kwargs is not None else {}
+
+            if behavior.arguments.match_any_additional_kwargs:
+                kwargs = kwargs | KWARGS
+            if behavior.arguments.match_any_additional_args:
+                args = args + ARGS
 
             stubbed = invocation.StubbedInvocation(mock_obj, behavior.function)(
                 *args,

--- a/tests/cli/eval/mocks/test_mocks.py
+++ b/tests/cli/eval/mocks/test_mocks.py
@@ -135,6 +135,91 @@ async def test_mockito_mockable_async():
     assert await foo(x=2) == "bar1"
 
 
+def test_mockito_mockable_anyargs_sync():
+    # Arrange
+    @mockable()
+    def foo(*args, **kwargs):
+        raise NotImplementedError()
+
+    evaluation_item: dict[str, Any] = {
+        "id": "evaluation-id",
+        "name": "Mock foo",
+        "inputs": {},
+        "evaluationCriterias": {
+            "ExactMatchEvaluator": None,
+        },
+        "mockingStrategy": {
+            "type": "mockito",
+            "behaviors": [
+                {
+                    "function": "foo",
+                    "arguments": {
+                        "args": [],
+                        "kwargs": {},
+                        "matchAnyAdditionalArgs": True,
+                        "matchAnyAdditionalKwargs": True,
+                    },
+                    "then": [
+                        {"type": "return", "value": "bar1"},
+                    ],
+                }
+            ],
+        },
+    }
+    evaluation = EvaluationItem(**evaluation_item)
+    assert isinstance(evaluation.mocking_strategy, MockitoMockingStrategy)
+
+    # Act & Assert
+    set_execution_context(evaluation, _mock_span_collector, "test-execution-id")
+    assert foo(x=1) == "bar1"
+    assert foo(x="x") == "bar1"
+    assert foo() == "bar1"
+    assert foo(1) == "bar1"
+
+
+@pytest.mark.asyncio
+async def test_mockito_mockable_anyargs_async():
+    # Arrange
+    @mockable()
+    async def foo(*args, **kwargs):
+        raise NotImplementedError()
+
+    evaluation_item: dict[str, Any] = {
+        "id": "evaluation-id",
+        "name": "Mock foo",
+        "inputs": {},
+        "evaluationCriterias": {
+            "ExactMatchEvaluator": None,
+        },
+        "mockingStrategy": {
+            "type": "mockito",
+            "behaviors": [
+                {
+                    "function": "foo",
+                    "arguments": {
+                        "args": [],
+                        "kwargs": {},
+                        "matchAnyAdditionalArgs": True,
+                        "matchAnyAdditionalKwargs": True,
+                    },
+                    "then": [
+                        {"type": "return", "value": "bar1"},
+                    ],
+                }
+            ],
+        },
+    }
+    evaluation = EvaluationItem(**evaluation_item)
+    assert isinstance(evaluation.mocking_strategy, MockitoMockingStrategy)
+
+    # Act & Assert
+    set_execution_context(evaluation, _mock_span_collector, "test-execution-id")
+    assert await foo(x=1) == "bar1"
+    assert await foo(x="x") == "bar1"
+    assert await foo() == "bar1"
+    assert await foo(1) == "bar1"
+
+
 @pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def test_llm_mockable_sync(httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch):
     monkeypatch.setenv("UIPATH_URL", "https://example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.33"
+version = "2.2.34"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
While mocking, additional args and kwargs need to be handled explicitly.