### PR TITLE
fix: filter spans with run_type=uipath from LLM Ops export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.4"
+version = "2.5.5"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/tracing/_otel_exporters.py
+++ b/src/uipath/tracing/_otel_exporters.py
@@ -406,10 +406,12 @@ class LlmOpsHttpExporter(SpanExporter):
     def _should_drop_span(self, span: ReadableSpan) -> bool:
         """Check if span is marked for dropping.
 
-        Spans with telemetry.filter="drop" are skipped by this exporter.
+        Spans with telemetry.filter="drop" or run_type="uipath" are skipped.
         """
         attrs = span.attributes or {}
-        return attrs.get("telemetry.filter") == "drop"
+        return (
+            attrs.get("run_type") == "uipath" or attrs.get("telemetry.filter") == "drop"
+        )
 
 
 class JsonLinesFileExporter(SpanExporter):

--- a/tests/tracing/test_otel_exporters.py
+++ b/tests/tracing/test_otel_exporters.py
@@ -613,6 +613,18 @@ class TestSpanFiltering:
         span.attributes = {"telemetry.filter": "keep"}
         assert exporter_with_mocks._should_drop_span(span) is False
 
+    def test_filters_spans_with_uipath_run_type(self, exporter_with_mocks):
+        """Span with run_type=uipath → filtered out."""
+        span = MagicMock(spec=ReadableSpan)
+        span.attributes = {"run_type": "uipath"}
+        assert exporter_with_mocks._should_drop_span(span) is True
+
+    def test_passes_spans_with_other_run_types(self, exporter_with_mocks):
+        """Span with other run_type values → passes through."""
+        span = MagicMock(spec=ReadableSpan)
+        span.attributes = {"run_type": "agent"}
+        assert exporter_with_mocks._should_drop_span(span) is False
+
     def test_export_filters_marked_spans(self, exporter_with_mocks):
         """export() should filter out spans marked for drop."""
         # Create mixed batch: 1 marked for drop, 1 unmarked

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.4"
+version = "2.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Filter internal UiPath SDK spans (`run_type="uipath"`) from LLM Ops export
- Add `run_type` check to `_should_drop_span()` in `LlmOpsHttpExporter`
- Add tests for new filtering condition

## Why move from uipath-agents-python?
The `run_type="uipath"` filtering was previously in [uipath-agents-python span_processor.py#L29](https://github.com/UiPath/uipath-agents-python/blob/main/src/uipath_agents/_observability/span_processor.py#L29), but this approach has timing issues:
- At span start: `run_type` attribute is not yet set, so we can't filter
- At span end: spans are immutable, so we can't add `telemetry.filter="drop"`

Moving the filter to the exporter level in uipath-python:
- Filters spans at export time when all attributes are available
- Centralizes all span filtering logic in one place (`_should_drop_span`)
- Ensures filtering works regardless of which SDK creates the spans

## Test plan
- [x] Verify spans with `run_type="uipath"` are not exported to LLM Ops
- [x] Verify spans with other `run_type` values pass through
- [x] Verify existing `telemetry.filter="drop"` filtering still works
- [x] Run unit tests: `pytest tests/tracing/test_otel_exporters.py -k TestSpanFiltering`

🤖 Generated with [Claude Code](https://claude.ai/code)