### PR TITLE
fix: parse correctly 403 from guardrails validate API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.4"
+version = "2.5.5"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/tests/sdk/services/test_guardrails_service.py
+++ b/tests/sdk/services/test_guardrails_service.py
@@ -123,7 +123,7 @@ class TestGuardrailsService:
             assert result.result == GuardrailValidationResultType.VALIDATION_FAILED
             assert result.reason == "PII detected: Email found"
 
-        def test_evaluate_guardrail_entitlements_skip(
+        def test_evaluate_guardrail_feature_disabled_403(
             self,
             httpx_mock: HTTPXMock,
             service: GuardrailsService,
@@ -131,10 +131,10 @@ class TestGuardrailsService:
             org: str,
             tenant: str,
         ) -> None:
-            # Mock API response for entitlements check - feature disabled
+            # Mock API response with 403 status for FEATURE_DISABLED
             httpx_mock.add_response(
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
-                status_code=200,
+                status_code=403,
                 json={
                     "result": "FEATURE_DISABLED",
                     "details": "Guardrail feature is disabled",
@@ -161,7 +161,7 @@ class TestGuardrailsService:
             assert result.result == GuardrailValidationResultType.FEATURE_DISABLED
             assert result.reason == "Guardrail feature is disabled"
 
-        def test_evaluate_guardrail_entitlements_missing(
+        def test_evaluate_guardrail_entitlements_missing_403(
             self,
             httpx_mock: HTTPXMock,
             service: GuardrailsService,
@@ -169,10 +169,10 @@ class TestGuardrailsService:
             org: str,
             tenant: str,
         ) -> None:
-            # Mock API response for entitlements check - entitlement missing
+            # Mock API response with 403 status for ENTITLEMENTS_MISSING
             httpx_mock.add_response(
                 url=f"{base_url}{org}{tenant}/agentsruntime_/api/execution/guardrails/validate",
-                status_code=200,
+                status_code=403,
                 json={
                     "result": "ENTITLEMENTS_MISSING",
                     "details": "Guardrail entitlement is missing",

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.4"
+version = "2.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
# Parse 403 Responses from Guardrails Validate API

## Summary
Updated `GuardrailsService.evaluate_guardrail()` to correctly handle HTTP 403 responses that contain valid JSON guardrail validation results. Previously, these responses were treated as generic HTTP errors, obscuring the specific guardrail validation details.

## Problem
The guardrails validate API returns HTTP 403 status codes for certain validation results (`ENTITLEMENTS_MISSING` and `FEATURE_DISABLED`), but includes a valid JSON body with the actual guardrail validation details:

```json
{
  "result": "ENTITLEMENTS_MISSING",
  "details": "Guardrail entitlement is missing"
}
```

The previous implementation would raise a generic `EnrichedException` for 403 responses, preventing the agent from accessing the specific guardrail error reason and causing misleading error messages.

## Solution
Added special handling for HTTP 403 responses in `evaluate_guardrail()`:

1. **Catch `EnrichedException`**: Intercept exceptions raised by `self.request()` for 403 status codes
2. **Extract JSON body**: Parse the JSON response from the underlying `HTTPStatusError` or `response_content`
3. **Process normally**: Continue with the standard validation result parsing flow

This ensures that `ENTITLEMENTS_MISSING` and `FEATURE_DISABLED` results are properly extracted and returned as `GuardrailValidationResult` objects, allowing the agent to handle them appropriately.