### PR TITLE
feat: add upsert_span method for real-time span state updates

### DIFF
--- a/src/uipath/tracing/__init__.py
+++ b/src/uipath/tracing/__init__.py
@@ -5,10 +5,12 @@ from uipath.core import traced
 from ._otel_exporters import (  # noqa: D104
     JsonLinesFileExporter,
     LlmOpsHttpExporter,
+    SpanStatus,
 )
 
 __all__ = [
     "traced",
     "LlmOpsHttpExporter",
     "JsonLinesFileExporter",
+    "SpanStatus",
 ]


### PR DESCRIPTION
## Summary
- Add `upsert_span()` method to `LlmOpsHttpExporter` for single span updates
- Add `SpanStatus` enum matching LLMOps StatusEnum values
- Export `SpanStatus` from `uipath.tracing`

## Use Case
Enables manual instrumentation in uipath-agents-python for:
- **Parity with Temporal low-code agents**: Send spans with real-time state updates
- **Interruptible processes**: Update span status (RUNNING → OK/ERROR) across multiple calls ([thread](https://uipath-product.slack.com/archives/C09Q8B4FYM8/p1765879123019159?thread_ts=1765364733.858349&cid=C09Q8B4FYM8))
- **SpanProcessor pattern**: Call on `on_start` (status=RUNNING) and `on_end` (status=OK/ERROR)