### PR TITLE
fix(TelemetryFilter): do not send filtered spans for mocking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.7"
+version = "2.5.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/tracing/_utils.py
+++ b/src/uipath/tracing/_utils.py
@@ -380,8 +380,9 @@ class _SpanUtils:
 
             input_value = attributes.get("input.value")
             output_value = attributes.get("output.value")
+            telemetry_filter = attributes.get("telemetry.filter")
 
-            if not input_value or not output_value:
+            if not input_value or not output_value or telemetry_filter == "drop":
                 continue
 
             history.append(f"Function: {span.name}")

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.7"
+version = "2.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Dropped telemetry spans should not be used for mocking.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.5.8.dev1011413970",

  # Any version from PR
  "uipath>=2.5.8.dev1011410000,<2.5.8.dev1011420000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.5.8.dev1011410000,<2.5.8.dev1011420000",
]
```
<!-- DEV_PACKAGE_END -->