### PR TITLE
fix: cleaner error message for init command

### DIFF
--- a/src/uipath/_cli/_utils/_console.py
+++ b/src/uipath/_cli/_utils/_console.py
@@ -108,13 +108,18 @@ class ConsoleLogger:
             message: The error message to display
             include_traceback: Whether to include the current exception traceback
         """
-        self.log(message, LogLevel.ERROR, "red")
-
         if include_traceback:
+            import sys
             import traceback
 
-            click.echo(traceback.format_exc(), err=True)
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            if exc_value is not None:
+                tb = "".join(
+                    traceback.format_exception(exc_type, exc_value, exc_tb, chain=False)
+                )
+                message = f"{message}\n{tb}"
 
+        self.log(message, LogLevel.ERROR, "red")
         click.get_current_context().exit(1)
 
     def warning(self, message: str) -> None:

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -323,9 +323,7 @@ def init(no_agents_md_override: bool) -> None:
                     )
 
             except Exception as e:
-                console.error(
-                    f"Error during initialization:\n{str(e)}", include_traceback=True
-                )
+                console.error(f"Error during initialization:\n{e}")
 
         asyncio.run(initialize())
 


### PR DESCRIPTION
## Description

- Cleaner error message for `uipath init`
- Fix console error formatting
- Console error shows latest traceback (chain=false)