### PR TITLE
fix: remove element instance id from connection overwrite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.2.42"
+version = "2.2.43"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_utils/_bindings.py
+++ b/src/uipath/_utils/_bindings.py
@@ -57,7 +57,6 @@ class GenericResourceOverwrite(ResourceOverwrite):
 class ConnectionResourceOverwrite(ResourceOverwrite):
     resource_type: Literal["connection"]
     connection_id: str = Field(alias="connectionId")
-    element_instance_id: str = Field(alias="elementInstanceId")
     folder_key: str = Field(alias="folderKey")
 
     model_config = ConfigDict(

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.2.42"
+version = "2.2.43"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
It's not guaranteed to be present in the response from StudioWeb.
Could cause jobs to fail during bindings resolution.
<img width="1237" height="232" alt="image" src="https://github.com/user-attachments/assets/9e5eafe8-23f7-460c-9817-674e46918ed3" />

ElementInstanceId itself is deprecated and part of the old IS contract. Now it can be replaced by ConnectionId.