### PR TITLE
feat: remove evalSetRun status update logic if user provided eval-set-run-id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.6.7"
+version = "2.6.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.7"
+version = "2.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
This PR removes all code logic that updates the status of `evalSetRun` entities, as requested if eval-set-run-id is specified.

follow-up to https://github.com/UiPath/Agents/pull/4178
