### PR TITLE
fix: allow None values for app channel properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.40"
+version = "2.2.41"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -283,10 +283,10 @@ AgentEscalationRecipient = Annotated[
 class AgentEscalationChannelProperties(BaseResourceProperties):
     """Agent escalation channel properties model."""
 
-    app_name: str = Field(..., alias="appName")
+    app_name: str | None = Field(..., alias="appName")
     app_version: int = Field(..., alias="appVersion")
     folder_name: Optional[str] = Field(None, alias="folderName")
-    resource_key: str = Field(..., alias="resourceKey")
+    resource_key: str | None = Field(..., alias="resourceKey")
     is_actionable_message_enabled: Optional[bool] = Field(
         None, alias="isActionableMessageEnabled"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.40"
+version = "2.2.41"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- allow None values for app channel properties

Fixes: 
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for AgentEvalsDefinition
resources.2.escalation.channels.0.properties.appName
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
resources.2.escalation.channels.0.properties.resourceKey
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
During task with name 'download_project' and id '...'
```

since IXP escalation tool does not have neither appName not resourceKey 

<img width="434" height="226" alt="image" src="https://github.com/user-attachments/assets/b72ebe35-6cd2-445a-82fa-10c246172656" />
