### PR TITLE
feat: add support for the new guardrails result payload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "uipath"
-version = "2.5.0"
+version = "2.5.1"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-  "uipath-core>=0.1.4, <0.2.0",
+  "uipath-core>=0.1.6, <0.2.0",
   "uipath-runtime>=0.5.0, <0.6.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/src/uipath/platform/guardrails/__init__.py
+++ b/src/uipath/platform/guardrails/__init__.py
@@ -10,6 +10,7 @@ from uipath.core.guardrails import (
     DeterministicGuardrailsService,
     GuardrailScope,
     GuardrailValidationResult,
+    GuardrailValidationResultType,
 )
 
 from ._guardrails_service import GuardrailsService
@@ -17,7 +18,6 @@ from .guardrails import (
     BuiltInValidatorGuardrail,
     EnumListParameterValue,
     GuardrailType,
-    GuardrailValidationResultType,
     MapEnumParameterValue,
 )
 

--- a/src/uipath/platform/guardrails/_guardrails_service.py
+++ b/src/uipath/platform/guardrails/_guardrails_service.py
@@ -1,11 +1,14 @@
 from typing import Any
 
-from uipath.core.guardrails import GuardrailValidationResult
+from uipath.core.guardrails import (
+    GuardrailValidationResult,
+    GuardrailValidationResultType,
+)
 
 from ..._utils import Endpoint, RequestSpec
 from ...tracing import traced
 from ..common import BaseService, UiPathApiConfig, UiPathExecutionContext
-from .guardrails import BuiltInValidatorGuardrail, GuardrailValidationResultType
+from .guardrails import BuiltInValidatorGuardrail
 
 
 class GuardrailsService(BaseService):
@@ -63,23 +66,39 @@ class GuardrailsService(BaseService):
         )
         response_data = response.json()
 
-        # Map API response to populate result enum and details field
-        # Handle skip case for entitlements checks
-        skip = response_data.get("skip", False)
-        validation_passed = response_data.get("validation_passed", False)
-        reason = response_data.get("reason", "")
+        # Handle new API format: try to parse result field
+        result = None
+        result_str = response_data.get("result")
+        if result_str:
+            # Try to get enum by name first (e.g., "VALIDATION_FAILED")
+            try:
+                result = GuardrailValidationResultType[result_str]
+            except KeyError:
+                # If not found by name, try by value (e.g., "validation_failed")
+                try:
+                    result = GuardrailValidationResultType(result_str)
+                except ValueError:
+                    # Parsing failed, fall back to old format
+                    result = None
 
-        # Determine result enum value based on skip and validation_passed
-        if skip:
-            result = GuardrailValidationResultType.SKIPPED
-        elif validation_passed:
-            result = GuardrailValidationResultType.PASSED
-        else:
-            result = GuardrailValidationResultType.FAILED
+        # Old format: backwards compatibility - determine result from validation_passed
+        if result is None:
+            validation_passed = response_data.get("validation_passed", False)
+            result = (
+                GuardrailValidationResultType.PASSED
+                if validation_passed
+                else GuardrailValidationResultType.VALIDATION_FAILED
+            )
 
-        # Add result and details to response data
-        # Convert enum to string value for JSON serialization
-        response_data["result"] = result.value
-        response_data["details"] = reason
+        # Ensure result is always set (defensive check)
+        if result is None:
+            result = GuardrailValidationResultType.VALIDATION_FAILED
 
-        return GuardrailValidationResult.model_validate(response_data)
+        # Prepare model data with only the fields needed by GuardrailValidationResult
+        # (result and reason; ignore old fields like details, validation_passed, skip)
+        model_data = {
+            "result": result.value,
+            "reason": response_data.get("reason", ""),
+        }
+
+        return GuardrailValidationResult.model_validate(model_data)

--- a/src/uipath/platform/guardrails/guardrails.py
+++ b/src/uipath/platform/guardrails/guardrails.py
@@ -60,11 +60,3 @@ class GuardrailType(str, Enum):
 
     BUILT_IN_VALIDATOR = "builtInValidator"
     CUSTOM = "custom"
-
-
-class GuardrailValidationResultType(str, Enum):
-    """Guardrail validation result type enumeration."""
-
-    PASSED = "passed"
-    FAILED = "failed"
-    SKIPPED = "skipped"

--- a/tests/sdk/services/test_guardrails_service.py
+++ b/tests/sdk/services/test_guardrails_service.py
@@ -6,6 +6,7 @@ from pytest_httpx import HTTPXMock
 from uipath.core.guardrails import (
     GuardrailScope,
     GuardrailSelector,
+    GuardrailValidationResultType,
 )
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
@@ -47,9 +48,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "validation_passed": True,
+                    "result": "passed",
                     "reason": "Validation passed",
-                    "skip": False,
                 },
             )
 
@@ -82,13 +82,8 @@ class TestGuardrailsService:
 
             result = service.evaluate_guardrail(test_input, pii_guardrail)
 
-            assert result.validation_passed is True
+            assert result.result == GuardrailValidationResultType.PASSED
             assert result.reason == "Validation passed"
-            # If skip field exists, new API is deployed - check result and details
-            if hasattr(result, "skip"):
-                assert result.skip is False
-                assert result.result == "passed"
-                assert result.details == "Validation passed"
 
         def test_evaluate_guardrail_validation_failed(
             self,
@@ -103,9 +98,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "validation_passed": False,
+                    "result": "validation_failed",
                     "reason": "PII detected: Email found",
-                    "skip": False,
                 },
             )
 
@@ -126,13 +120,8 @@ class TestGuardrailsService:
 
             result = service.evaluate_guardrail(test_input, pii_guardrail)
 
-            assert result.validation_passed is False
+            assert result.result == GuardrailValidationResultType.VALIDATION_FAILED
             assert result.reason == "PII detected: Email found"
-            # If skip field exists, new API is deployed - check result and details
-            if hasattr(result, "skip"):
-                assert result.skip is False
-                assert result.result == "failed"
-                assert result.details == "PII detected: Email found"
 
         def test_evaluate_guardrail_entitlements_skip(
             self,
@@ -147,9 +136,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "validation_passed": True,
+                    "result": "feature_disabled",
                     "reason": "Guardrail feature is disabled",
-                    "skip": True,
                 },
             )
 
@@ -170,13 +158,8 @@ class TestGuardrailsService:
 
             result = service.evaluate_guardrail(test_input, pii_guardrail)
 
-            assert result.validation_passed is True
+            assert result.result == GuardrailValidationResultType.FEATURE_DISABLED
             assert result.reason == "Guardrail feature is disabled"
-            # If skip field exists, new API is deployed - check result and details
-            if hasattr(result, "skip"):
-                assert result.skip is True
-                assert result.result == "skipped"
-                assert result.details == "Guardrail feature is disabled"
 
         def test_evaluate_guardrail_entitlements_missing(
             self,
@@ -191,9 +174,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "validation_passed": True,
+                    "result": "entitlements_missing",
                     "reason": "Guardrail entitlement is missing",
-                    "skip": True,
                 },
             )
 
@@ -214,13 +196,8 @@ class TestGuardrailsService:
 
             result = service.evaluate_guardrail(test_input, pii_guardrail)
 
-            assert result.validation_passed is True
+            assert result.result == GuardrailValidationResultType.ENTITLEMENTS_MISSING
             assert result.reason == "Guardrail entitlement is missing"
-            # If skip field exists, new API is deployed - check result and details
-            if hasattr(result, "skip"):
-                assert result.skip is True
-                assert result.result == "skipped"
-                assert result.details == "Guardrail entitlement is missing"
 
         def test_evaluate_guardrail_request_payload_structure(
             self,
@@ -239,9 +216,8 @@ class TestGuardrailsService:
                 return httpx.Response(
                     status_code=200,
                     json={
-                        "validation_passed": True,
+                        "result": "passed",
                         "reason": "Validation passed",
-                        "skip": False,
                     },
                 )
 
@@ -320,9 +296,5 @@ class TestGuardrailsService:
             assert thresholds_param["value"] == {"Email": 1, "Address": 0.7}
 
             # Verify result fields
-            assert result.validation_passed is True
-            # If skip field exists, new API is deployed - check result and details
-            if hasattr(result, "skip"):
-                assert result.skip is False
-                assert result.result == "passed"
-                assert result.details == "Validation passed"
+            assert result.result == GuardrailValidationResultType.PASSED
+            assert result.reason == "Validation passed"

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2554,7 +2554,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
-    { name = "uipath-core", specifier = ">=0.1.4,<0.2.0" },
+    { name = "uipath-core", specifier = ">=0.1.6,<0.2.0" },
     { name = "uipath-runtime", specifier = ">=0.5,<0.6.0" },
 ]
 
@@ -2589,16 +2589,16 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.1.4"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/ef/44b9b0adb378e0e988b621b72af55008dbfb166179412cba1fe54ab4b692/uipath_core-0.1.4.tar.gz", hash = "sha256:6100eb5299b30b145e557e3dbc716141bbaa92cd37633d36257c7e3f90ce578f", size = 96025, upload-time = "2025-12-16T14:25:01.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/da/842e9cbc70ce396fa8369803174d6ce58f9c85d1c9b57e1b96440d86ed77/uipath_core-0.1.6.tar.gz", hash = "sha256:0d1e2f305326d58e655c236bdd2755b6855cbeed2a8acf61e30bab3d056c83dd", size = 97409, upload-time = "2026-01-15T08:10:07.806Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/c3/e64ea37ba8aa56cfae4a15589652a9dc4f66889e4d19788ca5e1b034b46f/uipath_core-0.1.4-py3-none-any.whl", hash = "sha256:574d6fe0314f70c12de8b6a3c5ab05a6191f6a8b9087c1d1a6352e67765f2f72", size = 30431, upload-time = "2025-12-16T14:25:00.174Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/611e5443d0bb4b570768db60c80df8a9fba197205a646ca2c0b67b3f236d/uipath_core-0.1.6-py3-none-any.whl", hash = "sha256:fb514a9b15d57ea9464e62c04f83e86e1b21cb0865012ecca947d2a458805a4a", size = 31238, upload-time = "2026-01-15T08:10:06.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Simplify Guardrails Service Response Handling

## Summary
Simplified the `GuardrailsService.evaluate_guardrail()` method to prioritize the new API response format while maintaining backwards compatibility with the legacy format.

## Changes

### Implementation
- **Simplified response parsing logic**: The service now checks for the new `result` field first, then falls back to the legacy `validation_passed` field for backwards compatibility
- **Removed complex skip field handling**: The simplified implementation no longer processes the `skip` field from legacy responses, as the new API format uses the `result` field directly

## Benefits
- **Cleaner code**: Reduced complexity in response parsing logic
- **Better maintainability**: Clearer separation between new and legacy API formats
- **Future-ready**: Aligned with the new API response format while supporting legacy clients
