### PR TITLE
fix(LazyInit): support lazy initialization of llm in legacy evaluators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.18"
+version = "2.4.19"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/eval/evaluators/legacy_context_precision_evaluator.py
+++ b/src/uipath/eval/evaluators/legacy_context_precision_evaluator.py
@@ -101,9 +101,8 @@ class LegacyContextPrecisionEvaluator(
     llm: Optional[UiPathLlmChatService] = None
 
     def model_post_init(self, __context: Any):
-        """Initialize the LLM service after model creation."""
+        """Initialize the evaluator after model creation."""
         super().model_post_init(__context)
-        self._initialize_llm()
 
     def _initialize_llm(self):
         """Initialize the LLM used for evaluation."""
@@ -127,6 +126,10 @@ class LegacyContextPrecisionEvaluator(
         Returns:
             NumericEvaluationResult with normalized score (0-1) and detailed justification
         """
+        # Lazily initialize the LLM on first evaluation call
+        if self.llm is None:
+            self._initialize_llm()
+
         # Extract context grounding spans from the trace
         context_groundings = self._extract_context_groundings(
             agent_execution.agent_trace

--- a/src/uipath/eval/evaluators/legacy_faithfulness_evaluator.py
+++ b/src/uipath/eval/evaluators/legacy_faithfulness_evaluator.py
@@ -41,9 +41,8 @@ class LegacyFaithfulnessEvaluator(
     llm: Optional[UiPathLlmChatService] = None
 
     def model_post_init(self, __context: Any):
-        """Initialize the LLM service after model creation."""
+        """Initialize the evaluator after model creation."""
         super().model_post_init(__context)
-        self._initialize_llm()
 
     def _initialize_llm(self):
         """Initialize the LLM used for evaluation."""
@@ -67,6 +66,10 @@ class LegacyFaithfulnessEvaluator(
         Returns:
             NumericEvaluationResult with normalized score (0-100) and detailed justification
         """
+        # Lazily initialize the LLM on first evaluation call
+        if self.llm is None:
+            self._initialize_llm()
+
         # Extract agent output
         agent_output = str(evaluation_criteria.expected_output or "")
         if not agent_output or not agent_output.strip():

--- a/src/uipath/eval/evaluators/legacy_llm_as_judge_evaluator.py
+++ b/src/uipath/eval/evaluators/legacy_llm_as_judge_evaluator.py
@@ -43,9 +43,8 @@ class LegacyLlmAsAJudgeEvaluator(LegacyBaseEvaluator[LegacyLlmAsAJudgeEvaluatorC
         return v
 
     def model_post_init(self, __context: Any):
-        """Initialize the LLM service after model creation."""
+        """Initialize the evaluator after model creation."""
         super().model_post_init(__context)
-        self._initialize_llm()
 
     def _initialize_llm(self):
         """Initialize the LLM used for evaluation."""
@@ -73,6 +72,10 @@ class LegacyLlmAsAJudgeEvaluator(LegacyBaseEvaluator[LegacyLlmAsAJudgeEvaluatorC
         Returns:
             EvaluationResult: Numerical score with LLM justification as details
         """
+        # Lazily initialize the LLM on first evaluation call
+        if self.llm is None:
+            self._initialize_llm()
+
         # Create the evaluation prompt
         evaluation_prompt = self._create_evaluation_prompt(
             expected_output=evaluation_criteria.expected_output,

--- a/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
+++ b/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
@@ -49,9 +49,8 @@ class LegacyTrajectoryEvaluator(LegacyBaseEvaluator[LegacyTrajectoryEvaluatorCon
         return v
 
     def model_post_init(self, __context: Any):
-        """Initialize the LLM service after model creation."""
+        """Initialize the evaluator after model creation."""
         super().model_post_init(__context)
-        self._initialize_llm()
 
     def _initialize_llm(self):
         """Initialize the LLM used for evaluation."""
@@ -82,6 +81,10 @@ class LegacyTrajectoryEvaluator(LegacyBaseEvaluator[LegacyTrajectoryEvaluatorCon
         Raises:
             NotImplementedError: This evaluator is not yet implemented
         """
+        # Lazily initialize the LLM on first evaluation call
+        if self.llm is None:
+            self._initialize_llm()
+
         evaluation_prompt = self._create_evaluation_prompt(
             expected_agent_behavior=agent_execution.expected_agent_behavior,
             agent_run_history=agent_execution.agent_trace,
@@ -133,8 +136,7 @@ class LegacyTrajectoryEvaluator(LegacyBaseEvaluator[LegacyTrajectoryEvaluatorCon
         Returns:
             LLMResponse with score and justification
         """
-        if not self.llm:
-            raise ValueError("LLM service not initialized")
+        assert self.llm, "LLM should be initialized before calling this method."
 
         model = self.model
         if model.endswith(COMMUNITY_agents_SUFFIX):

--- a/tests/cli/evaluators/test_legacy_context_precision_evaluator.py
+++ b/tests/cli/evaluators/test_legacy_context_precision_evaluator.py
@@ -33,15 +33,23 @@ def _make_base_params() -> EvaluatorBaseParams:
     )
 
 
+@pytest.fixture(autouse=True)
+def mock_uipath_platform():
+    """Fixture to mock UiPath platform for all tests."""
+    with patch("uipath.platform.UiPath") as mock_uipath_class:
+        mock_uipath_instance = mock_uipath_class.return_value
+        mock_uipath_instance.llm = AsyncMock()
+        yield mock_uipath_class
+
+
 @pytest.fixture
 def evaluator_with_mocked_llm():
     """Fixture to create evaluator with mocked LLM service."""
-    with patch("uipath.platform.UiPath"):
-        evaluator = LegacyContextPrecisionEvaluator(
-            **_make_base_params().model_dump(),
-            config={},
-            model="gpt-4.1-2025-04-14",
-        )
+    evaluator = LegacyContextPrecisionEvaluator(
+        **_make_base_params().model_dump(),
+        config={},
+        model="gpt-4.1-2025-04-14",
+    )
     return evaluator
 
 

--- a/tests/cli/evaluators/test_legacy_faithfulness_evaluator.py
+++ b/tests/cli/evaluators/test_legacy_faithfulness_evaluator.py
@@ -34,15 +34,23 @@ def _make_base_params() -> EvaluatorBaseParams:
     )
 
 
+@pytest.fixture(autouse=True)
+def mock_uipath_platform():
+    """Fixture to mock UiPath platform for all tests."""
+    with patch("uipath.platform.UiPath") as mock_uipath_class:
+        mock_uipath_instance = mock_uipath_class.return_value
+        mock_uipath_instance.llm = AsyncMock()
+        yield mock_uipath_class
+
+
 @pytest.fixture
 def evaluator_with_mocked_llm():
     """Fixture to create evaluator with mocked LLM service."""
-    with patch("uipath.platform.UiPath"):
-        evaluator = LegacyFaithfulnessEvaluator(
-            **_make_base_params().model_dump(),
-            config={},
-            model="gpt-4.1-2025-04-14",
-        )
+    evaluator = LegacyFaithfulnessEvaluator(
+        **_make_base_params().model_dump(),
+        config={},
+        model="gpt-4.1-2025-04-14",
+    )
     return evaluator
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.18"
+version = "2.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Legacy evaluators that use LLMs currently initialize `UiPath` object during instantiation. This fails loading of evaluator in case `.env` is not found. Fixing it by performing lazy initialization.

Additionally, llm input-mocking also fails all evaluations in case .env is not found. This is a bad dev experience, so handling it gracefully.