### PR TITLE
refactor(EvalRuntimeInstance): evaluate specific runtime instance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.3.3"
+version = "2.3.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.3.3"
+version = "2.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Doing this will avoid creation of temporary runtimes everywhere.

Tested calculator agent on default and legacy eval sets -- works fine. 