### PR TITLE
feat: sanitize breakpoint names [PC-3577]

### DIFF
--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -23,6 +23,7 @@ from uipath.runtime.events import UiPathRuntimeStateEvent
 from uipath.runtime.resumable import UiPathResumeTriggerType
 
 from uipath._cli._utils._common import serialize_object
+from uipath._utils import sanitize_string
 
 logger = logging.getLogger(__name__)
 
@@ -768,8 +769,9 @@ class SignalRDebugBridge:
                 else None
             )
             if node_name:
-                self.state.add_breakpoint(node_name)
-                logger.info(f"Breakpoint added: {node_name}")
+                sanitized_name = sanitize_string(node_name)
+                self.state.add_breakpoint(sanitized_name)
+                logger.info(f"Breakpoint added: {sanitized_name}")
             else:
                 logger.warning(f"Breakpoint without node name: {bp}")
 

--- a/src/uipath/_utils/__init__.py
+++ b/src/uipath/_utils/__init__.py
@@ -3,6 +3,7 @@ from ._endpoint import Endpoint
 from ._logs import setup_logging
 from ._request_override import header_folder
 from ._request_spec import RequestSpec
+from ._sanitize import sanitize_string
 from ._url import UiPathUrl
 from ._user_agent import header_user_agent, user_agent_value
 from .validation import validate_pagination_params
@@ -18,4 +19,5 @@ __all__ = [
     "user_agent_value",
     "UiPathUrl",
     "validate_pagination_params",
+    "sanitize_string",
 ]

--- a/src/uipath/_utils/_sanitize.py
+++ b/src/uipath/_utils/_sanitize.py
@@ -1,0 +1,28 @@
+"""Sanitization utilities for names and identifiers."""
+
+import re
+
+
+def sanitize_string(name: str) -> str:
+    """Sanitize a string for LLM compatibility.
+
+    Used for sanitizing names like tool names, node names, or other identifiers
+    to make them compatible with LLMs. Ensures the string contains only
+    alphanumeric characters, underscores, and hyphens, with a maximum length
+    of 64 characters.
+
+    Args:
+        name: The original string to sanitize.
+
+    Returns:
+        Sanitized string safe for LLM usage.
+
+    Examples:
+        >>> sanitize_string("My Tool Name")
+        'My_Tool_Name'
+        >>> sanitize_string("tool@special!chars")
+        'toolspecialchars'
+    """
+    trim_whitespaces = "_".join(name.split())
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]", "", trim_whitespaces)
+    return sanitized[:64]


### PR DESCRIPTION
Breakpoints for low code agents don't stop the execution when the tool name has special characters. Sanitizing the breakpoint names will cause breakpoints to hit. After this PR is merged, I will do another PR for using in uipath-langchain-python the sanitize_name from uipath-python and remove sanitize_tool_name from uipath-langchain-python.