### PR TITLE
fix: lazy load signalr and socketio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.17"
+version = "2.4.18"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_chat/_bridge.py
+++ b/src/uipath/_cli/_chat/_bridge.py
@@ -7,8 +7,6 @@ import uuid
 from typing import Any
 from urllib.parse import urlparse
 
-import socketio  # type: ignore[import-untyped]
-from socketio import AsyncClient
 from uipath.core.chat import (
     UiPathConversationEvent,
     UiPathConversationExchangeEndEvent,
@@ -54,7 +52,7 @@ class SocketIOChatBridge:
         self.exchange_id = exchange_id
         self.auth = auth
         self.headers = headers
-        self._client: AsyncClient | None = None
+        self._client: Any | None = None
         self._connected_event = asyncio.Event()
 
     async def connect(self, timeout: float = 10.0) -> None:
@@ -77,7 +75,10 @@ class SocketIOChatBridge:
             return
 
         # Create new SocketIO client
-        self._client = socketio.AsyncClient(
+        # Lazy import to avoid dependency if not used, improve startup time
+        from socketio import AsyncClient  # type: ignore[import-untyped]
+
+        self._client = AsyncClient(
             logger=logger,
             engineio_logger=logger,
         )

--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -8,9 +8,7 @@ from enum import Enum
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from pysignalr.client import SignalRClient
 from rich.console import Console
-from rich.syntax import Syntax
 from rich.tree import Tree
 from uipath.runtime import (
     UiPathBreakpointResult,
@@ -436,6 +434,7 @@ class ConsoleDebugBridge:
                 json_str = json.dumps(data, indent=2, default=str)
                 if len(json_str) > 10000:
                     json_str = json_str[:10000] + "\n..."
+                from rich.syntax import Syntax
 
                 syntax = Syntax(json_str, "json", theme="monokai", line_numbers=False)
                 self.console.print(f"\n[dim]{label}:")
@@ -465,7 +464,6 @@ class SignalRDebugBridge:
         self.access_token = access_token
         self.headers = headers or {}
         self.state = DebuggerState()
-        self._client: SignalRClient | None = None
         self._connected_event = asyncio.Event()
         self._resume_event: asyncio.Event | None = None
         self._terminate_event = asyncio.Event()
@@ -475,6 +473,9 @@ class SignalRDebugBridge:
         all_headers = {**self.headers}
         if self.access_token:
             all_headers["Authorization"] = f"Bearer {self.access_token}"
+
+        # Lazy import to avoid dependency if not used, improve startup time
+        from pysignalr.client import SignalRClient
 
         self._client = SignalRClient(self.hub_url, headers=all_headers)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.17"
+version = "2.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
# `uipath run main` hello-world performance

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Mean | 1.213s | 913ms | **-300ms (24.7%)** |
| User | 711ms | 506ms | -205ms (28.8%) |
| System | 244ms | 221ms | -23ms (9.4%) |
| Min | 1.154s | 860ms | -294ms |
| Max | 1.440s | 1.008s | -432ms |
| σ | 68ms | 38ms | -44% (more stable) |

**Result:** 1.3x faster, now under 1 second.