### PR TITLE
feat: export evaluator spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.4"
+version = "2.5.5"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -422,8 +422,8 @@ class StudioWebProgressReporter:
         try:
             eval_run_id = self.eval_run_ids.get(payload.execution_id)
 
-            # Use evalRunId as the trace_id for agent execution spans
-            # This makes all agent spans children of the eval run trace
+            # Use evalRunId as the trace_id for agent execution and evaluator spans
+            # This makes all spans children of the eval run trace
             if eval_run_id:
                 self.spans_exporter.trace_id = eval_run_id
             else:
@@ -433,7 +433,13 @@ class StudioWebProgressReporter:
                         self.eval_set_execution_id
                     )
 
+            # Export agent execution spans
             self.spans_exporter.export(payload.spans)
+
+            # Export evaluator spans (including LLM calls made by evaluators)
+            # with the same trace_id so they can be fetched together
+            if payload.evaluator_spans:
+                self.spans_exporter.export(payload.evaluator_spans)
 
             for eval_result in payload.eval_results:
                 evaluator_id = eval_result.evaluator_id

--- a/src/uipath/_events/_events.py
+++ b/src/uipath/_events/_events.py
@@ -49,6 +49,7 @@ class EvalRunUpdatedEvent(BaseModel):
     agent_output: Any
     agent_execution_time: float
     spans: list[ReadableSpan]
+    evaluator_spans: list[ReadableSpan] = []
     logs: list[logging.LogRecord]
     exception_details: EvalItemExceptionDetails | None = None
 

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.4"
+version = "2.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Export evaluator LLM call spans with the same trace_id as agent execution spans. This allows both agent and evaluator spans to be fetched together using a single ID.

Changes:
- Add evaluator_spans field to EvalRunUpdatedEvent
- Collect evaluator spans after all evaluators run in _execute_eval
- Export evaluator spans with the correct trace_id in handle_update_eval_run

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.5.4.dev1011303908",

  # Any version from PR
  "uipath>=2.5.4.dev1011300000,<2.5.4.dev1011310000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.5.4.dev1011300000,<2.5.4.dev1011310000",
]
```
<!-- DEV_PACKAGE_END -->

### BEFORE
<img width="309" height="488" alt="Screenshot 2026-01-15 at 4 26 26 PM" src="https://github.com/user-attachments/assets/6d9d7352-0122-4641-b4bd-093bfa544093" />

### After
<img width="501" height="514" alt="Screenshot 2026-01-15 at 4 25 21 PM" src="https://github.com/user-attachments/assets/9ea37dd2-9559-4b75-9283-a203487c88a4" />
