### PR TITLE
fix: update uipath-runtime 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.3.5"
+version = "2.4.0"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.1.4, <0.2.0",
-  "uipath-runtime>=0.3.1, <0.4.0",
+  "uipath-runtime>=0.4.0, <0.5.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/src/uipath/functions/factory.py
+++ b/src/uipath/functions/factory.py
@@ -49,7 +49,7 @@ class UiPathFunctionsRuntimeFactory:
         return [self._create_runtime(ep) for ep in self.discover_entrypoints()]
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str
+        self, entrypoint: str, runtime_id: str, **kwargs
     ) -> UiPathRuntimeProtocol:
         """Create a new runtime instance for the given entrypoint."""
         return self._create_runtime(entrypoint)

--- a/tests/cli/eval/test_eval_runtime_metadata.py
+++ b/tests/cli/eval/test_eval_runtime_metadata.py
@@ -118,7 +118,7 @@ class MockFactory:
         return [await self.runtime_creator()]
 
     async def new_runtime(
-        self, entrypoint: str, runtime_id: str
+        self, entrypoint: str, runtime_id: str, **kwargs
     ) -> UiPathRuntimeProtocol:
         self.new_runtime_call_count += 1
         return await self.runtime_creator()

--- a/tests/cli/eval/test_evaluate.py
+++ b/tests/cli/eval/test_evaluate.py
@@ -79,7 +79,7 @@ async def test_evaluate():
             return [TestRuntime(self.executor)]
 
         async def new_runtime(
-            self, entrypoint: str, runtime_id: str
+            self, entrypoint: str, runtime_id: str, **kwargs
         ) -> UiPathRuntimeProtocol:
             return TestRuntime(self.executor)
 
@@ -175,7 +175,7 @@ async def test_eval_runtime_generates_uuid_when_no_custom_id():
             return [TestRuntime(self.executor)]
 
         async def new_runtime(
-            self, entrypoint: str, runtime_id: str
+            self, entrypoint: str, runtime_id: str, **kwargs
         ) -> UiPathRuntimeProtocol:
             return TestRuntime(self.executor)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.3.5"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2542,7 +2542,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.1.4,<0.2.0" },
-    { name = "uipath-runtime", specifier = ">=0.3.1,<0.4.0" },
+    { name = "uipath-runtime", specifier = ">=0.4.0,<0.5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2588,14 +2588,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/12/01a12e2503d8ae312d7617cbdb01f6d1a05f0c89fc11e19e617cee2c60ed/uipath_runtime-0.3.1.tar.gz", hash = "sha256:cb4c891b2b3fafb6b0c763a6ac8c611f690d63d451552a7fd07ed307b57023f4", size = 99320, upload-time = "2025-12-26T06:37:38.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/6f/683b258720c18f8ec0e68ec712a05f42ede6ecf63e75710aa555b8d52092/uipath_runtime-0.4.0.tar.gz", hash = "sha256:129933b08c6f589d13c2c0e7045ddf61ca144029340c1482134d127dd15563e3", size = 99934, upload-time = "2026-01-03T05:44:33.712Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/c1/763f014cd893d3d2040f9d5a1f5b6d3e8086b42861c7fc338922daa98cd8/uipath_runtime-0.3.1-py3-none-any.whl", hash = "sha256:4e8c7c8ae5a736eabf2c0283b69c477b0fa90581b56466f3edbb50593d8f8617", size = 38085, upload-time = "2025-12-26T06:37:37.226Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/402708653a197c7f0b1d9de66b235f8a5798f814c775bab575cd2d7e2539/uipath_runtime-0.4.0-py3-none-any.whl", hash = "sha256:f49a23ed24f7cfaa736f99a5763bcf314234c67b727c40ec891a0a3d10140027", size = 38359, upload-time = "2026-01-03T05:44:31.817Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Update `uipath-runtime` to 0.4.0

Ref: https://github.com/UiPath/uipath-runtime-python/pull/62

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.4.0.dev1010633577",

  # Any version from PR
  "uipath>=2.4.0.dev1010630000,<2.4.0.dev1010640000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.4.0.dev1010630000,<2.4.0.dev1010640000",
]
```
<!-- DEV_PACKAGE_END -->