### PR TITLE
feat: add list assets to service and cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.10"
+version = "2.5.11"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -33,6 +33,7 @@ _LAZY_COMMANDS = {
     "add": "cli_add",
     "register": "cli_register",
     "debug": "cli_debug",
+    "assets": "services.cli_assets",
     "buckets": "services.cli_buckets",
 }
 

--- a/src/uipath/_cli/_utils/_formatters.py
+++ b/src/uipath/_cli/_utils/_formatters.py
@@ -54,9 +54,18 @@ def format_output(
             )
 
     if hasattr(data, "model_dump"):
-        data = data.model_dump()
+        model_fields = getattr(data, "model_fields", None)
+        if isinstance(model_fields, dict):
+            data = data.model_dump(include=set(model_fields.keys()))
+        else:
+            data = data.model_dump()
     elif isinstance(data, list) and len(data) > 0 and hasattr(data[0], "model_dump"):
-        data = [item.model_dump() for item in data]
+        model_fields = getattr(data[0], "model_fields", None)
+        if isinstance(model_fields, dict):
+            fields = set(model_fields.keys())
+            data = [item.model_dump(include=fields) for item in data]
+        else:
+            data = [item.model_dump() for item in data]
 
     if hasattr(data, "__aiter__"):
         raise TypeError(

--- a/src/uipath/_cli/services/__init__.py
+++ b/src/uipath/_cli/services/__init__.py
@@ -7,9 +7,10 @@ All services are explicitly imported to ensure:
 - Debuggable registration
 """
 
+from .cli_assets import assets
 from .cli_buckets import buckets
 
-__all__ = ["buckets", "register_service_commands"]
+__all__ = ["assets", "buckets", "register_service_commands"]
 
 
 def register_service_commands(cli_group):
@@ -30,7 +31,7 @@ def register_service_commands(cli_group):
     Industry Precedent:
         AWS CLI, Azure CLI, and gcloud all use explicit registration.
     """
-    services = [buckets]
+    services = [assets, buckets]
 
     for service in services:
         cli_group.add_command(service)

--- a/src/uipath/_cli/services/cli_assets.py
+++ b/src/uipath/_cli/services/cli_assets.py
@@ -1,0 +1,87 @@
+"""Assets service commands for UiPath CLI.
+
+Assets are key-value pairs stored in Orchestrator that can be used to store
+configuration data, credentials, and other settings used by automation processes.
+"""
+
+import click
+
+from .._utils._service_base import (
+    ServiceCommandBase,
+    common_service_options,
+    service_command,
+)
+
+
+@click.group()
+def assets():
+    r"""Manage UiPath assets.
+
+    Assets are key-value pairs that store configuration data, credentials,
+    and settings used by automation processes.
+
+    \b
+    Examples:
+        # List all assets in a folder
+        uipath assets list --folder-path "Shared"
+
+        # List with filter
+        uipath assets list --filter "ValueType eq 'Text'"
+
+        # List with ordering
+        uipath assets list --orderby "Name asc"
+    """
+    pass
+
+
+@assets.command(name="list")
+@click.option("--filter", "filter_", help="OData $filter expression")
+@click.option("--orderby", help="OData $orderby expression")
+@click.option(
+    "--top",
+    type=click.IntRange(min=1, max=1000),
+    default=100,
+    help="Maximum number of items to return (default: 100, max: 1000)",
+)
+@click.option(
+    "--skip",
+    type=click.IntRange(min=0),
+    default=0,
+    help="Number of items to skip",
+)
+@common_service_options
+@service_command
+def list_assets(
+    ctx,
+    filter_,
+    orderby,
+    top,
+    skip,
+    folder_path,
+    folder_key,
+    format,
+    output,
+):
+    r"""List assets in a folder.
+
+    \b
+    Examples:
+        uipath assets list
+        uipath assets list --folder-path "Shared"
+        uipath assets list --filter "ValueType eq 'Text'"
+        uipath assets list --filter "Name eq 'MyAsset'"
+        uipath assets list --orderby "Name asc"
+        uipath assets list --top 50 --skip 100
+    """
+    client = ServiceCommandBase.get_client(ctx)
+
+    result = client.assets.list(
+        folder_path=folder_path,
+        folder_key=folder_key,
+        filter=filter_,
+        orderby=orderby,
+        top=top,
+        skip=skip,
+    )
+
+    return list(result.items)

--- a/tests/cli/integration/test_assets_commands.py
+++ b/tests/cli/integration/test_assets_commands.py
@@ -1,0 +1,164 @@
+"""Integration tests for assets CLI commands.
+
+These tests verify end-to-end functionality of the assets service commands,
+including proper context handling, error messages, and output formatting.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from uipath._cli import cli
+from uipath.platform.common.paging import PagedResult
+
+
+@pytest.fixture
+def runner():
+    """Provide a Click CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_client():
+    """Provide a mocked UiPath client."""
+    with patch("uipath.platform._uipath.UiPath") as mock:
+        client_instance = MagicMock()
+        mock.return_value = client_instance
+
+        # Mock assets service
+        client_instance.assets = MagicMock()
+
+        yield client_instance
+
+
+def test_assets_list_command_basic(runner, mock_client, mock_env_vars):
+    """Test basic assets list command."""
+    mock_assets = [
+        MagicMock(
+            name="asset1",
+            value="value1",
+            value_type="Text",
+            model_dump=lambda: {
+                "name": "asset1",
+                "value": "value1",
+                "valueType": "Text",
+            },
+        ),
+        MagicMock(
+            name="asset2",
+            value="value2",
+            value_type="Text",
+            model_dump=lambda: {
+                "name": "asset2",
+                "value": "value2",
+                "valueType": "Text",
+            },
+        ),
+    ]
+    mock_client.assets.list.return_value = PagedResult(
+        items=mock_assets,
+        has_more=False,
+        skip=0,
+        top=100,
+    )
+
+    result = runner.invoke(cli, ["assets", "list"])
+
+    assert result.exit_code == 0
+    assert "asset1" in result.output
+    assert "asset2" in result.output
+
+
+def test_assets_list_with_json_format(runner, mock_client, mock_env_vars):
+    """Test assets list with JSON output format."""
+    mock_assets = [
+        MagicMock(model_dump=lambda: {"name": "test-asset", "value": "test-value"}),
+    ]
+    mock_client.assets.list.return_value = PagedResult(
+        items=mock_assets,
+        has_more=False,
+        skip=0,
+        top=100,
+    )
+
+    result = runner.invoke(cli, ["assets", "list", "--format", "json"])
+
+    assert result.exit_code == 0
+    assert "test-asset" in result.output
+
+
+def test_assets_list_with_filter(runner, mock_client, mock_env_vars):
+    """Test assets list with OData filter."""
+    mock_assets = [
+        MagicMock(model_dump=lambda: {"name": "text-asset", "valueType": "Text"}),
+    ]
+    mock_client.assets.list.return_value = PagedResult(
+        items=mock_assets,
+        has_more=False,
+        skip=0,
+        top=100,
+    )
+
+    result = runner.invoke(cli, ["assets", "list", "--filter", "ValueType eq 'Text'"])
+
+    assert result.exit_code == 0
+    mock_client.assets.list.assert_called_once()
+    call_kwargs = mock_client.assets.list.call_args.kwargs
+    assert call_kwargs["filter"] == "ValueType eq 'Text'"
+
+
+def test_assets_list_with_orderby(runner, mock_client, mock_env_vars):
+    """Test assets list with OData orderby."""
+    mock_assets: list[MagicMock] = []
+    mock_client.assets.list.return_value = PagedResult(
+        items=mock_assets,
+        has_more=False,
+        skip=0,
+        top=100,
+    )
+
+    result = runner.invoke(cli, ["assets", "list", "--orderby", "Name asc"])
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.assets.list.call_args.kwargs
+    assert call_kwargs["orderby"] == "Name asc"
+
+
+def test_assets_list_with_folder_path(runner, mock_client, mock_env_vars):
+    """Test assets list with folder path option."""
+    mock_assets: list[MagicMock] = []
+    mock_client.assets.list.return_value = PagedResult(
+        items=mock_assets,
+        has_more=False,
+        skip=0,
+        top=100,
+    )
+
+    result = runner.invoke(cli, ["assets", "list", "--folder-path", "Shared"])
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.assets.list.call_args.kwargs
+    assert call_kwargs["folder_path"] == "Shared"
+
+
+def test_assets_help_text(runner):
+    """Test that assets command has proper help text."""
+    result = runner.invoke(cli, ["assets", "--help"])
+
+    assert result.exit_code == 0
+    assert "Manage UiPath assets" in result.output
+    assert "list" in result.output
+
+
+def test_assets_list_help_text(runner):
+    """Test that assets list command has proper help text."""
+    result = runner.invoke(cli, ["assets", "list", "--help"])
+
+    assert result.exit_code == 0
+    assert "List assets" in result.output
+    assert "--folder-path" in result.output
+    assert "--filter" in result.output
+    assert "--orderby" in result.output
+    assert "--top" in result.output
+    assert "--skip" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.10"
+version = "2.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
This PR introduces the methods `list()` and `list_async()` to `AssetsService` and the CLI command `uipath assets`.

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.5.11.dev1011504015",

  # Any version from PR
  "uipath>=2.5.11.dev1011500000,<2.5.11.dev1011510000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.5.11.dev1011500000,<2.5.11.dev1011510000",
]
```
<!-- DEV_PACKAGE_END -->