### PR TITLE
fix: correctly create multipart requests for is activities

### DIFF
--- a/src/uipath/_utils/_request_spec.py
+++ b/src/uipath/_utils/_request_spec.py
@@ -20,4 +20,5 @@ class RequestSpec:
     content: Optional[Any] = None
     json: Optional[Any] = None
     data: Optional[Any] = None
+    files: Optional[dict[str, Any]] = None
     timeout: Optional[Union[int, float]] = None

--- a/src/uipath/platform/connections/_connections_service.py
+++ b/src/uipath/platform/connections/_connections_service.py
@@ -661,7 +661,7 @@ class ConnectionsService(BaseService):
             ValueError: If required parameters are missing or invalid
             RuntimeError: If the HTTP request fails or returns an error status
         """
-        spec, files = self._build_activity_request_spec(
+        spec = self._build_activity_request_spec(
             activity_metadata, connection_id, activity_input
         )
 
@@ -671,7 +671,7 @@ class ConnectionsService(BaseService):
             headers=spec.headers,
             params=spec.params,
             json=spec.json,
-            files=files,
+            files=spec.files,
         )
 
         return response.json()
@@ -700,7 +700,7 @@ class ConnectionsService(BaseService):
             ValueError: If required parameters are missing or invalid
             RuntimeError: If the HTTP request fails or returns an error status
         """
-        spec, files = self._build_activity_request_spec(
+        spec = self._build_activity_request_spec(
             activity_metadata, connection_id, activity_input
         )
 
@@ -710,7 +710,7 @@ class ConnectionsService(BaseService):
             headers=spec.headers,
             params=spec.params,
             json=spec.json,
-            files=files,
+            files=spec.files,
         )
 
         return response.json()
@@ -720,7 +720,7 @@ class ConnectionsService(BaseService):
         activity_metadata: ActivityMetadata,
         connection_id: str,
         activity_input: Dict[str, Any],
-    ) -> tuple[RequestSpec, dict[str, Any] | None]:
+    ) -> RequestSpec:
         """Build the request specification for invoking an activity."""
         url = f"/elements_/v3/element/instances/{connection_id}{activity_metadata.object_path}"
 
@@ -767,7 +767,7 @@ class ConnectionsService(BaseService):
         }
 
         # body and files handling
-        json_data = None
+        json_data: Dict[str, Any] | None = None
         files: Dict[str, Any] | None = None
 
         # multipart/form-data for file uploads
@@ -786,9 +786,8 @@ class ConnectionsService(BaseService):
                     None,
                 )  # probably needs to extract content type from val since IS metadata doesn't provide it
 
-            # body fields need to get added as a separate part
             files["body"] = (
-                "body",
+                "",
                 json.dumps(body_fields),
                 "application/json",
             )
@@ -801,13 +800,11 @@ class ConnectionsService(BaseService):
                 f"Unsupported content type: {activity_metadata.content_type}"
             )
 
-        return (
-            RequestSpec(
-                method=activity_metadata.method_name,
-                endpoint=Endpoint(url),
-                headers=headers,
-                params=query_params,
-                json=json_data,
-            ),
-            files,
+        return RequestSpec(
+            method=activity_metadata.method_name,
+            endpoint=Endpoint(url),
+            headers=headers,
+            params=query_params,
+            json=json_data,
+            files=files,
         )


### PR DESCRIPTION
- IS activities with `multipart/form-data` content type expect the "body" to be added as a part.
- With httpx, we were doing this by adding the body to the "files" array, because that is the only way to coerce httpx to construct multipart. This was causing httpx to also add `filename: body` to `Content-Disposition`, which caused some providers to interpret it as a file. (MS API did not work, Google API worked).
### Wrong request body:
```
--boundary
Content-Disposition: form-data; name="body"; filename="body"
Content-Type: application/json

...body...

--boundary--
```

### Correct request body (no filename):
```
--boundary
Content-Disposition: form-data; name="body";
Content-Type: application/json

...body...

--boundary--
```

- the fix is to pass an empty string as the first tuple param, which will omit the `filename` field and produce the correct body