### PR TITLE
feat: add group name support for escalations recipients

### DIFF
--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -61,6 +61,8 @@ class AgentEscalationRecipientType(str, Enum):
     GROUP_ID = "GroupId"
     USER_EMAIL = "UserEmail"
     ASSET_USER_EMAIL = "AssetUserEmail"
+    GROUP_NAME = "GroupName"
+    ASSET_GROUP_NAME = "AssetGroupName"
 
 
 class AgentContextRetrievalMode(str, Enum):
@@ -240,6 +242,8 @@ def _normalize_recipient_type(recipient: Any) -> Any:
             2: AgentEscalationRecipientType.GROUP_ID,
             3: AgentEscalationRecipientType.USER_EMAIL,
             4: AgentEscalationRecipientType.ASSET_USER_EMAIL,
+            5: AgentEscalationRecipientType.GROUP_NAME,
+            6: AgentEscalationRecipientType.ASSET_GROUP_NAME,
         }
         recipient["type"] = type_mapping.get(recipient_type, str(recipient_type))
 
@@ -253,23 +257,25 @@ class BaseEscalationRecipient(BaseCfg):
 
 
 class StandardRecipient(BaseEscalationRecipient):
-    """Standard recipient with value field (for UserId, GroupId, UserEmail)."""
+    """Standard recipient with value field."""
 
     type: Literal[
         AgentEscalationRecipientType.USER_ID,
         AgentEscalationRecipientType.GROUP_ID,
         AgentEscalationRecipientType.USER_EMAIL,
+        AgentEscalationRecipientType.GROUP_NAME,
     ] = Field(..., alias="type")
     value: str = Field(..., alias="value")
     display_name: Optional[str] = Field(default=None, alias="displayName")
 
 
 class AssetRecipient(BaseEscalationRecipient):
-    """Asset recipient with assetName and folderPath (for AssetUserEmail)."""
+    """Asset recipient with assetName and folderPath."""
 
-    type: Literal[AgentEscalationRecipientType.ASSET_USER_EMAIL] = Field(
-        ..., alias="type"
-    )
+    type: Literal[
+        AgentEscalationRecipientType.ASSET_USER_EMAIL,
+        AgentEscalationRecipientType.ASSET_GROUP_NAME,
+    ] = Field(..., alias="type")
     asset_name: str = Field(..., alias="assetName")
     folder_path: str = Field(..., alias="folderPath")
 


### PR DESCRIPTION
## Description
Add support for Group Name in Escalations

## Testing
Locally and added unit tests

[PC-3717](https://uipath.atlassian.net/browse/PC-3717)

[PC-3717]: https://uipath.atlassian.net/browse/PC-3717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ