### PR TITLE
fix(ConnectionIdOverwrites): connection id overwrites in eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.5"
+version = "2.4.6"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_utils/_bindings.py
+++ b/src/uipath/_utils/_bindings.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, TypeAdapter
 
 T = TypeVar("T")
 
@@ -56,7 +56,11 @@ class GenericResourceOverwrite(ResourceOverwrite):
 
 class ConnectionResourceOverwrite(ResourceOverwrite):
     resource_type: Literal["connection"]
-    connection_id: str = Field(alias="connectionId")
+    # In eval context, studio web provides "ConnectionId".
+    connection_id: str = Field(
+        alias="connectionId",
+        validation_alias=AliasChoices("connectionId", "ConnectionId"),
+    )
     folder_key: str = Field(alias="folderKey")
 
     model_config = ConfigDict(

--- a/tests/sdk/test_bindings.py
+++ b/tests/sdk/test_bindings.py
@@ -4,7 +4,9 @@ import pytest
 
 from uipath._utils import resource_override
 from uipath._utils._bindings import (
+    ConnectionResourceOverwrite,
     GenericResourceOverwrite,
+    ResourceOverwriteParser,
     ResourceOverwritesContext,
     _resource_overwrites,
 )
@@ -335,3 +337,57 @@ class TestResourceOverwritesContext:
         # Verify context was cleaned up despite the exception
         result_after = get_asset("test", "original")
         assert result_after == ("test", "original")
+
+
+class TestConnectionResourceOverwriteAliases:
+    """Test that ConnectionResourceOverwrite accepts both connectionId and ConnectionId aliases."""
+
+    def test_connection_resource_overwrite_with_lowercase_alias(self):
+        """Test that connectionId alias works."""
+        overwrite = ConnectionResourceOverwrite(
+            resource_type="connection",
+            connectionId="conn-123",
+            folderKey="folder1",
+        )
+        assert overwrite.connection_id == "conn-123"
+        assert overwrite.folder_key == "folder1"
+
+    def test_connection_resource_overwrite_with_capitalized_alias(self):
+        """Test that ConnectionId alias works."""
+        overwrite = ConnectionResourceOverwrite(
+            resource_type="connection",
+            ConnectionId="conn-456",
+            folderKey="folder2",
+        )
+        assert overwrite.connection_id == "conn-456"
+        assert overwrite.folder_key == "folder2"
+
+    def test_connection_resource_overwrite_with_field_name(self):
+        """Test that the actual field name connection_id also works."""
+        overwrite = ConnectionResourceOverwrite(
+            resource_type="connection",
+            connection_id="conn-789",
+            folder_key="folder3",
+        )
+        assert overwrite.connection_id == "conn-789"
+        assert overwrite.folder_key == "folder3"
+
+    def test_parse_connection_with_lowercase_alias(self):
+        """Test parsing a connection resource with lowercase connectionId alias."""
+        overwrite = ResourceOverwriteParser.parse(
+            key="connection.conn-123",
+            value={"connectionId": "conn-123", "folderKey": "folder1"},
+        )
+        assert isinstance(overwrite, ConnectionResourceOverwrite)
+        assert overwrite.connection_id == "conn-123"
+        assert overwrite.folder_key == "folder1"
+
+    def test_parse_connection_with_capitalized_alias(self):
+        """Test parsing a connection resource with capitalized ConnectionId alias."""
+        overwrite = ResourceOverwriteParser.parse(
+            key="connection.conn-456",
+            value={"ConnectionId": "conn-456", "folderKey": "folder2"},
+        )
+        assert isinstance(overwrite, ConnectionResourceOverwrite)
+        assert overwrite.connection_id == "conn-456"
+        assert overwrite.folder_key == "folder2"

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.5"
+version = "2.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
In eval context `studio_client.get_resource_overwrites()` is invoked. This client provides overrides for connections as `ConnectionId` instead of `connectionId`. Allowing parsing of both fields using `AliasChoice`, but we prioritize `connectionId` over `ConnectionId` for backwards compatibility. Serialization will always be done to `connectionId`.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.4.6.dev1010753659",

  # Any version from PR
  "uipath>=2.4.6.dev1010750000,<2.4.6.dev1010760000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.4.6.dev1010750000,<2.4.6.dev1010760000",
]
```
<!-- DEV_PACKAGE_END -->