### PR TITLE
fix(EmptyMockStrategy): empty mock strategy should not error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.6.9"
+version = "2.6.10"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/mocks/mocks.py
+++ b/src/uipath/_cli/_evals/mocks/mocks.py
@@ -45,7 +45,7 @@ def set_execution_context(
     mocking_context.set(context)
 
     try:
-        if context:
+        if context and context.strategy:
             mocker_context.set(MockerFactory.create(context))
         else:
             mocker_context.set(None)

--- a/tests/cli/eval/mocks/test_mocks.py
+++ b/tests/cli/eval/mocks/test_mocks.py
@@ -22,10 +22,49 @@ from uipath._cli._evals.mocks.types import (
     LLMMockingStrategy,
     MockingContext,
     MockitoMockingStrategy,
+    ToolSimulation,
 )
 from uipath.eval.mocks import mockable
 
 _mock_span_collector = MagicMock()
+
+
+class TestSetExecutionContext:
+    """Tests for the set_execution_context function."""
+
+    def test_sets_mocker_to_none_when_context_is_none(self):
+        clear_execution_context()
+        set_execution_context(None, _mock_span_collector, "test-execution-id")
+        # Verify mocker context is None by checking is_tool_simulated returns False
+        assert is_tool_simulated("any_tool") is False
+        clear_execution_context()
+
+    def test_sets_mocker_to_none_when_strategy_is_none(self):
+        clear_execution_context()
+        context = MockingContext(
+            strategy=None,
+            name="test",
+            inputs={},
+        )
+        set_execution_context(context, _mock_span_collector, "test-execution-id")
+        # Verify mocker context is None by checking is_tool_simulated returns False
+        assert is_tool_simulated("any_tool") is False
+        clear_execution_context()
+
+    def test_creates_mocker_when_context_and_strategy_exist(self):
+        clear_execution_context()
+        context = MockingContext(
+            strategy=LLMMockingStrategy(
+                prompt="test prompt",
+                tools_to_simulate=[ToolSimulation(name="test_tool")],
+            ),
+            name="test",
+            inputs={},
+        )
+        set_execution_context(context, _mock_span_collector, "test-execution-id")
+        # Verify mocker context was created by checking is_tool_simulated returns True
+        assert is_tool_simulated("test_tool") is True
+        clear_execution_context()
 
 
 class TestNormalizeToolName:

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.9"
+version = "2.6.10"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
A recent refactor updated the logic which logs an error `"Failed to create mocker."` when mocking strategy is not specified. Fixing this behavior.