### PR TITLE
feat: support just latest version of guardrails validate api response

### DIFF
--- a/tests/sdk/services/test_guardrails_service.py
+++ b/tests/sdk/services/test_guardrails_service.py
@@ -48,8 +48,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "result": "passed",
-                    "reason": "Validation passed",
+                    "result": "PASSED",
+                    "details": "Validation passed",
                 },
             )
 
@@ -98,8 +98,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "result": "validation_failed",
-                    "reason": "PII detected: Email found",
+                    "result": "VALIDATION_FAILED",
+                    "details": "PII detected: Email found",
                 },
             )
 
@@ -136,8 +136,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "result": "feature_disabled",
-                    "reason": "Guardrail feature is disabled",
+                    "result": "FEATURE_DISABLED",
+                    "details": "Guardrail feature is disabled",
                 },
             )
 
@@ -174,8 +174,8 @@ class TestGuardrailsService:
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
                 status_code=200,
                 json={
-                    "result": "entitlements_missing",
-                    "reason": "Guardrail entitlement is missing",
+                    "result": "ENTITLEMENTS_MISSING",
+                    "details": "Guardrail entitlement is missing",
                 },
             )
 
@@ -216,8 +216,8 @@ class TestGuardrailsService:
                 return httpx.Response(
                     status_code=200,
                     json={
-                        "result": "passed",
-                        "reason": "Validation passed",
+                        "result": "PASSED",
+                        "details": "Validation passed",
                     },
                 )
 


### PR DESCRIPTION
# Support Latest Version of Guardrails Validate API Response

## Summary
Updated `GuardrailsService.evaluate_guardrail()` to only support the latest API response format, removing backwards compatibility with legacy formats.

## Changes
- **Simplified response parsing**: Now only processes the `result` field from the latest API response format
- **Removed legacy format support**: No longer handles the legacy `validation_passed` field or `skip` field from older API versions

## Benefits
- **Cleaner implementation**: Reduced code complexity by removing backwards compatibility logic
- **Aligned with latest API**: Ensures the service matches the current guardrails validate API specification
