### PR TITLE
feat: pass model settings via kwargs to new_runtime

### DIFF
--- a/src/uipath/_cli/_evals/_configurable_factory.py
+++ b/src/uipath/_cli/_evals/_configurable_factory.py
@@ -1,0 +1,167 @@
+"""Configurable runtime factory that supports model settings overrides."""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from uipath.runtime import UiPathRuntimeFactoryProtocol, UiPathRuntimeProtocol
+
+from ._models._evaluation_set import EvaluationSetModelSettings
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigurableRuntimeFactory:
+    """Wrapper factory that supports model settings overrides for evaluation runs.
+
+    This factory wraps an existing UiPathRuntimeFactoryProtocol implementation
+    and allows applying model settings overrides when creating runtimes.
+    """
+
+    def __init__(self, base_factory: UiPathRuntimeFactoryProtocol):
+        """Initialize with a base factory to wrap."""
+        self.base_factory = base_factory
+        self.model_settings_override: EvaluationSetModelSettings | None = None
+        self._temp_files: list[str] = []
+
+    def set_model_settings_override(
+        self, settings: EvaluationSetModelSettings | None
+    ) -> None:
+        """Set model settings to override when creating runtimes.
+
+        Args:
+            settings: The model settings to apply, or None to clear overrides
+        """
+        self.model_settings_override = settings
+
+    async def new_runtime(
+        self, entrypoint: str, runtime_id: str
+    ) -> UiPathRuntimeProtocol:
+        """Create a new runtime with optional model settings overrides.
+
+        If model settings override is configured, creates a temporary modified
+        entrypoint file with the overridden settings.
+
+        Args:
+            entrypoint: Path to the agent entrypoint file
+            runtime_id: Unique identifier for the runtime instance
+
+        Returns:
+            A new runtime instance with overrides applied if configured
+        """
+        # If no overrides, delegate directly to base factory
+        if not self.model_settings_override:
+            return await self.base_factory.new_runtime(entrypoint, runtime_id)
+
+        # Apply overrides by creating modified entrypoint
+        modified_entrypoint = self._apply_overrides(
+            entrypoint, self.model_settings_override
+        )
+        if modified_entrypoint:
+            # Track temp file for cleanup
+            self._temp_files.append(modified_entrypoint)
+            return await self.base_factory.new_runtime(modified_entrypoint, runtime_id)
+
+        # If override failed, fall back to original
+        return await self.base_factory.new_runtime(entrypoint, runtime_id)
+
+    def _apply_overrides(
+        self, entrypoint: str, settings: EvaluationSetModelSettings
+    ) -> str | None:
+        """Apply model settings overrides to an agent entrypoint.
+
+        Creates a temporary modified version of the entrypoint file with
+        the specified model settings overrides applied.
+
+        Args:
+            entrypoint: Path to the original entrypoint file
+            settings: Model settings to override
+
+        Returns:
+            Path to temporary modified entrypoint, or None if override not needed/failed
+        """
+        if (
+            settings.model == "same-as-agent"
+            and settings.temperature == "same-as-agent"
+        ):
+            logger.debug(
+                "Both model and temperature are 'same-as-agent', no override needed"
+            )
+            return None
+
+        entrypoint_path = Path(entrypoint)
+        if not entrypoint_path.exists():
+            logger.warning(f"Entrypoint file '{entrypoint_path}' not found")
+            return None
+
+        try:
+            with open(entrypoint_path, "r") as f:
+                agent_data = json.load(f)
+        except (json.JSONDecodeError, IOError) as e:
+            logger.error(f"Failed to load entrypoint file: {e}")
+            return None
+
+        original_settings = agent_data.get("settings", {})
+        modified_settings = original_settings.copy()
+
+        # Override model if not "same-as-agent"
+        if settings.model != "same-as-agent":
+            modified_settings["model"] = settings.model
+            logger.debug(
+                f"Overriding model: {original_settings.get('model')} -> {settings.model}"
+            )
+
+        # Override temperature if not "same-as-agent"
+        if settings.temperature not in ["same-as-agent", None]:
+            if isinstance(settings.temperature, (int, float)):
+                modified_settings["temperature"] = float(settings.temperature)
+            elif isinstance(settings.temperature, str):
+                try:
+                    modified_settings["temperature"] = float(settings.temperature)
+                except ValueError:
+                    logger.warning(
+                        f"Invalid temperature value: '{settings.temperature}'"
+                    )
+
+            if "temperature" in modified_settings:
+                logger.debug(
+                    f"Overriding temperature: {original_settings.get('temperature')} -> "
+                    f"{modified_settings['temperature']}"
+                )
+
+        if modified_settings == original_settings:
+            return None
+
+        agent_data["settings"] = modified_settings
+
+        # Create a temporary file with the modified agent definition
+        try:
+            temp_fd, temp_path = tempfile.mkstemp(
+                suffix=".json", prefix="agent_override_"
+            )
+            with os.fdopen(temp_fd, "w") as temp_file:
+                json.dump(agent_data, temp_file, indent=2)
+
+            logger.info(f"Created temporary entrypoint with overrides: {temp_path}")
+            return temp_path
+        except Exception as e:
+            logger.error(f"Failed to create temporary entrypoint file: {e}")
+            return None
+
+    async def dispose(self) -> None:
+        """Dispose resources and clean up temporary files."""
+        # Clean up any temporary files created
+        for temp_file in self._temp_files:
+            try:
+                os.unlink(temp_file)
+                logger.debug(f"Cleaned up temporary file: {temp_file}")
+            except Exception as e:
+                logger.warning(f"Failed to clean up temporary file {temp_file}: {e}")
+
+        self._temp_files.clear()
+
+        # Delegate disposal to base factory
+        if hasattr(self.base_factory, "dispose"):
+            await self.base_factory.dispose()

--- a/tests/cli/eval/test_configurable_factory.py
+++ b/tests/cli/eval/test_configurable_factory.py
@@ -1,0 +1,183 @@
+"""Tests for ConfigurableRuntimeFactory."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from uipath._cli._evals._configurable_factory import ConfigurableRuntimeFactory
+from uipath._cli._evals._models._evaluation_set import EvaluationSetModelSettings
+
+
+@pytest.mark.asyncio
+async def test_configurable_factory_no_override():
+    """Test factory without any overrides."""
+    mock_base_factory = AsyncMock()
+    mock_runtime = Mock()
+    mock_base_factory.new_runtime.return_value = mock_runtime
+
+    factory = ConfigurableRuntimeFactory(mock_base_factory)
+
+    result = await factory.new_runtime("test.json", "test-id")
+
+    assert result == mock_runtime
+    mock_base_factory.new_runtime.assert_called_once_with("test.json", "test-id")
+
+
+@pytest.mark.asyncio
+async def test_configurable_factory_with_model_override():
+    """Test factory with model override."""
+    # Create a temporary agent.json file
+    test_agent = {"settings": {"model": "gpt-4", "temperature": 0.7}}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(test_agent, f)
+        temp_path = f.name
+
+    try:
+        mock_base_factory = AsyncMock()
+        mock_runtime = Mock()
+        mock_base_factory.new_runtime.return_value = mock_runtime
+
+        factory = ConfigurableRuntimeFactory(mock_base_factory)
+
+        # Set model override
+        settings = EvaluationSetModelSettings(
+            id="test-settings", model="gpt-3.5-turbo", temperature="same-as-agent"
+        )
+        factory.set_model_settings_override(settings)
+
+        result = await factory.new_runtime(temp_path, "test-id")
+
+        assert result == mock_runtime
+        # Should have been called with a modified temp file
+        call_args = mock_base_factory.new_runtime.call_args
+        assert call_args[0][0] != temp_path  # Different path (temp file)
+        assert call_args[0][1] == "test-id"
+
+        # Verify the temp file has correct content
+        with open(call_args[0][0]) as f:
+            modified_data = json.load(f)
+        assert modified_data["settings"]["model"] == "gpt-3.5-turbo"
+        assert modified_data["settings"]["temperature"] == 0.7  # Unchanged
+
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+        # Clean up temp files created by factory
+        await factory.dispose()
+
+
+@pytest.mark.asyncio
+async def test_configurable_factory_same_as_agent():
+    """Test factory when both settings are 'same-as-agent'."""
+    # Create a temporary agent.json file
+    test_agent = {"settings": {"model": "gpt-4", "temperature": 0.7}}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(test_agent, f)
+        temp_path = f.name
+
+    try:
+        mock_base_factory = AsyncMock()
+        mock_runtime = Mock()
+        mock_base_factory.new_runtime.return_value = mock_runtime
+
+        factory = ConfigurableRuntimeFactory(mock_base_factory)
+
+        # Set "same-as-agent" for both
+        settings = EvaluationSetModelSettings(
+            id="test-settings", model="same-as-agent", temperature="same-as-agent"
+        )
+        factory.set_model_settings_override(settings)
+
+        result = await factory.new_runtime(temp_path, "test-id")
+
+        assert result == mock_runtime
+        # Should use original path (no override)
+        mock_base_factory.new_runtime.assert_called_once_with(temp_path, "test-id")
+
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_configurable_factory_temperature_override():
+    """Test factory with temperature override."""
+    # Create a temporary agent.json file
+    test_agent = {"settings": {"model": "gpt-4", "temperature": 0.7}}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(test_agent, f)
+        temp_path = f.name
+
+    try:
+        mock_base_factory = AsyncMock()
+        mock_runtime = Mock()
+        mock_base_factory.new_runtime.return_value = mock_runtime
+
+        factory = ConfigurableRuntimeFactory(mock_base_factory)
+
+        # Set temperature override
+        settings = EvaluationSetModelSettings(
+            id="test-settings", model="same-as-agent", temperature=0.2
+        )
+        factory.set_model_settings_override(settings)
+
+        result = await factory.new_runtime(temp_path, "test-id")
+
+        assert result == mock_runtime
+        # Should have been called with a modified temp file
+        call_args = mock_base_factory.new_runtime.call_args
+        assert call_args[0][0] != temp_path  # Different path (temp file)
+
+        # Verify the temp file has correct content
+        with open(call_args[0][0]) as f:
+            modified_data = json.load(f)
+        assert modified_data["settings"]["model"] == "gpt-4"  # Unchanged
+        assert modified_data["settings"]["temperature"] == 0.2  # Changed
+
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+        await factory.dispose()
+
+
+@pytest.mark.asyncio
+async def test_configurable_factory_cleanup():
+    """Test that temporary files are cleaned up."""
+    test_agent = {"settings": {"model": "gpt-4", "temperature": 0.7}}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(test_agent, f)
+        temp_path = f.name
+
+    try:
+        mock_base_factory = AsyncMock()
+        mock_runtime = Mock()
+        mock_base_factory.new_runtime.return_value = mock_runtime
+
+        factory = ConfigurableRuntimeFactory(mock_base_factory)
+
+        settings = EvaluationSetModelSettings(
+            id="test-settings", model="gpt-3.5-turbo", temperature=0.5
+        )
+        factory.set_model_settings_override(settings)
+
+        await factory.new_runtime(temp_path, "test-id")
+
+        # Get the temp file created
+        call_args = mock_base_factory.new_runtime.call_args
+        temp_file_created = call_args[0][0]
+
+        # Temp file should exist
+        assert Path(temp_file_created).exists()
+
+        # Clean up
+        await factory.dispose()
+
+        # Temp file should be deleted
+        assert not Path(temp_file_created).exists()
+
+    finally:
+        Path(temp_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Remove `ConfigurableRuntimeFactory` wrapper that wrapped the factory and wrote temp files
- Add `_get_model_settings_override()` to extract settings from eval set
- Add `_create_runtime_with_settings()` to pass settings via `new_runtime(settings=...)` kwargs
- Backward compatible: falls back gracefully if factory doesn't support kwargs (older uipath-runtime)

## Dependencies

This PR depends on [uipath-runtime-python#62](https://github.com/UiPath/uipath-runtime-python/pull/62) which adds `**kwargs` to the `new_runtime()` protocol.

## Architecture

The new approach:
1. `_get_model_settings_override()` extracts model settings from eval set
2. `_create_runtime_with_settings()` passes settings via kwargs to `factory.new_runtime(settings=...)`
3. The agents/low-code runtime receives these settings and applies them during graph building

This removes the need for:
- Wrapping the factory with `ConfigurableRuntimeFactory`
- Writing temporary agent.json files with overridden settings
- Deserializing/re-serializing agent configuration

## Test plan

- [ ] Verify eval runs work with default model settings
- [ ] Verify eval runs with model_settings_id override work correctly
- [ ] Verify backward compatibility with older uipath-runtime versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)