### PR TITLE
fix: enable resume for local testing and preserve eval state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.17"
+version = "2.5.18"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -976,7 +976,7 @@ class UiPathEvalRuntime:
                     logger.info(f"Resuming evaluation {eval_item.id}")
                     options = UiPathExecuteOptions(resume=True)
                     result = await execution_runtime.execute(
-                        input=None,  # Let wrapper load resume data
+                        input=input_overrides if self.context.job_id is None else None,
                         options=options,
                     )
                 else:

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -219,6 +219,7 @@ def eval(
                     output_file=output_file,
                     trace_manager=trace_manager,
                     command="eval",
+                    resume=resume,
                 ) as ctx:
                     # Set job_id in eval context for single runtime runs
                     eval_context.job_id = ctx.job_id

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.17"
+version = "2.5.18"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

This PR fixes two critical issues with the resume functionality to enable local testing and ensure proper state management:

1. **Pass resume flag to runtime context** (`cli_eval.py:222`)
   - The `resume` parameter was not being passed to `UiPathRuntimeContext.with_defaults()`, preventing the runtime from knowing when to resume

2. **Preserve state for local testing** (`_runtime.py:979`)
   - When `job_id` is `None` (local testing), we now pass `input_overrides` during resume instead of `None`
   - This ensures state is not cleaned up at the cli_eval level for non-Studio executions

## Why These Changes Are Needed

### Problem 1: Resume flag not propagated
Without passing `resume=resume` to the runtime context, the resume functionality couldn't work properly because the context wouldn't know it should be in resume mode.

### Problem 2: State cleanup in local testing
Previously, when resuming in local mode (`job_id is None`), we always passed `input=None`. This caused the state to be cleaned up prematurely. By conditionally passing `input_overrides` when not in Studio (no job_id), we preserve the necessary state for local testing scenarios.

## Test Plan

- ✅ Resume works in local testing environment
- ✅ State is preserved correctly when job_id is None
- ✅ No regression in Studio Web executions (job_id present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)