### PR TITLE
feat: add discovery call to the llm gateway service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.11"
+version = "2.5.12"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/platform/chat/__init__.py
+++ b/src/uipath/platform/chat/__init__.py
@@ -9,6 +9,7 @@ from ._conversations_service import ConversationsService
 from ._llm_gateway_service import (
     ChatModels,
     EmbeddingModels,
+    LlmDiscoveryService,
     UiPathLlmChatService,
     UiPathOpenAIService,
 )
@@ -38,6 +39,7 @@ __all__ = [
     # LLM Gateway Services
     "ChatModels",
     "EmbeddingModels",
+    "LlmDiscoveryService",
     "UiPathLlmChatService",
     "UiPathOpenAIService",
     # LLM Throttling

--- a/src/uipath/platform/chat/_llm_gateway_service.py
+++ b/src/uipath/platform/chat/_llm_gateway_service.py
@@ -4,6 +4,7 @@ This module provides services for interacting with UiPath's LLM (Large Language 
 offering both OpenAI-compatible and normalized API interfaces for chat completions and embeddings.
 
 The module includes:
+- LlmDiscoveryService: Service for discovering available LLM models
 - UiPathOpenAIService: OpenAI-compatible API for chat completions and embeddings
 - UiPathLlmChatService: UiPath's normalized API with advanced features like tool calling
 - ChatModels: Constants for available chat models
@@ -12,6 +13,7 @@ The module includes:
 Classes:
     ChatModels: Container for supported chat model identifiers
     EmbeddingModels: Container for supported embedding model identifiers
+    LlmDiscoveryService: Service for discovering available LLM models
     UiPathOpenAIService: Service using OpenAI-compatible API format
     UiPathLlmChatService: Service using UiPath's normalized API format
 """
@@ -45,6 +47,32 @@ DEFAULT_LLM_HEADERS = {
     "X-UiPath-LlmGateway-RequestingProduct": "uipath-python-sdk",
     "X-UiPath-LlmGateway-RequestingFeature": "langgraph-agent",
 }
+
+
+class LlmDiscoveryService(BaseService):
+    """Service for discovering available LLM models from the LLM Gateway."""
+
+    def __init__(
+        self, config: UiPathApiConfig, execution_context: UiPathExecutionContext
+    ) -> None:
+        """Initialize the LLM discovery service."""
+        super().__init__(config=config, execution_context=execution_context)
+
+    def get_available_models(self, agenthub_config: str) -> list[dict[str, Any]]:
+        """Fetch available models from LLM Gateway discovery endpoint.
+
+        Args:
+            agenthub_config: The AgentHub configuration identifier
+
+        Returns:
+            List of available models and their configurations.
+        """
+        response = self.request(
+            "GET",
+            url=Endpoint("/agenthub_/llm/api/discovery"),
+            headers={"X-UiPath-AgentHub-Config": agenthub_config},
+        )
+        return response.json()
 
 
 class ChatModels(object):

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.11"
+version = "2.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Summary

- Add fetch_llm_discovery function to the LLM Gateway service for fetching available models from the discovery endpoint

Changes

- Added fetch_llm_discovery(agenthub_config: str) function to _llm_gateway_service.py
- Exported the function from uipath.platform.chat module