### PR TITLE
feat: fix the eval telemetry and suppress appinsight logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.5.30"
+version = "2.5.31"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/telemetry/_track.py
+++ b/src/uipath/telemetry/_track.py
@@ -138,6 +138,11 @@ class _AppInsightsEventClient:
 
         _AppInsightsEventClient._initialized = True
 
+        # Suppress verbose logging from Application Insights SDK
+        # The SDK logs telemetry ingestion details which should not be user-facing
+        getLogger("applicationinsights").setLevel(WARNING)
+        getLogger("applicationinsights.channel").setLevel(WARNING)
+
         if not _HAS_APPINSIGHTS:
             return
 
@@ -153,6 +158,9 @@ class _AppInsightsEventClient:
             _AppInsightsEventClient._client = AppInsightsTelemetryClient(
                 instrumentation_key
             )
+
+            # Set application version
+            _AppInsightsEventClient._client.context.application.ver = version("uipath")
         except Exception:
             # Silently fail - telemetry should never break the main application
             pass
@@ -222,7 +230,10 @@ class _TelemetryClient:
             os.environ["OTEL_TRACES_EXPORTER"] = "none"
             os.environ["APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL"] = "true"
 
+            # Suppress verbose logging from telemetry libraries
             getLogger("azure").setLevel(WARNING)
+            getLogger("applicationinsights").setLevel(WARNING)
+            getLogger("opentelemetry").setLevel(WARNING)
             _logger.addHandler(_AzureMonitorOpenTelemetryEventHandler())
             _logger.setLevel(INFO)
 

--- a/testcases/eval-telemetry-testcase/src/assert.py
+++ b/testcases/eval-telemetry-testcase/src/assert.py
@@ -16,10 +16,10 @@ import httpx
 
 # Expected telemetry event names
 EXPECTED_EVENTS = [
-    "EvalSetRun.Start.URT",
-    "EvalSetRun.End.URT",
-    "EvalRun.Start.URT",
-    "EvalRun.End.URT",
+    "EvalSetRun.Start",
+    "EvalSetRun.End",
+    "EvalRun.Start",
+    "EvalRun.End",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.5.30"
+version = "2.5.31"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

This PR fixes evaluation telemetry properties and event names, and suppresses verbose Application Insights logging to improve the user experience.

## Changes

### 1. Telemetry Property Renaming
- **AgentId** → **Entrypoint**: Renamed property to accurately reflect that it contains the entrypoint path (e.g., `agent.json`, `agent.py`)
- Added new **AgentType** property: Automatically determined from entrypoint
  - `"LowCode"` when entrypoint is `agent.json`
  - `"Coded"` for Python agent files
- Added **Runtime** property: Set to `"URT"` (UiPath Runtime) for all evaluation events

### 2. Event Name Cleanup
Removed `.URT` suffix from all evaluation telemetry event names for cleaner event tracking:
- `EvalSetRun.Start.URT` → `EvalSetRun.Start`
- `EvalSetRun.End.URT` → `EvalSetRun.End`
- `EvalSetRun.Failed.URT` → `EvalSetRun.Failed`
- `EvalRun.Start.URT` → `EvalRun.Start`
- `EvalRun.End.URT` → `EvalRun.End`
- `EvalRun.Failed.URT` → `EvalRun.Failed`

### 3. Application Insights Log Suppression
Suppressed verbose logging from Application Insights SDK to prevent internal telemetry details from appearing in user-facing output:
- Set `applicationinsights` logger to WARNING level
- Set `applicationinsights.channel` logger to WARNING level
- Set `azure` logger to WARNING level
- Set `opentelemetry` logger to WARNING level
- Removed debug logs for telemetry subscription (no longer needed)

### 4. Application Version Tracking
Set `context.application.ver` in the Application Insights client to track the UiPath SDK version with telemetry events.

## Testing

- Updated test assertions to match new property names (`Entrypoint`, `AgentType`, `Runtime`)
- Updated test case assertions for evaluation telemetry
- All existing evaluation telemetry tests pass with new naming

## Impact

- **Breaking Change**: Telemetry consumers expecting `AgentId` property must update to use `Entrypoint`
- **User Experience**: Users will no longer see verbose Application Insights logging in their output
- **Telemetry Quality**: More accurate property names and cleaner event names for better analytics