### PR TITLE
feat: infer attachment on init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.4.13"
+version = "2.4.14"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.1.4, <0.2.0",
-  "uipath-runtime>=0.4.0, <0.5.0",
+  "uipath-runtime>=0.4.1, <0.5.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -173,7 +173,11 @@ def write_entry_points_file(entry_points: list[UiPathRuntimeSchema]) -> Path:
         "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
         "$id": "entry-points.json",
         "entryPoints": [
-            ep.model_dump(by_alias=True, exclude_unset=True) for ep in entry_points
+            ep.model_dump(
+                by_alias=True,
+                exclude_unset=True,
+            )
+            for ep in entry_points
         ],
     }
 
@@ -297,6 +301,7 @@ def init(no_agents_md_override: bool) -> None:
                                 entrypoint_name, runtime_id="default"
                             )
                             schema = await runtime.get_schema()
+
                             entry_point_schemas.append(schema)
                         finally:
                             if runtime:

--- a/src/uipath/functions/runtime.py
+++ b/src/uipath/functions/runtime.py
@@ -22,7 +22,7 @@ from uipath.runtime.errors import (
     UiPathErrorContract,
     UiPathRuntimeError,
 )
-from uipath.runtime.schema import UiPathRuntimeSchema
+from uipath.runtime.schema import UiPathRuntimeSchema, transform_attachments
 
 from .schema_gen import get_type_schema
 from .type_conversion import (
@@ -174,7 +174,8 @@ class UiPathFunctionsRuntime:
             input_schema = {}
         else:
             input_param_name = next(iter(sig.parameters))
-            input_schema = get_type_schema(hints.get(input_param_name))
+            schema = get_type_schema(hints.get(input_param_name))
+            input_schema = transform_attachments(schema)
 
         # Determine output schema
         output_schema = get_type_schema(hints.get("return"))

--- a/src/uipath/functions/schema_gen.py
+++ b/src/uipath/functions/schema_gen.py
@@ -7,6 +7,7 @@ from types import UnionType
 from typing import Any, Union, get_args, get_origin
 
 from pydantic import BaseModel
+from uipath.runtime.schema import transform_nullable_types, transform_references
 
 TYPE_MAP: dict[str, str] = {
     "int": "integer",
@@ -91,17 +92,20 @@ def _get_enum_schema(enum_class: type[Enum]) -> dict[str, Any]:
 
 
 def _get_pydantic_schema(model_class: type[BaseModel]) -> dict[str, Any]:
-    """Generate schema for Pydantic models."""
-    properties = {}
-    required = []
+    """Generate schema for Pydantic models using Pydantic's built-in schema generation."""
+    schema = model_class.model_json_schema()
 
-    for field_name, field_info in model_class.model_fields.items():
-        schema_field_name = field_info.alias or field_name
-        properties[schema_field_name] = get_type_schema(field_info.annotation)
-        if field_info.is_required():
-            required.append(schema_field_name)
-
-    return {"type": "object", "properties": properties, "required": required}
+    resolved_schema, _ = transform_references(schema)
+    processed_properties = transform_nullable_types(resolved_schema)
+    assert isinstance(processed_properties, dict)
+    schema = {
+        "type": "object",
+        "properties": processed_properties.get("properties", {}),
+        "required": processed_properties.get("required", []),
+    }
+    if (title := processed_properties.get("title", None)) is not None:
+        schema["title"] = title
+    return schema
 
 
 def _get_dataclass_schema(dataclass_type: type) -> dict[str, Any]:
@@ -111,6 +115,7 @@ def _get_dataclass_schema(dataclass_type: type) -> dict[str, Any]:
 
     for field in fields(dataclass_type):
         properties[field.name] = get_type_schema(field.type)
+
         # Field is required if it has no default value and no default_factory
         if field.default == field.default_factory == field.default.__class__.__name__:
             required.append(field.name)

--- a/src/uipath/platform/attachments/attachments.py
+++ b/src/uipath/platform/attachments/attachments.py
@@ -21,6 +21,9 @@ class Attachment(BaseModel):
     id: Optional[uuid.UUID] = Field(None, alias="ID")
     full_name: str = Field(..., alias="FullName")
     mime_type: str = Field(..., alias="MimeType")
+    model_config = {
+        "title": "UiPathAttachment",
+    }
 
 
 @dataclass

--- a/tests/cli/test_input_args.py
+++ b/tests/cli/test_input_args.py
@@ -37,82 +37,78 @@ class SimpleDataClass:
     value: int = 42
 
 
-def test_pydantic_model_with_aliases():
-    """Test that Pydantic model schemas use field aliases when defined."""
-    schema = get_type_schema(EventArguments)
+class TestInputArgs:
+    def test_pydantic_model_with_aliases(self):
+        """Test that Pydantic model schemas use field aliases when defined."""
+        schema = get_type_schema(EventArguments)
 
-    assert schema["type"] == "object"
-    assert "properties" in schema
+        assert schema["type"] == "object"
+        assert "properties" in schema
 
-    # Check that aliases are used in property names
-    expected_properties = {
-        "UiPathEventConnector",
-        "UiPathEvent",
-        "UiPathEventObjectType",
-        "UiPathEventObjectId",
-        "UiPathAdditionalEventData",
-    }
-    actual_properties = set(schema["properties"].keys())
-    assert actual_properties == expected_properties
+        # Check that aliases are used in property names
+        expected_properties = {
+            "UiPathEventConnector",
+            "UiPathEvent",
+            "UiPathEventObjectType",
+            "UiPathEventObjectId",
+            "UiPathAdditionalEventData",
+        }
+        actual_properties = set(schema["properties"].keys())
+        assert actual_properties == expected_properties
 
-    # All fields have defaults, so none should be required
-    assert schema["required"] == []
+        # All fields have defaults, so none should be required
+        assert schema["required"] == []
 
+    def test_pydantic_model_required_fields(self):
+        """Test that required fields are correctly identified in Pydantic models."""
+        schema = get_type_schema(RequiredFieldsModel)
 
-def test_pydantic_model_required_fields():
-    """Test that required fields are correctly identified in Pydantic models."""
-    schema = get_type_schema(RequiredFieldsModel)
+        assert schema["type"] == "object"
+        assert "properties" in schema
 
-    assert schema["type"] == "object"
-    assert "properties" in schema
+        # Check properties include both field names and aliases
+        expected_properties = {
+            "required_field",  # field name (no alias)
+            "optional_field",  # field name (no alias)
+            "AliasedRequired",  # alias
+            "AliasedOptional",  # alias
+        }
+        actual_properties = set(schema["properties"].keys())
+        assert actual_properties == expected_properties
 
-    # Check properties include both field names and aliases
-    expected_properties = {
-        "required_field",  # field name (no alias)
-        "optional_field",  # field name (no alias)
-        "AliasedRequired",  # alias
-        "AliasedOptional",  # alias
-    }
-    actual_properties = set(schema["properties"].keys())
-    assert actual_properties == expected_properties
+        # Check required fields (using aliases where defined)
+        expected_required = {"required_field", "AliasedRequired"}
+        actual_required = set(schema["required"])
+        assert actual_required == expected_required
 
-    # Check required fields (using aliases where defined)
-    expected_required = {"required_field", "AliasedRequired"}
-    actual_required = set(schema["required"])
-    assert actual_required == expected_required
+    def test_dataclass_still_works(self):
+        """Test that dataclass functionality is not broken."""
+        schema = get_type_schema(SimpleDataClass)
 
+        assert schema["type"] == "object"
+        assert "properties" in schema
 
-def test_dataclass_still_works():
-    """Test that dataclass functionality is not broken."""
-    schema = get_type_schema(SimpleDataClass)
+        # Dataclass should use field names (no alias support)
+        expected_properties = {"name", "value"}
+        actual_properties = set(schema["properties"].keys())
+        assert actual_properties == expected_properties
 
-    assert schema["type"] == "object"
-    assert "properties" in schema
+        # Field with default should not be required
+        assert schema["required"] == ["name"]
 
-    # Dataclass should use field names (no alias support)
-    expected_properties = {"name", "value"}
-    actual_properties = set(schema["properties"].keys())
-    assert actual_properties == expected_properties
+    def test_primitive_types(self):
+        """Test that primitive type handling still works."""
+        assert get_type_schema(str) == {"type": "string"}
+        assert get_type_schema(int) == {"type": "integer"}
+        assert get_type_schema(float) == {"type": "number"}
+        assert get_type_schema(bool) == {"type": "boolean"}
 
-    # Field with default should not be required
-    assert schema["required"] == ["name"]
+    def test_optional_types(self):
+        """Test handling of Optional types."""
+        response = get_type_schema(Optional[str])
+        assert response == {"type": "string"}  # Should unwrap Optional
 
-
-def test_primitive_types():
-    """Test that primitive type handling still works."""
-    assert get_type_schema(str) == {"type": "string"}
-    assert get_type_schema(int) == {"type": "integer"}
-    assert get_type_schema(float) == {"type": "number"}
-    assert get_type_schema(bool) == {"type": "boolean"}
-
-
-def test_optional_types():
-    """Test handling of Optional types."""
-    schema = get_type_schema(Optional[str])
-    assert schema == {"type": "string"}  # Should unwrap Optional
-
-
-def test_optional_union_types():
-    """Test handling of Optional types."""
-    schema = get_type_schema(str | None)
-    assert schema == {"type": "string"}  # Should unwrap Optional
+    def test_optional_union_types(self):
+        """Test handling of Optional types."""
+        response = get_type_schema(str | None)
+        assert response == {"type": "string"}  # Should unwrap Optional

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.13"
+version = "2.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2553,7 +2553,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.1.4,<0.2.0" },
-    { name = "uipath-runtime", specifier = ">=0.4.0,<0.5.0" },
+    { name = "uipath-runtime", specifier = ">=0.4.1,<0.5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2599,14 +2599,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/6f/683b258720c18f8ec0e68ec712a05f42ede6ecf63e75710aa555b8d52092/uipath_runtime-0.4.0.tar.gz", hash = "sha256:129933b08c6f589d13c2c0e7045ddf61ca144029340c1482134d127dd15563e3", size = 99934, upload-time = "2026-01-03T05:44:33.712Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/2a/8373a1c1118442b000c5a89e864a61e8548e6e1575c30fb21501b0e60652/uipath_runtime-0.4.1.tar.gz", hash = "sha256:ddcb26c02833993432a4c19c3306a55858a14afecaffcf32195601564bb44585", size = 102875, upload-time = "2026-01-13T13:34:50.803Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/46/402708653a197c7f0b1d9de66b235f8a5798f814c775bab575cd2d7e2539/uipath_runtime-0.4.0-py3-none-any.whl", hash = "sha256:f49a23ed24f7cfaa736f99a5763bcf314234c67b727c40ec891a0a3d10140027", size = 38359, upload-time = "2026-01-03T05:44:31.817Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/58/14c89ba528c4e69683d0e19b43026bc8102dab02ec66c4a0d9f2a0fc4ae9/uipath_runtime-0.4.1-py3-none-any.whl", hash = "sha256:b10c7072246066c8e525eb602a9e04f5497a7da6af871d1bd27693fb9e910d7b", size = 39834, upload-time = "2026-01-13T13:34:49.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Infer attachments on init

special handling for `Attachment` model from `uipath.platform.attachments` when inferring the input schemas.
