### PR TITLE
fix: filter dropped spans in upsert_span to match export behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.4.23"
+version = "2.4.24"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/tracing/_otel_exporters.py
+++ b/src/uipath/tracing/_otel_exporters.py
@@ -188,6 +188,9 @@ class LlmOpsHttpExporter(SpanExporter):
         Returns:
             SpanExportResult indicating success or failure
         """
+        if self._should_drop_span(span):
+            return SpanExportResult.SUCCESS
+
         span_data = _SpanUtils.otel_span_to_uipath_span(
             span, custom_trace_id=self.trace_id, serialize_attributes=False
         ).to_dict(serialize_attributes=False)

--- a/tests/tracing/test_otel_exporters.py
+++ b/tests/tracing/test_otel_exporters.py
@@ -737,6 +737,16 @@ class TestUpsertSpan:
             assert result == SpanExportResult.FAILURE
             assert exporter_with_mocks.http_client.post.call_count == 4  # max_retries=4
 
+    def test_upsert_span_filters_dropped_spans(self, exporter_with_mocks):
+        """upsert_span should skip spans marked with telemetry.filter=drop."""
+        span = MagicMock(spec=ReadableSpan)
+        span.attributes = {"telemetry.filter": "drop"}
+
+        result = exporter_with_mocks.upsert_span(span)
+
+        assert result == SpanExportResult.SUCCESS
+        exporter_with_mocks.http_client.post.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.4.23"
+version = "2.4.24"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Root Cause

OpenInference spans (LangGraph internal nodes like `init`, `agent`, `route_agent`) were appearing in LLMOps traces despite being marked with `telemetry.filter=drop`.

The `LlmOpsHttpExporter` had **two export paths**:
- `export()` - batch export, **had filtering** via `_should_drop_span()`
- `upsert_span()` - real-time upsert for live tracking, **missing filtering**

The agents package calls `upsert_span()` for live visibility, which bypassed the filtering.

## Fix

Added the same `_should_drop_span()` check to `upsert_span()`:

```python
def upsert_span(self, span, status_override=None):
    if self._should_drop_span(span):  # ← Added this
        return SpanExportResult.SUCCESS
    # ... rest of method
```

Now both paths consistently filter spans marked for dropping.

## Test plan
- [x] Unit test `test_upsert_span_filters_dropped_spans` passes
- [x] Run agent with OpenInference instrumentation and verify no LangGraph internal spans appear in LLMOps

🤖 Generated with [Claude Code](https://claude.com/claude-code)