### PR TITLE
fix: endExchange not being sent

### DIFF
--- a/src/uipath/_cli/_chat/_bridge.py
+++ b/src/uipath/_cli/_chat/_bridge.py
@@ -141,7 +141,10 @@ class SocketIOChatBridge:
             return
 
         try:
+            # Request disconnect then wait for it to happen, this allows pending sends to complete. Without the wait,
+            # sending the endExchange event was racing with process termination, and losing much of the time.
             await self._client.disconnect()
+            await self._client.wait()
         except Exception as e:
             logger.error(f"Error during WebSocket disconnect: {e}")
         finally:


### PR DESCRIPTION
socket.io send and disconnect are both background operations even when you await on the api calls. This allows the final "endExchange" event to go unsent if the process exits too quickly when the agent terminates. The fix is to wait for the disconnect to complete.