### PR TITLE
chore: remove unused _status_to_string method

### DIFF
--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -111,19 +111,6 @@ class StudioWebProgressReporter:
         """Helper method to format and display error messages consistently."""
         self._rich_console.print(f"    • \u26a0  [dim]{context}: {error}[/dim]")
 
-    def _status_to_string(self, status: EvaluationStatus) -> str:
-        """Convert EvaluationStatus enum to PascalCase string for API.
-
-        Args:
-            status: The EvaluationStatus enum value
-
-        Returns:
-            PascalCase string representation (e.g., "InProgress", "Completed")
-        """
-        # Convert SNAKE_CASE enum name to PascalCase
-        components = status.name.split("_")
-        return "".join(x.title() for x in components)
-
     def _is_localhost(self) -> bool:
         """Check if the eval backend URL is localhost.
 


### PR DESCRIPTION
## Summary
- Remove unused `_status_to_string` method from `StudioWebProgressReporter` class

## Details
The `_status_to_string` method was defined but never called anywhere in the codebase. This PR removes the dead code to improve maintainability.

## Test plan
- [ ] Verify no references to `_status_to_string` exist in the codebase
- [ ] Confirm all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)