### PR TITLE
feat: add multi-model support for LLM-as-a-judge evaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ site
 
 
 .claude/*
+firebase-debug.log

--- a/samples/calculator/evaluations/eval-sets/context-precision-multi-model.json
+++ b/samples/calculator/evaluations/eval-sets/context-precision-multi-model.json
@@ -1,0 +1,30 @@
+{
+  "fileName": "context-precision-multi-model.json",
+  "id": "context-precision-multi-model-eval-set",
+  "name": "Multi-Model Context Precision Evaluation",
+  "batchSize": 10,
+  "evaluatorRefs": [
+    "ContextPrecisionEvaluatorClaude",
+    "ContextPrecisionEvaluatorGemini"
+  ],
+  "evaluations": [
+    {
+      "id": "test-context-precision-add-multi-model",
+      "name": "Test Add Context Precision with Multiple LLM Judges",
+      "inputs": {
+        "a": 7,
+        "b": 3,
+        "operator": "+"
+      },
+      "expectedOutput": {
+        "result": 10.0
+      },
+      "evalSetId": "context-precision-multi-model-eval-set",
+      "createdAt": "2025-01-25T00:00:00.000Z",
+      "updatedAt": "2025-01-25T00:00:00.000Z"
+    }
+  ],
+  "modelSettings": [],
+  "createdAt": "2025-01-25T00:00:00.000Z",
+  "updatedAt": "2025-01-25T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/eval-sets/faithfulness-multi-model.json
+++ b/samples/calculator/evaluations/eval-sets/faithfulness-multi-model.json
@@ -1,0 +1,30 @@
+{
+  "fileName": "faithfulness-multi-model.json",
+  "id": "faithfulness-multi-model-eval-set",
+  "name": "Multi-Model Faithfulness Evaluation",
+  "batchSize": 10,
+  "evaluatorRefs": [
+    "FaithfulnessEvaluatorClaude",
+    "FaithfulnessEvaluatorGemini"
+  ],
+  "evaluations": [
+    {
+      "id": "test-faithfulness-add-multi-model",
+      "name": "Test Add Faithfulness with Multiple LLM Judges",
+      "inputs": {
+        "a": 7,
+        "b": 3,
+        "operator": "+"
+      },
+      "expectedOutput": {
+        "result": 10.0
+      },
+      "evalSetId": "faithfulness-multi-model-eval-set",
+      "createdAt": "2025-01-25T00:00:00.000Z",
+      "updatedAt": "2025-01-25T00:00:00.000Z"
+    }
+  ],
+  "modelSettings": [],
+  "createdAt": "2025-01-25T00:00:00.000Z",
+  "updatedAt": "2025-01-25T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/eval-sets/multi-model.json
+++ b/samples/calculator/evaluations/eval-sets/multi-model.json
@@ -1,0 +1,65 @@
+{
+  "version": "1.0",
+  "id": "MultiModelLLMJudgeEval",
+  "name": "Multi-Model LLM Judge Evaluation",
+  "evaluatorRefs": [
+    "LLMJudgeOutputEvaluator",
+    "LLMJudgeOutputEvaluatorClaude",
+    "LLMJudgeOutputEvaluatorGemini",
+    "LLMJudgeStrictJSONSimilarityOutputEvaluator"
+  ],
+  "evaluations": [
+    {
+      "id": "test-add-multi-model",
+      "name": "Test Add with Multiple LLM Judges",
+      "inputs": {
+        "a": 2,
+        "b": 3,
+        "operator": "+"
+      },
+      "evaluationCriterias": {
+        "LLMJudgeOutputEvaluator": {
+          "expectedOutput": {
+            "result": 5.0
+          }
+        },
+        "LLMJudgeOutputEvaluatorClaude": {
+          "expectedOutput": {
+            "result": 5.0
+          }
+        },
+        "LLMJudgeOutputEvaluatorGemini": {
+          "expectedOutput": {
+            "result": 5.0
+          }
+        }
+      }
+    },
+    {
+      "id": "test-multiply-multi-model",
+      "name": "Test Multiply with Multiple LLM Judges",
+      "inputs": {
+        "a": 4,
+        "b": 5,
+        "operator": "*"
+      },
+      "evaluationCriterias": {
+        "LLMJudgeOutputEvaluator": {
+          "expectedOutput": {
+            "result": 20.0
+          }
+        },
+        "LLMJudgeOutputEvaluatorClaude": {
+          "expectedOutput": {
+            "result": 20.0
+          }
+        },
+        "LLMJudgeOutputEvaluatorGemini": {
+          "expectedOutput": {
+            "result": 20.0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/samples/calculator/evaluations/eval-sets/trajectory-multi-model.json
+++ b/samples/calculator/evaluations/eval-sets/trajectory-multi-model.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "id": "TrajectoryMultiModelEval",
+  "name": "Multi-Model Trajectory Evaluation",
+  "evaluatorRefs": [
+    "TrajectoryEvaluator",
+    "TrajectoryEvaluatorClaude",
+    "TrajectoryEvaluatorGemini"
+  ],
+  "evaluations": [
+    {
+      "id": "test-trajectory-add-multi-model",
+      "name": "Test Add Trajectory with Multiple LLM Judges",
+      "inputs": {
+        "a": 7,
+        "b": 3,
+        "operator": "+"
+      },
+      "evaluationCriterias": {
+        "TrajectoryEvaluator": {
+          "expectedAgentBehavior": "The agent should correctly add the two numbers and return the result 10."
+        },
+        "TrajectoryEvaluatorClaude": {
+          "expectedAgentBehavior": "The agent should correctly add the two numbers and return the result 10."
+        },
+        "TrajectoryEvaluatorGemini": {
+          "expectedAgentBehavior": "The agent should correctly add the two numbers and return the result 10."
+        }
+      }
+    },
+    {
+      "id": "test-trajectory-divide-multi-model",
+      "name": "Test Divide Trajectory with Multiple LLM Judges",
+      "inputs": {
+        "a": 20,
+        "b": 4,
+        "operator": "/"
+      },
+      "evaluationCriterias": {
+        "TrajectoryEvaluator": {
+          "expectedAgentBehavior": "The agent should correctly divide the first number by the second and return the result 5."
+        },
+        "TrajectoryEvaluatorClaude": {
+          "expectedAgentBehavior": "The agent should correctly divide the first number by the second and return the result 5."
+        },
+        "TrajectoryEvaluatorGemini": {
+          "expectedAgentBehavior": "The agent should correctly divide the first number by the second and return the result 5."
+        }
+      }
+    }
+  ]
+}

--- a/samples/calculator/evaluations/evaluators/context-precision-claude.json
+++ b/samples/calculator/evaluations/evaluators/context-precision-claude.json
@@ -1,0 +1,13 @@
+{
+  "id": "ContextPrecisionEvaluatorClaude",
+  "fileName": "context-precision-claude.json",
+  "name": "Context Precision Evaluator (Claude)",
+  "description": "Uses Claude to evaluate the relevance of context chunks to queries.",
+  "category": 1,
+  "type": 8,
+  "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  "prompt": "Evaluate the relevance of each context chunk to the provided query.",
+  "targetOutputKey": "*",
+  "createdAt": "2025-01-25T00:00:00.000Z",
+  "updatedAt": "2025-01-25T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/evaluators/context-precision-gemini.json
+++ b/samples/calculator/evaluations/evaluators/context-precision-gemini.json
@@ -1,0 +1,13 @@
+{
+  "id": "ContextPrecisionEvaluatorGemini",
+  "fileName": "context-precision-gemini.json",
+  "name": "Context Precision Evaluator (Gemini)",
+  "description": "Uses Gemini to evaluate the relevance of context chunks to queries.",
+  "category": 1,
+  "type": 8,
+  "model": "gemini-2.5-flash",
+  "prompt": "Evaluate the relevance of each context chunk to the provided query.",
+  "targetOutputKey": "*",
+  "createdAt": "2025-01-25T00:00:00.000Z",
+  "updatedAt": "2025-01-25T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/evaluators/faithfulness-claude.json
+++ b/samples/calculator/evaluations/evaluators/faithfulness-claude.json
@@ -1,0 +1,13 @@
+{
+  "id": "FaithfulnessEvaluatorClaude",
+  "fileName": "faithfulness-claude.json",
+  "name": "Faithfulness Evaluator (Claude)",
+  "description": "Uses Claude to evaluate whether agent output claims are grounded in context.",
+  "category": 1,
+  "type": 9,
+  "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  "prompt": "Evaluate whether the agent output claims are grounded in the provided context sources.",
+  "targetOutputKey": "*",
+  "createdAt": "2025-01-25T00:00:00.000Z",
+  "updatedAt": "2025-01-25T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/evaluators/faithfulness-gemini.json
+++ b/samples/calculator/evaluations/evaluators/faithfulness-gemini.json
@@ -1,0 +1,13 @@
+{
+  "id": "FaithfulnessEvaluatorGemini",
+  "fileName": "faithfulness-gemini.json",
+  "name": "Faithfulness Evaluator (Gemini)",
+  "description": "Uses Gemini to evaluate whether agent output claims are grounded in context.",
+  "category": 1,
+  "type": 9,
+  "model": "gemini-2.5-flash",
+  "prompt": "Evaluate whether the agent output claims are grounded in the provided context sources.",
+  "targetOutputKey": "*",
+  "createdAt": "2025-01-25T00:00:00.000Z",
+  "updatedAt": "2025-01-25T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/evaluators/llm-judge-claude.json
+++ b/samples/calculator/evaluations/evaluators/llm-judge-claude.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "id": "LLMJudgeOutputEvaluatorClaude",
+  "description": "Uses Claude to judge semantic similarity between expected and actual output.",
+  "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
+  "evaluatorConfig": {
+    "name": "LLMJudgeOutputEvaluatorClaude",
+    "targetOutputKey": "*",
+    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "prompt": "Compare the following outputs and evaluate their semantic similarity.\n\nActual Output: {{ActualOutput}}\nExpected Output: {{ExpectedOutput}}\n\nProvide a score from 0-100 where 100 means semantically identical and 0 means completely different.",
+    "temperature": 0.0,
+    "defaultEvaluationCriteria": {
+      "expectedOutput": {
+        "result": 5.0
+      }
+    }
+  }
+}

--- a/samples/calculator/evaluations/evaluators/llm-judge-gemini.json
+++ b/samples/calculator/evaluations/evaluators/llm-judge-gemini.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "id": "LLMJudgeOutputEvaluatorGemini",
+  "description": "Uses Gemini to judge semantic similarity between expected and actual output.",
+  "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
+  "evaluatorConfig": {
+    "name": "LLMJudgeOutputEvaluatorGemini",
+    "targetOutputKey": "*",
+    "model": "gemini-2.5-flash",
+    "prompt": "Compare the following outputs and evaluate their semantic similarity.\n\nActual Output: {{ActualOutput}}\nExpected Output: {{ExpectedOutput}}\n\nProvide a score from 0-100 where 100 means semantically identical and 0 means completely different.",
+    "temperature": 0.0,
+    "defaultEvaluationCriteria": {
+      "expectedOutput": {
+        "result": 5.0
+      }
+    }
+  }
+}

--- a/samples/calculator/evaluations/evaluators/trajectory-claude.json
+++ b/samples/calculator/evaluations/evaluators/trajectory-claude.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "id": "TrajectoryEvaluatorClaude",
+  "description": "Uses Claude to evaluate the agent's execution trajectory and decision sequence.",
+  "evaluatorTypeId": "uipath-llm-judge-trajectory-similarity",
+  "evaluatorConfig": {
+    "name": "TrajectoryEvaluatorClaude",
+    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "prompt": "Evaluate the agent's execution trajectory based on the expected behavior.\n\nExpected Agent Behavior: {{ExpectedAgentBehavior}}\nAgent Run History: {{AgentRunHistory}}\n\nProvide a score from 0-100 based on how well the agent followed the expected trajectory.",
+    "temperature": 0.0,
+    "defaultEvaluationCriteria": {
+      "expectedAgentBehavior": "The agent should correctly perform the calculation and return the result."
+    }
+  }
+}

--- a/samples/calculator/evaluations/evaluators/trajectory-gemini.json
+++ b/samples/calculator/evaluations/evaluators/trajectory-gemini.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "id": "TrajectoryEvaluatorGemini",
+  "description": "Uses Gemini to evaluate the agent's execution trajectory and decision sequence.",
+  "evaluatorTypeId": "uipath-llm-judge-trajectory-similarity",
+  "evaluatorConfig": {
+    "name": "TrajectoryEvaluatorGemini",
+    "model": "gemini-2.5-flash",
+    "prompt": "Evaluate the agent's execution trajectory based on the expected behavior.\n\nExpected Agent Behavior: {{ExpectedAgentBehavior}}\nAgent Run History: {{AgentRunHistory}}\n\nProvide a score from 0-100 based on how well the agent followed the expected trajectory.",
+    "temperature": 0.0,
+    "defaultEvaluationCriteria": {
+      "expectedAgentBehavior": "The agent should correctly perform the calculation and return the result."
+    }
+  }
+}

--- a/src/uipath/eval/evaluators/legacy_llm_helpers.py
+++ b/src/uipath/eval/evaluators/legacy_llm_helpers.py
@@ -1,0 +1,105 @@
+"""Helper functions for legacy LLM evaluators using function calling."""
+
+import logging
+from typing import Any
+
+from uipath.platform.chat.llm_gateway import (
+    ToolDefinition,
+    ToolFunctionDefinition,
+    ToolParametersDefinition,
+    ToolPropertyDefinition,
+)
+
+from ..models.models import LLMResponse
+
+logger = logging.getLogger(__name__)
+
+
+def create_evaluation_tool() -> ToolDefinition:
+    """Create the standard evaluation tool definition for function calling.
+
+    Returns:
+        ToolDefinition with submit_evaluation function for structured output
+    """
+    return ToolDefinition(
+        type="function",
+        function=ToolFunctionDefinition(
+            name="submit_evaluation",
+            description="Submit the evaluation score and justification for the agent output",
+            parameters=ToolParametersDefinition(
+                type="object",
+                properties={
+                    "justification": ToolPropertyDefinition(
+                        type="string",
+                        description="Clear analysis of the evaluation explaining the reasoning behind the score",
+                    ),
+                    "score": ToolPropertyDefinition(
+                        type="number",
+                        description="Numeric score between 0 and 100 representing the evaluation result",
+                    ),
+                },
+                required=["justification", "score"],
+            ),
+        ),
+    )
+
+
+def extract_tool_call_response(response: Any, model: str) -> LLMResponse:
+    """Extract the evaluation response from the tool call.
+
+    Args:
+        response: The response from the LLM chat completions API
+        model: The model name used for the request (for error logging)
+
+    Returns:
+        LLMResponse: Parsed response with score and justification
+
+    Raises:
+        ValueError: If the response format is invalid or missing required fields
+    """
+    try:
+        if not response.choices or len(response.choices) == 0:
+            error_msg = f"No choices in response from model {model}"
+            logger.error(f"❌ {error_msg}")
+            raise ValueError(error_msg)
+
+        choice = response.choices[0]
+        message = choice.message
+
+        if not message.tool_calls or len(message.tool_calls) == 0:
+            error_msg = f"No tool calls in response from model {model}"
+            logger.error(f"❌ {error_msg}")
+            logger.debug(f"Response: {response}")
+            raise ValueError(error_msg)
+
+        tool_call = message.tool_calls[0]
+        arguments = tool_call.arguments
+
+        if "score" not in arguments:
+            error_msg = f"Missing 'score' in tool call arguments from model {model}"
+            logger.error(f"❌ {error_msg}")
+            logger.debug(f"Arguments: {arguments}")
+            raise ValueError(error_msg)
+
+        if "justification" not in arguments:
+            error_msg = (
+                f"Missing 'justification' in tool call arguments from model {model}"
+            )
+            logger.error(f"❌ {error_msg}")
+            logger.debug(f"Arguments: {arguments}")
+            raise ValueError(error_msg)
+
+        score = float(arguments["score"])
+        justification = str(arguments["justification"])
+
+        logger.debug(
+            f"✅ Extracted score: {score}, justification length: {len(justification)} chars"
+        )
+
+        return LLMResponse(score=score, justification=justification)
+
+    except (KeyError, IndexError, AttributeError) as e:
+        error_msg = f"Failed to extract tool call response from model {model}: {str(e)}"
+        logger.error(f"❌ {error_msg}")
+        logger.debug(f"Response: {response}")
+        raise ValueError(error_msg) from e

--- a/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
+++ b/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
@@ -1,6 +1,5 @@
 """Trajectory evaluator for analyzing execution paths and decision sequences."""
 
-import json
 from typing import Any, Optional
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -10,6 +9,7 @@ from uipath.eval.models import EvaluationResult
 
 from ..._utils.constants import COMMUNITY_agents_SUFFIX
 from ...platform.chat import UiPathLlmChatService
+from ...platform.chat.llm_gateway import RequiredToolChoice
 from ..models.models import (
     AgentExecution,
     LLMResponse,
@@ -21,6 +21,7 @@ from .legacy_base_evaluator import (
     LegacyEvaluationCriteria,
     LegacyEvaluatorConfig,
 )
+from .legacy_llm_helpers import create_evaluation_tool, extract_tool_call_response
 
 
 class LegacyTrajectoryEvaluatorConfig(LegacyEvaluatorConfig):
@@ -128,7 +129,7 @@ class LegacyTrajectoryEvaluator(LegacyBaseEvaluator[LegacyTrajectoryEvaluatorCon
         return formatted_prompt
 
     async def _get_llm_response(self, evaluation_prompt: str) -> LLMResponse:
-        """Get response from the LLM.
+        """Get response from the LLM using universal function calling.
 
         Args:
             evaluation_prompt: The formatted prompt to send to the LLM
@@ -142,33 +143,17 @@ class LegacyTrajectoryEvaluator(LegacyBaseEvaluator[LegacyTrajectoryEvaluatorCon
         if model.endswith(COMMUNITY_agents_SUFFIX):
             model = model.replace(COMMUNITY_agents_SUFFIX, "")
 
-        # Prepare the request
+        # Create evaluation tool for function calling (works across all models)
+        evaluation_tool = create_evaluation_tool()
+        tool_choice = RequiredToolChoice()
+
+        # Prepare the request with function calling
         request_data = {
             "model": model,
             "messages": [{"role": "user", "content": evaluation_prompt}],
-            "response_format": {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "evaluation_response",
-                    "schema": {
-                        "type": "object",
-                        "properties": {
-                            "score": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 100,
-                                "description": "Score between 0 and 100",
-                            },
-                            "justification": {
-                                "type": "string",
-                                "description": "Explanation for the score",
-                            },
-                        },
-                        "required": ["score", "justification"],
-                    },
-                },
-            },
+            "tools": [evaluation_tool],
+            "tool_choice": tool_choice,
         }
 
         response = await self.llm.chat_completions(**request_data)
-        return LLMResponse(**json.loads(response.choices[-1].message.content or "{}"))
+        return extract_tool_call_response(response, model)

--- a/testcases/calculator-evals/run.sh
+++ b/testcases/calculator-evals/run.sh
@@ -10,5 +10,9 @@ uv run uipath auth --client-id="$CLIENT_ID" --client-secret="$CLIENT_SECRET" --b
 echo "Running evaluations with custom evaluator..."
 uv run uipath eval main ../../samples/calculator/evaluations/eval-sets/legacy.json --no-report --output-file legacy.json
 uv run uipath eval main ../../samples/calculator/evaluations/eval-sets/default.json --no-report --output-file default.json
+uv run uipath eval main ../../samples/calculator/evaluations/eval-sets/multi-model.json --no-report --output-file multi-model.json
+uv run uipath eval main ../../samples/calculator/evaluations/eval-sets/trajectory-multi-model.json --no-report --output-file trajectory-multi-model.json
+uv run uipath eval main ../../samples/calculator/evaluations/eval-sets/faithfulness-multi-model.json --no-report --output-file faithfulness-multi-model.json
+uv run uipath eval main ../../samples/calculator/evaluations/eval-sets/context-precision-multi-model.json --no-report --output-file context-precision-multi-model.json
 
 echo "Test completed successfully!"

--- a/tests/evaluators/test_documentation_examples.py
+++ b/tests/evaluators/test_documentation_examples.py
@@ -527,13 +527,19 @@ class TestLLMJudgeOutputExamples:
         from uipath.eval.evaluators import LLMJudgeOutputEvaluator
         from uipath.eval.models import AgentExecution
 
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 95,
+            "justification": "Both outputs convey the same meaning about Paris being the capital of France.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 95, "justification": "Both outputs convey the same meaning about Paris being the capital of France."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -569,13 +575,19 @@ class TestLLMJudgeOutputExamples:
     @pytest.mark.asyncio
     async def test_custom_evaluation_prompt(self, mocker: MockerFixture) -> None:
         """Test custom evaluation prompt example."""
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_2"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 90,
+            "justification": "Both messages convey successful cart addition.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 90, "justification": "Both messages convey successful cart addition."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -626,13 +638,19 @@ Provide a score from 0-100 based on semantic similarity.
         self, mocker: MockerFixture
     ) -> None:
         """Test evaluating natural language quality example."""
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_3"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 85,
+            "justification": "The email is professional and addresses the customer inquiry appropriately.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 85, "justification": "The email is professional and addresses the customer inquiry appropriately."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -683,13 +701,19 @@ Support Team"""
             LLMJudgeStrictJSONSimilarityOutputEvaluator,
         )
 
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_4"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 100,
+            "justification": "All keys match perfectly.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 100, "justification": "All keys match perfectly."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -741,13 +765,19 @@ class TestLLMJudgeTrajectoryExamples:
         from uipath.eval.evaluators import LLMJudgeTrajectoryEvaluator
         from uipath.eval.models import AgentExecution
 
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_5"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 85,
+            "justification": "Agent followed the expected booking flow.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 85, "justification": "Agent followed the expected booking flow."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -791,13 +821,19 @@ class TestLLMJudgeTrajectoryExamples:
     @pytest.mark.asyncio
     async def test_validating_tool_usage_sequence(self, mocker: MockerFixture) -> None:
         """Test validating tool usage sequence example."""
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_6"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 90,
+            "justification": "Agent correctly validated, updated, and notified in proper sequence.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 90, "justification": "Agent correctly validated, updated, and notified in proper sequence."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -842,13 +878,19 @@ class TestLLMJudgeTrajectoryExamples:
         """Test tool simulation trajectory evaluation example."""
         from uipath.eval.evaluators import LLMJudgeTrajectorySimulationEvaluator
 
-        # Mock the LLM response
+        # Mock the LLM response with tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_7"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 88,
+            "justification": "Agent followed expected flow with simulated tool responses.",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 88, "justification": "Agent followed expected flow with simulated tool responses."}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 

--- a/tests/evaluators/test_evaluator_methods.py
+++ b/tests/evaluators/test_evaluator_methods.py
@@ -795,19 +795,25 @@ class TestLlmAsAJudgeEvaluator:
     async def test_llm_judge_basic_evaluation(
         self, sample_agent_execution: AgentExecution, mocker: MockerFixture
     ) -> None:
-        """Test LLM as judge basic evaluation functionality."""
+        """Test LLM as judge basic evaluation functionality with function calling."""
         # Mock the UiPath constructor to avoid authentication
         mock_uipath = mocker.MagicMock()
         mock_llm = mocker.MagicMock()
         mock_uipath.llm = mock_llm
 
-        # Mock the chat completions response as an async method
+        # Mock the chat completions response with tool call (function calling approach)
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 80,
+            "justification": "Good response that meets criteria",
+        }
+
         mock_response = mocker.MagicMock()
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 80, "justification": "Good response that meets criteria"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -841,13 +847,20 @@ class TestLlmAsAJudgeEvaluator:
     async def test_llm_judge_basic_evaluation_with_llm_service(
         self, sample_agent_execution: AgentExecution, mocker: MockerFixture
     ) -> None:
-        """Test LLM judge basic evaluation functionality with a custom LLM service."""
+        """Test LLM judge basic evaluation functionality with a custom LLM service and function calling."""
+        # Mock tool call for function calling approach
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 80,
+            "justification": "Good response that meets criteria",
+        }
+
         mock_response = mocker.MagicMock()
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 80, "justification": "Good response that meets criteria"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -881,19 +894,25 @@ class TestLlmAsAJudgeEvaluator:
     async def test_llm_judge_validate_and_evaluate_criteria(
         self, sample_agent_execution: AgentExecution, mocker: MockerFixture
     ) -> None:
-        """Test LLM judge using validate_and_evaluate_criteria."""
+        """Test LLM judge using validate_and_evaluate_criteria with function calling."""
         # Mock the UiPath constructor to avoid authentication
         mock_uipath = mocker.MagicMock()
         mock_llm = mocker.MagicMock()
         mock_uipath.llm = mock_llm
 
-        # Mock the chat completions response as an async method
+        # Mock tool call for function calling approach
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 75,
+            "justification": "Good response using raw criteria",
+        }
+
         mock_response = mocker.MagicMock()
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 75, "justification": "Good response using raw criteria"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -933,19 +952,25 @@ class TestLlmJudgeTrajectoryEvaluator:
     async def test_llm_trajectory_basic_evaluation(
         self, sample_agent_execution: AgentExecution, mocker: MockerFixture
     ) -> None:
-        """Test LLM trajectory judge basic evaluation functionality."""
+        """Test LLM trajectory judge basic evaluation functionality with function calling."""
         # Mock the UiPath constructor to avoid authentication
         mock_uipath = mocker.MagicMock()
         mock_llm = mocker.MagicMock()
         mock_uipath.llm = mock_llm
 
-        # Mock the chat completions response as an async method
+        # Mock tool call for function calling approach
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 90,
+            "justification": "The agent followed the expected behavior and met the criteria",
+        }
+
         mock_response = mocker.MagicMock()
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 90, "justification": "The agent followed the expected behavior and met the criteria"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -982,19 +1007,25 @@ class TestLlmJudgeTrajectoryEvaluator:
     async def test_llm_trajectory_validate_and_evaluate_criteria(
         self, sample_agent_execution: AgentExecution, mocker: MockerFixture
     ) -> None:
-        """Test LLM trajectory judge using validate_and_evaluate_criteria."""
+        """Test LLM trajectory judge using validate_and_evaluate_criteria with function calling."""
         # Mock the UiPath constructor to avoid authentication
         mock_uipath = mocker.MagicMock()
         mock_llm = mocker.MagicMock()
         mock_uipath.llm = mock_llm
 
-        # Mock the chat completions response as an async method
+        # Mock tool call for function calling approach
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 85,
+            "justification": "The agent behavior was good using raw criteria",
+        }
+
         mock_response = mocker.MagicMock()
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 85, "justification": "The agent behavior was good using raw criteria"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -1265,19 +1296,25 @@ class TestJustificationHandling:
     async def test_llm_judge_output_evaluator_justification(
         self, sample_agent_execution: AgentExecution, mocker: MockerFixture
     ) -> None:
-        """Test that LLMJudgeOutputEvaluator handles str justification correctly."""
+        """Test that LLMJudgeOutputEvaluator handles str justification correctly with function calling."""
         # Mock the UiPath constructor to avoid authentication
         mock_uipath = mocker.MagicMock()
         mock_llm = mocker.MagicMock()
         mock_uipath.llm = mock_llm
 
-        # Mock the chat completions response with justification
+        # Mock tool call for function calling approach
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 80,
+            "justification": "The response meets most criteria but could be more detailed",
+        }
+
         mock_response = mocker.MagicMock()
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 80, "justification": "The response meets most criteria but could be more detailed"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 
@@ -1321,13 +1358,19 @@ class TestJustificationHandling:
         mock_llm = mocker.MagicMock()
         mock_uipath.llm = mock_llm
 
-        # Mock the chat completions response with justification
+        # Mock the chat completions response with justification using tool_call format
         mock_response = mocker.MagicMock()
+        mock_tool_call = mocker.MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.name = "submit_evaluation"
+        mock_tool_call.arguments = {
+            "score": 85,
+            "justification": "The agent trajectory shows good decision making and follows expected behavior patterns",
+        }
+
         mock_response.choices = [
             mocker.MagicMock(
-                message=mocker.MagicMock(
-                    content='{"score": 85, "justification": "The agent trajectory shows good decision making and follows expected behavior patterns"}'
-                )
+                message=mocker.MagicMock(content=None, tool_calls=[mock_tool_call])
             )
         ]
 


### PR DESCRIPTION
## Summary
Migrates all LLM-based evaluators to use universal function calling via the Normalized API, ensuring support for Claude, Gemini, and GPT models.

## Changes

### Core Evaluator
- **llm_as_judge_evaluator**: Replaced model-specific `response_format` with universal function calling using `ToolDefinition` and `RequiredToolChoice`
- Added `_extract_tool_call_response()` method for consistent response extraction

### Legacy Evaluators
- **legacy_llm_helpers.py** (NEW): Shared utilities for function calling with `create_evaluation_tool()` and `extract_tool_call_response()`
- **legacy_trajectory_evaluator**: Migrated to use function calling
- **legacy_llm_as_judge_evaluator**: Migrated to use function calling
- **legacy_faithfulness_evaluator**: Migrated with dynamic schema-based function calling
- **legacy_context_precision_evaluator**: Migrated to use function calling

### Testing & Integration
- Updated all test mocks to use `tool_calls` format instead of JSON content parsing
- Added multi-model evaluation configs (GPT-4, Claude 3.5, Gemini 2.5)
- Integrated multi-model testing into calculator sample integration tests

## Test Results
- ✅ All 1804 tests passing
- ✅ Verified with GPT-4, Claude 3.5 Sonnet, and Gemini 2.5 Flash (all returning 100% scores)

## Technical Details
Function calling provides a universal structured output mechanism across all models, eliminating the need for model-specific code paths. The implementation uses:
- `ToolDefinition` with `ToolFunctionDefinition` and `ToolParametersDefinition`
- `RequiredToolChoice()` to ensure models use the specified tool
- Response extraction from `message.tool_calls[0].arguments`

This approach works seamlessly with Claude, Gemini, and GPT models via the Normalized API.