### PR TITLE
fix: model to model_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.1"
+version = "2.4.2"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/_configurable_factory.py
+++ b/src/uipath/_cli/_evals/_configurable_factory.py
@@ -83,7 +83,7 @@ class ConfigurableRuntimeFactory:
             Path to temporary modified entrypoint, or None if override not needed/failed
         """
         if (
-            settings.model == "same-as-agent"
+            settings.model_name == "same-as-agent"
             and settings.temperature == "same-as-agent"
         ):
             logger.debug(
@@ -107,10 +107,10 @@ class ConfigurableRuntimeFactory:
         modified_settings = original_settings.copy()
 
         # Override model if not "same-as-agent"
-        if settings.model != "same-as-agent":
-            modified_settings["model"] = settings.model
+        if settings.model_name != "same-as-agent":
+            modified_settings["model"] = settings.model_name
             logger.debug(
-                f"Overriding model: {original_settings.get('model')} -> {settings.model}"
+                f"Overriding model: {original_settings.get('model')} -> {settings.model_name}"
             )
 
         # Override temperature if not "same-as-agent"

--- a/src/uipath/_cli/_evals/_models/_evaluation_set.py
+++ b/src/uipath/_cli/_evals/_models/_evaluation_set.py
@@ -78,10 +78,14 @@ class ModelSettings(BaseModel):
     max_tokens: int | None = Field(default=None, alias="maxTokens")
 
 
-class EvaluationSetModelSettings(ModelSettings):
+class EvaluationSetModelSettings(BaseModel):
     """Model setting overrides within evaluation sets with ID."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str = Field(..., alias="id")
+    model_name: str = Field(..., alias="modelName")
+    temperature: float | str | None = Field(default=None, alias="temperature")
 
 
 class LLMMockingStrategy(BaseMockingStrategy):

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -596,7 +596,7 @@ class UiPathEvalRuntime:
 
         logger.info(
             f"Configuring model settings override: id='{target_model_settings.id}', "
-            f"model='{target_model_settings.model}', temperature='{target_model_settings.temperature}'"
+            f"model_name='{target_model_settings.model_name}', temperature='{target_model_settings.temperature}'"
         )
 
         # Configure the factory with the override settings

--- a/tests/cli/eval/test_configurable_factory.py
+++ b/tests/cli/eval/test_configurable_factory.py
@@ -45,7 +45,7 @@ async def test_configurable_factory_with_model_override():
 
         # Set model override
         settings = EvaluationSetModelSettings(
-            id="test-settings", model="gpt-3.5-turbo", temperature="same-as-agent"
+            id="test-settings", model_name="gpt-3.5-turbo", temperature="same-as-agent"
         )
         factory.set_model_settings_override(settings)
 
@@ -88,7 +88,7 @@ async def test_configurable_factory_same_as_agent():
 
         # Set "same-as-agent" for both
         settings = EvaluationSetModelSettings(
-            id="test-settings", model="same-as-agent", temperature="same-as-agent"
+            id="test-settings", model_name="same-as-agent", temperature="same-as-agent"
         )
         factory.set_model_settings_override(settings)
 
@@ -121,7 +121,7 @@ async def test_configurable_factory_temperature_override():
 
         # Set temperature override
         settings = EvaluationSetModelSettings(
-            id="test-settings", model="same-as-agent", temperature=0.2
+            id="test-settings", model_name="same-as-agent", temperature=0.2
         )
         factory.set_model_settings_override(settings)
 
@@ -160,7 +160,7 @@ async def test_configurable_factory_cleanup():
         factory = ConfigurableRuntimeFactory(mock_base_factory)
 
         settings = EvaluationSetModelSettings(
-            id="test-settings", model="gpt-3.5-turbo", temperature=0.5
+            id="test-settings", model_name="gpt-3.5-turbo", temperature=0.5
         )
         factory.set_model_settings_override(settings)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.1"
+version = "2.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
  ## Summary
  Refactors `EvaluationSetModelSettings` to use `modelName` field instead of inheriting `model` from `ModelSettings`.

  ## Changes
  - Updated `EvaluationSetModelSettings` to define `modelName` field with camelCase JSON alias
  - Updated `_configurable_factory.py` to use `model_name` instead of `model`
  - Updated `_runtime.py` logging to reference `model_name`
  - Updated all test cases to use the new field name