### PR TITLE
chore: bump version to 2.2.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.35"
+version = "2.2.36"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/mocks/mockito_mocker.py
+++ b/src/uipath/_cli/_evals/mocks/mockito_mocker.py
@@ -3,7 +3,7 @@
 import importlib
 from typing import Any, Callable
 
-from mockito import (  # type: ignore[import-untyped] # explicit ignore
+from mockito import (  # type: ignore[import-untyped]
     invocation,
     mocking,
 )

--- a/src/uipath/_cli/_utils/_debug.py
+++ b/src/uipath/_cli/_utils/_debug.py
@@ -26,7 +26,7 @@ def setup_debugging(debug: bool, debug_port: int = 5678) -> bool:
 
     # Try to import debugpy, log warning if not available
     try:
-        import debugpy  # type: ignore[import-not-found] # explicit ignore
+        import debugpy  # type: ignore[import-not-found]
     except ImportError:
         console.warning(
             "debugpy not found, please install it and retry: '[uv] pip install debugpy'"

--- a/src/uipath/eval/mocks/mockable.py
+++ b/src/uipath/eval/mocks/mockable.py
@@ -8,7 +8,7 @@ import threading
 from typing import Any, List, Optional
 
 from pydantic import TypeAdapter
-from pydantic_function_models import (  # type: ignore[import-untyped] # explicit ignore
+from pydantic_function_models import (  # type: ignore[import-untyped]
     ValidatedFunction,
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.35"
+version = "2.2.36"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bumps package version from 2.2.35 to 2.2.36

## Test plan
- [ ] Verify version number is correct in pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)