### PR TITLE
feat: add mcp server bindings overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.24"
+version = "2.5.25"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_utils/_bindings.py
+++ b/src/uipath/_utils/_bindings.py
@@ -41,7 +41,7 @@ class ResourceOverwrite(BaseModel, ABC):
 
 
 class GenericResourceOverwrite(ResourceOverwrite):
-    resource_type: Literal["process", "index", "app", "asset", "bucket"]
+    resource_type: Literal["process", "index", "app", "asset", "bucket", "mcpServer"]
     name: str = Field(alias="name")
     folder_path: str = Field(alias="folderPath")
 

--- a/tests/resource_overrides/overwrites.json
+++ b/tests/resource_overrides/overwrites.json
@@ -24,5 +24,9 @@
   "process.process_name": {
     "name": "Overwritten Process Name",
     "folderPath": "Overwritten/Process/Folder"
+  },
+  "mcpServer.mcp_server_name": {
+    "name": "Overwritten MCP Server Name",
+    "folderPath": "Overwritten/MCPServer/Folder"
   }
 }

--- a/tests/resource_overrides/test_resource_overrides.py
+++ b/tests/resource_overrides/test_resource_overrides.py
@@ -303,6 +303,11 @@ class TestResourceOverrides:
         assert process.resource_identifier == "Overwritten Process Name"
         assert process.folder_identifier == "Overwritten/Process/Folder"
 
+        # Verify MCP Server overwrite
+        mcp_server = parsed_overwrites["mcpServer.mcp_server_name"]
+        assert mcp_server.resource_identifier == "Overwritten MCP Server Name"
+        assert mcp_server.folder_identifier == "Overwritten/MCPServer/Folder"
+
     def test_overrides_decorator_should_pop_kwargs_dict_when_present(self):
         from uipath._utils import resource_override
 

--- a/uv.lock
+++ b/uv.lock
@@ -2486,7 +2486,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.24"
+version = "2.5.25"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Add mcpServer to the list of possible bindings overrides. 

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.5.25.dev1011684080",

  # Any version from PR
  "uipath>=2.5.25.dev1011680000,<2.5.25.dev1011690000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.5.25.dev1011680000,<2.5.25.dev1011690000",
]
```
<!-- DEV_PACKAGE_END -->