### PR TITLE
Resource override trace issue 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.3"
+version = "2.4.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_utils/__init__.py
+++ b/src/uipath/_utils/__init__.py
@@ -1,4 +1,4 @@
-from ._bindings import get_inferred_bindings_names, resource_override
+from ._bindings import resource_override
 from ._endpoint import Endpoint
 from ._logs import setup_logging
 from ._request_override import header_folder
@@ -12,7 +12,6 @@ __all__ = [
     "setup_logging",
     "RequestSpec",
     "header_folder",
-    "get_inferred_bindings_names",
     "resource_override",
     "header_user_agent",
     "user_agent_value",

--- a/src/uipath/_utils/_bindings.py
+++ b/src/uipath/_utils/_bindings.py
@@ -139,11 +139,29 @@ def resource_override(
     resource_identifier: str = "name",
     folder_identifier: str = "folder_path",
 ) -> Callable[..., Any]:
+    """Decorator for applying resource overrides for an overridable resource.
+
+    It checks the current ContextVar to identify the requested overrides and, if any key matches, it invokes the decorated function
+    with the extracted resource and folder identifiers.
+
+    Args:
+        resource_type: Type of resource to check for overrides (e.g., "asset", "bucket")
+        resource_identifier: Key name for the resource ID in override data (default: "name")
+        folder_identifier: Key name for the folder path in override data (default: "folder_path")
+
+    Returns:
+        Decorated function that receives overridden resource identifiers when applicable
+
+    Note:
+        Must be applied BEFORE the @traced decorator to ensure proper execution order.
+    """
+
     def decorator(func: Callable[..., Any]):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        sig = inspect.signature(func)
+
+        def process_args(args, kwargs) -> dict[str, Any]:
+            """Process arguments and apply resource overrides if applicable."""
             # convert both args and kwargs to single dict
-            sig = inspect.signature(func)
             bound = sig.bind_partial(*args, **kwargs)
             bound.apply_defaults()
             all_args = dict(bound.arguments)
@@ -177,22 +195,23 @@ def resource_override(
                             matched_overwrite.folder_identifier
                         )
 
-            return func(**all_args)
+            return all_args
 
-        wrapper._should_infer_bindings = True  # type: ignore[attr-defined] # probably a better way to do this
-        wrapper._infer_bindings_mappings = {  # type: ignore[attr-defined] # probably a better way to do this
-            "name": resource_identifier,
-            "folder_path": folder_identifier,
-        }
-        return wrapper
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                all_args = process_args(args, kwargs)
+                return await func(**all_args)
+
+            return async_wrapper
+        else:
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                all_args = process_args(args, kwargs)
+                return func(**all_args)
+
+            return wrapper
 
     return decorator
-
-
-def get_inferred_bindings_names(cls: T):
-    inferred_bindings = {}
-    for name, method in inspect.getmembers(cls, inspect.isfunction):
-        if hasattr(method, "_should_infer_bindings") and method._should_infer_bindings:
-            inferred_bindings[name] = method._infer_bindings_mappings  # type: ignore # probably a better way to do this
-
-    return inferred_bindings

--- a/src/uipath/platform/action_center/_tasks_service.py
+++ b/src/uipath/platform/action_center/_tasks_service.py
@@ -166,12 +166,12 @@ class TasksService(FolderContext, BaseService):
     ) -> None:
         super().__init__(config=config, execution_context=execution_context)
 
-    @traced(name="tasks_create", run_type="uipath")
     @resource_override(
         resource_type="app",
         resource_identifier="app_name",
         folder_identifier="app_folder_path",
     )
+    @traced(name="tasks_create", run_type="uipath")
     async def create_async(
         self,
         title: str,
@@ -234,12 +234,12 @@ class TasksService(FolderContext, BaseService):
             )
         return Task.model_validate(json_response)
 
-    @traced(name="tasks_create", run_type="uipath")
     @resource_override(
         resource_type="app",
         resource_identifier="app_name",
         folder_identifier="app_folder_path",
     )
+    @traced(name="tasks_create", run_type="uipath")
     def create(
         self,
         title: str,
@@ -302,12 +302,12 @@ class TasksService(FolderContext, BaseService):
             )
         return Task.model_validate(json_response)
 
-    @traced(name="tasks_retrieve", run_type="uipath")
     @resource_override(
         resource_type="app",
         resource_identifier="app_name",
         folder_identifier="app_folder_path",
     )
+    @traced(name="tasks_retrieve", run_type="uipath")
     def retrieve(
         self,
         action_key: str,
@@ -336,12 +336,12 @@ class TasksService(FolderContext, BaseService):
 
         return Task.model_validate(response.json())
 
-    @traced(name="tasks_retrieve", run_type="uipath")
     @resource_override(
         resource_type="app",
         resource_identifier="app_name",
         folder_identifier="app_folder_path",
     )
+    @traced(name="tasks_retrieve", run_type="uipath")
     async def retrieve_async(
         self,
         action_key: str,

--- a/src/uipath/platform/connections/_connections_service.py
+++ b/src/uipath/platform/connections/_connections_service.py
@@ -37,12 +37,12 @@ class ConnectionsService(BaseService):
         super().__init__(config=config, execution_context=execution_context)
         self._folders_service = folders_service
 
+    @resource_override("connection", resource_identifier="key")
     @traced(
         name="connections_retrieve",
         run_type="uipath",
         hide_output=True,
     )
-    @resource_override("connection", resource_identifier="key")
     def retrieve(self, key: str) -> Connection:
         """Retrieve connection details by its key.
 
@@ -248,12 +248,12 @@ class ConnectionsService(BaseService):
 
         return self._parse_and_validate_list_response(response)
 
+    @resource_override("connection", resource_identifier="key")
     @traced(
         name="connections_retrieve",
         run_type="uipath",
         hide_output=True,
     )
-    @resource_override("connection", resource_identifier="key")
     async def retrieve_async(self, key: str) -> Connection:
         """Asynchronously retrieve connection details by its key.
 

--- a/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -74,8 +74,8 @@ class ContextGroundingService(FolderContext, BaseService):
         super().__init__(config=config, execution_context=execution_context)
 
     # 2.3.0 prefix trace name with contextgrounding
-    @traced(name="add_to_index", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="add_to_index", run_type="uipath")
     def add_to_index(
         self,
         name: str,
@@ -130,8 +130,8 @@ class ContextGroundingService(FolderContext, BaseService):
             self.ingest_data(index, folder_key=folder_key, folder_path=folder_path)
 
     # 2.3.0 prefix trace name with contextgrounding
-    @traced(name="add_to_index", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="add_to_index", run_type="uipath")
     async def add_to_index_async(
         self,
         name: str,
@@ -189,8 +189,8 @@ class ContextGroundingService(FolderContext, BaseService):
                 index, folder_key=folder_key, folder_path=folder_path
             )
 
-    @traced(name="contextgrounding_retrieve", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="contextgrounding_retrieve", run_type="uipath")
     def retrieve(
         self,
         name: str,
@@ -231,8 +231,8 @@ class ContextGroundingService(FolderContext, BaseService):
         except StopIteration as e:
             raise Exception("ContextGroundingIndex not found") from e
 
-    @traced(name="contextgrounding_retrieve", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="contextgrounding_retrieve", run_type="uipath")
     async def retrieve_async(
         self,
         name: str,
@@ -343,8 +343,8 @@ class ContextGroundingService(FolderContext, BaseService):
 
         return response.json()
 
-    @traced(name="contextgrounding_create_index", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="contextgrounding_create_index", run_type="uipath")
     def create_index(
         self,
         name: str,
@@ -398,8 +398,8 @@ class ContextGroundingService(FolderContext, BaseService):
 
         return ContextGroundingIndex.model_validate(response.json())
 
-    @traced(name="contextgrounding_create_index", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="contextgrounding_create_index", run_type="uipath")
     async def create_index_async(
         self,
         name: str,
@@ -453,8 +453,8 @@ class ContextGroundingService(FolderContext, BaseService):
 
         return ContextGroundingIndex.model_validate(response.json())
 
-    @traced(name="contextgrounding_retrieve_deep_rag", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_retrieve_deep_rag", run_type="uipath")
     def retrieve_deep_rag(
         self,
         id: str,
@@ -482,8 +482,8 @@ class ContextGroundingService(FolderContext, BaseService):
         )
         return DeepRagResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_retrieve_deep_rag_async", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_retrieve_deep_rag_async", run_type="uipath")
     async def retrieve_deep_rag_async(
         self,
         id: str,
@@ -513,8 +513,8 @@ class ContextGroundingService(FolderContext, BaseService):
 
         return DeepRagResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_start_batch_transform", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_start_batch_transform", run_type="uipath")
     def start_batch_transform(
         self,
         name: str,
@@ -571,8 +571,8 @@ class ContextGroundingService(FolderContext, BaseService):
         )
         return BatchTransformCreationResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_start_batch_transform_async", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_start_batch_transform_async", run_type="uipath")
     async def start_batch_transform_async(
         self,
         name: str,
@@ -629,8 +629,8 @@ class ContextGroundingService(FolderContext, BaseService):
         )
         return BatchTransformCreationResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_retrieve_batch_transform", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_retrieve_batch_transform", run_type="uipath")
     def retrieve_batch_transform(
         self,
         id: str,
@@ -655,8 +655,8 @@ class ContextGroundingService(FolderContext, BaseService):
         )
         return BatchTransformResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_retrieve_batch_transform_async", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_retrieve_batch_transform_async", run_type="uipath")
     async def retrieve_batch_transform_async(
         self,
         id: str,
@@ -681,8 +681,8 @@ class ContextGroundingService(FolderContext, BaseService):
         )
         return BatchTransformResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_download_batch_transform_result", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_download_batch_transform_result", run_type="uipath")
     def download_batch_transform_result(
         self,
         id: str,
@@ -727,10 +727,10 @@ class ContextGroundingService(FolderContext, BaseService):
                 file_content = client.get(uri_response.uri).content
             file.write(file_content)
 
+    @resource_override(resource_type="index", resource_identifier="index_name")
     @traced(
         name="contextgrounding_download_batch_transform_result_async", run_type="uipath"
     )
-    @resource_override(resource_type="index", resource_identifier="index_name")
     async def download_batch_transform_result_async(
         self,
         id: str,
@@ -777,8 +777,8 @@ class ContextGroundingService(FolderContext, BaseService):
         with open(destination_path, "wb") as file:
             file.write(file_content)
 
-    @traced(name="contextgrounding_start_deep_rag", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_start_deep_rag", run_type="uipath")
     def start_deep_rag(
         self,
         name: str,
@@ -829,8 +829,8 @@ class ContextGroundingService(FolderContext, BaseService):
 
         return DeepRagCreationResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_start_deep_rag_async", run_type="uipath")
     @resource_override(resource_type="index", resource_identifier="index_name")
+    @traced(name="contextgrounding_start_deep_rag_async", run_type="uipath")
     async def start_deep_rag_async(
         self,
         name: str,
@@ -882,8 +882,8 @@ class ContextGroundingService(FolderContext, BaseService):
 
         return DeepRagCreationResponse.model_validate(response.json())
 
-    @traced(name="contextgrounding_search", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="contextgrounding_search", run_type="uipath")
     def search(
         self,
         name: str,
@@ -931,8 +931,8 @@ class ContextGroundingService(FolderContext, BaseService):
             response.json()
         )
 
-    @traced(name="contextgrounding_search", run_type="uipath")
     @resource_override(resource_type="index")
+    @traced(name="contextgrounding_search", run_type="uipath")
     async def search_async(
         self,
         name: str,

--- a/src/uipath/platform/orchestrator/_assets_service.py
+++ b/src/uipath/platform/orchestrator/_assets_service.py
@@ -21,10 +21,10 @@ class AssetsService(FolderContext, BaseService):
         super().__init__(config=config, execution_context=execution_context)
         self._base_url = "assets"
 
+    @resource_override(resource_type="asset")
     @traced(
         name="assets_retrieve", run_type="uipath", hide_input=True, hide_output=True
     )
-    @resource_override(resource_type="asset")
     def retrieve(
         self,
         name: str,
@@ -77,10 +77,10 @@ class AssetsService(FolderContext, BaseService):
         else:
             return Asset.model_validate(response.json()["value"][0])
 
+    @resource_override(resource_type="asset")
     @traced(
         name="assets_retrieve", run_type="uipath", hide_input=True, hide_output=True
     )
-    @resource_override(resource_type="asset")
     async def retrieve_async(
         self,
         name: str,
@@ -124,10 +124,10 @@ class AssetsService(FolderContext, BaseService):
         else:
             return Asset.model_validate(response.json()["value"][0])
 
+    @resource_override(resource_type="asset")
     @traced(
         name="assets_credential", run_type="uipath", hide_input=True, hide_output=True
     )
-    @resource_override(resource_type="asset")
     def retrieve_credential(
         self,
         name: str,
@@ -179,10 +179,10 @@ class AssetsService(FolderContext, BaseService):
 
         return user_asset.credential_password
 
+    @resource_override(resource_type="asset")
     @traced(
         name="assets_credential", run_type="uipath", hide_input=True, hide_output=True
     )
-    @resource_override(resource_type="asset")
     async def retrieve_credential_async(
         self,
         name: str,

--- a/src/uipath/platform/orchestrator/_buckets_service.py
+++ b/src/uipath/platform/orchestrator/_buckets_service.py
@@ -329,8 +329,8 @@ class BucketsService(FolderContext, BaseService):
         bucket = Bucket.model_validate(response)
         return bucket
 
-    @traced(name="buckets_delete", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_delete", run_type="uipath")
     def delete(
         self,
         *,
@@ -364,8 +364,8 @@ class BucketsService(FolderContext, BaseService):
             headers={**self.folder_headers},
         )
 
-    @traced(name="buckets_delete", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_delete", run_type="uipath")
     async def delete_async(
         self,
         *,
@@ -385,8 +385,8 @@ class BucketsService(FolderContext, BaseService):
             headers={**self.folder_headers},
         )
 
-    @traced(name="buckets_download", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_download", run_type="uipath")
     def download(
         self,
         *,
@@ -440,8 +440,8 @@ class BucketsService(FolderContext, BaseService):
                 file_content = self.custom_client.get(read_uri, headers=headers).content
             file.write(file_content)
 
-    @traced(name="buckets_download", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_download", run_type="uipath")
     async def download_async(
         self,
         *,
@@ -501,8 +501,8 @@ class BucketsService(FolderContext, BaseService):
 
         await asyncio.to_thread(Path(destination_path).write_bytes, file_content)
 
-    @traced(name="buckets_upload", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_upload", run_type="uipath")
     def upload(
         self,
         *,
@@ -593,8 +593,8 @@ class BucketsService(FolderContext, BaseService):
                         write_uri, headers=headers, content=file_content
                     )
 
-    @traced(name="buckets_upload", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_upload", run_type="uipath")
     async def upload_async(
         self,
         *,
@@ -690,8 +690,8 @@ class BucketsService(FolderContext, BaseService):
                     write_uri, headers=headers, content=file_content
                 )
 
-    @traced(name="buckets_retrieve", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_retrieve", run_type="uipath")
     def retrieve(
         self,
         *,
@@ -764,8 +764,8 @@ class BucketsService(FolderContext, BaseService):
         bucket = Bucket.model_validate(bucket_data)
         return bucket
 
-    @traced(name="buckets_retrieve", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_retrieve", run_type="uipath")
     async def retrieve_async(
         self,
         *,
@@ -842,8 +842,8 @@ class BucketsService(FolderContext, BaseService):
         bucket = Bucket.model_validate(bucket_data)
         return bucket
 
-    @traced(name="buckets_list_files", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_list_files", run_type="uipath")
     def list_files(
         self,
         *,
@@ -955,8 +955,8 @@ class BucketsService(FolderContext, BaseService):
             has_more=next_token is not None,
         )
 
-    @traced(name="buckets_list_files", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_list_files", run_type="uipath")
     async def list_files_async(
         self,
         *,
@@ -1042,8 +1042,8 @@ class BucketsService(FolderContext, BaseService):
             has_more=next_token is not None,
         )
 
-    @traced(name="buckets_exists_file", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_exists_file", run_type="uipath")
     def exists_file(
         self,
         *,
@@ -1125,8 +1125,8 @@ class BucketsService(FolderContext, BaseService):
 
         return False
 
-    @traced(name="buckets_exists_file", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_exists_file", run_type="uipath")
     async def exists_file_async(
         self,
         *,
@@ -1199,8 +1199,8 @@ class BucketsService(FolderContext, BaseService):
 
         return False
 
-    @traced(name="buckets_delete_file", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_delete_file", run_type="uipath")
     def delete_file(
         self,
         *,
@@ -1235,8 +1235,8 @@ class BucketsService(FolderContext, BaseService):
             headers=spec.headers,
         )
 
-    @traced(name="buckets_delete_file", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_delete_file", run_type="uipath")
     async def delete_file_async(
         self,
         *,
@@ -1271,8 +1271,8 @@ class BucketsService(FolderContext, BaseService):
             headers=spec.headers,
         )
 
-    @traced(name="buckets_get_files", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_get_files", run_type="uipath")
     def get_files(
         self,
         *,
@@ -1436,8 +1436,8 @@ class BucketsService(FolderContext, BaseService):
             top=top,
         )
 
-    @traced(name="buckets_get_files", run_type="uipath")
     @resource_override(resource_type="bucket")
+    @traced(name="buckets_get_files", run_type="uipath")
     async def get_files_async(
         self,
         *,

--- a/src/uipath/platform/orchestrator/_jobs_service.py
+++ b/src/uipath/platform/orchestrator/_jobs_service.py
@@ -471,8 +471,8 @@ class JobsService(FolderContext, BaseService):
         except LookupError:
             return False
 
-    @traced(name="jobs_retrieve", run_type="uipath")
     @resource_override(resource_type="process", resource_identifier="process_name")
+    @traced(name="jobs_retrieve", run_type="uipath")
     def retrieve(
         self,
         job_key: str,
@@ -518,8 +518,8 @@ class JobsService(FolderContext, BaseService):
                 raise LookupError(f"Job with key '{job_key}' not found") from e
             raise
 
-    @traced(name="jobs_retrieve_async", run_type="uipath")
     @resource_override(resource_type="process", resource_identifier="process_name")
+    @traced(name="jobs_retrieve_async", run_type="uipath")
     async def retrieve_async(
         self,
         job_key: str,

--- a/src/uipath/platform/orchestrator/_processes_service.py
+++ b/src/uipath/platform/orchestrator/_processes_service.py
@@ -28,8 +28,8 @@ class ProcessesService(FolderContext, BaseService):
         self._attachments_service = attachment_service
         super().__init__(config=config, execution_context=execution_context)
 
-    @traced(name="processes_invoke", run_type="uipath")
     @resource_override(resource_type="process")
+    @traced(name="processes_invoke", run_type="uipath")
     def invoke(
         self,
         name: str,
@@ -92,8 +92,8 @@ class ProcessesService(FolderContext, BaseService):
 
         return Job.model_validate(response.json()["value"][0])
 
-    @traced(name="processes_invoke", run_type="uipath")
     @resource_override(resource_type="process")
+    @traced(name="processes_invoke", run_type="uipath")
     async def invoke_async(
         self,
         name: str,

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.3"
+version = "2.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- inspect  functions decorated by @resource_override to await for the coroutine (if async)
- inverse order @resource_override -> @traced to capture the actual override resources name + folder in the spans
- removed` _should_infer_bindings`  and `_infer_bindings_mappings` from function attributes list, as bindings are not auto-inferred anymore
- add test to verify spans attrs content when resource_override is present

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.4.4.dev1010733647",

  # Any version from PR
  "uipath>=2.4.4.dev1010730000,<2.4.4.dev1010740000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.4.4.dev1010730000,<2.4.4.dev1010740000",
]
```
<!-- DEV_PACKAGE_END -->