### PR TITLE
feat: fix the tool mock name and add the Evaluation Output Span

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.7"
+version = "2.4.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/mocks/mocks.py
+++ b/src/uipath/_cli/_evals/mocks/mocks.py
@@ -61,6 +61,50 @@ def clear_execution_context() -> None:
     execution_id_context.set(None)
 
 
+def _normalize_tool_name(name: str) -> str:
+    """Normalize tool name by replacing underscores with spaces.
+
+    Tool names may use spaces in configuration but underscores in execution.
+    """
+    return name.replace("_", " ")
+
+
+def is_tool_simulated(tool_name: str) -> bool:
+    """Check if a tool will be simulated based on the current evaluation context.
+
+    Args:
+        tool_name: The name of the tool to check.
+
+    Returns:
+        True if we're in an evaluation context and the tool is configured
+        to be simulated, False otherwise.
+    """
+    eval_item = evaluation_context.get()
+    if eval_item is None or eval_item.mocking_strategy is None:
+        return False
+
+    from uipath._cli._evals._models._evaluation_set import (
+        LLMMockingStrategy,
+        MockitoMockingStrategy,
+    )
+
+    strategy = eval_item.mocking_strategy
+    normalized_tool_name = _normalize_tool_name(tool_name)
+
+    if isinstance(strategy, LLMMockingStrategy):
+        simulated_names = [
+            _normalize_tool_name(t.name) for t in strategy.tools_to_simulate
+        ]
+        return normalized_tool_name in simulated_names
+    elif isinstance(strategy, MockitoMockingStrategy):
+        return any(
+            _normalize_tool_name(b.function) == normalized_tool_name
+            for b in strategy.behaviors
+        )
+
+    return False
+
+
 async def get_mocked_response(
     func: Callable[[Any], Any], params: dict[str, Any], *args, **kwargs
 ) -> Any:

--- a/src/uipath/eval/mocks/__init__.py
+++ b/src/uipath/eval/mocks/__init__.py
@@ -1,7 +1,8 @@
 """Mock interface."""
 
 from uipath._cli._evals._models._mocks import ExampleCall
+from uipath._cli._evals.mocks.mocks import is_tool_simulated
 
 from .mockable import mockable
 
-__all__ = ["ExampleCall", "mockable"]
+__all__ = ["ExampleCall", "mockable", "is_tool_simulated"]

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.7"
+version = "2.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Add `is_tool_simulated(tool_name: str) -> bool` function that checks whether a tool will be simulated based on the current evaluation context
- Add `_normalize_tool_name` helper to handle underscore/space normalization in tool names (e.g., `my_tool` matches config with `my tool`)
- Export `is_tool_simulated` from `uipath.eval.mocks` public API
- Add "Evaluation output" span as a child of each evaluator span in evaluation tracing containing:
  - `value`: the evaluation score
  - `justification`: extracted from evaluation details  
  - `evaluatorId`: the ID of the evaluator
- Bump version to 2.4.8

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Add unit tests for `_normalize_tool_name` function
- [x] Add unit tests for `is_tool_simulated` with various scenarios:
  - No evaluation context
  - Null mocking strategy
  - LLM strategy with simulated/non-simulated tools
  - Mockito strategy with simulated/non-simulated tools
  - Underscore/space normalization handling
- [x] Add tests for new "Evaluation output" span:
  - Span name and type
  - Required attributes (value, evaluatorId, justification)
  - Span hierarchy (child of evaluator)
  - Justification extraction from different detail formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.4.8.dev1010783672",

  # Any version from PR
  "uipath>=2.4.8.dev1010780000,<2.4.8.dev1010790000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.4.8.dev1010780000,<2.4.8.dev1010790000",
]
```
<!-- DEV_PACKAGE_END -->


## related PR 

https://github.com/UiPath/uipath-agents-python/pull/79


<img width="1510" height="949" alt="image" src="https://github.com/user-attachments/assets/190529d7-ae9e-4014-90cf-0b087338c05c" />
