### PR TITLE
fix: clean live tracking

### DIFF
--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -43,7 +43,6 @@ from uipath.eval.evaluators import (
 from uipath.eval.models import EvalItemResult, ScoreType
 from uipath.platform import UiPath
 from uipath.platform.common import UiPathConfig
-from uipath.tracing import LlmOpsHttpExporter
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +73,7 @@ def gracefully_handle_errors(func):
 class StudioWebProgressReporter:
     """Handles reporting evaluation progress to StudioWeb."""
 
-    def __init__(self, spans_exporter: LlmOpsHttpExporter):
-        self.spans_exporter = spans_exporter
-
+    def __init__(self):
         logging.getLogger("uipath._cli.middlewares").setLevel(logging.CRITICAL)
         console_logger = ConsoleLogger.get_instance()
 

--- a/src/uipath/functions/factory.py
+++ b/src/uipath/functions/factory.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import Any
 
 from uipath.runtime import (
-    UiPathResumableStorageProtocol,
     UiPathRuntimeFactorySettings,
     UiPathRuntimeProtocol,
+    UiPathRuntimeStorageProtocol,
 )
 
 from .runtime import UiPathFunctionsRuntime
@@ -48,7 +48,7 @@ class UiPathFunctionsRuntimeFactory:
         config = self._load_config()
         return list(config.get("functions", {}).keys())
 
-    async def get_storage(self) -> UiPathResumableStorageProtocol | None:
+    async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
         """Get storage protocol if any (placeholder for protocol compliance)."""
         return None
 

--- a/src/uipath/tracing/__init__.py
+++ b/src/uipath/tracing/__init__.py
@@ -2,6 +2,7 @@
 
 from uipath.core import traced
 
+from ._live_tracking_processor import LiveTrackingSpanProcessor
 from ._otel_exporters import (  # noqa: D104
     JsonLinesFileExporter,
     LlmOpsHttpExporter,
@@ -12,5 +13,6 @@ __all__ = [
     "traced",
     "LlmOpsHttpExporter",
     "JsonLinesFileExporter",
+    "LiveTrackingSpanProcessor",
     "SpanStatus",
 ]

--- a/tests/cli/eval/test_eval_runtime_metadata.py
+++ b/tests/cli/eval/test_eval_runtime_metadata.py
@@ -15,12 +15,12 @@ import pytest
 from uipath.core.tracing import UiPathTraceManager
 from uipath.runtime import (
     UiPathExecuteOptions,
-    UiPathResumableStorageProtocol,
     UiPathRuntimeEvent,
     UiPathRuntimeFactorySettings,
     UiPathRuntimeProtocol,
     UiPathRuntimeResult,
     UiPathRuntimeStatus,
+    UiPathRuntimeStorageProtocol,
     UiPathStreamOptions,
 )
 from uipath.runtime.schema import UiPathRuntimeSchema
@@ -116,7 +116,7 @@ class MockFactory:
     def discover_entrypoints(self) -> list[str]:
         return ["test"]
 
-    async def get_storage(self) -> UiPathResumableStorageProtocol | None:
+    async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
         return None
 
     async def get_settings(self) -> UiPathRuntimeFactorySettings | None:

--- a/tests/cli/eval/test_eval_runtime_suspend_resume.py
+++ b/tests/cli/eval/test_eval_runtime_suspend_resume.py
@@ -15,12 +15,12 @@ import pytest
 from uipath.core.tracing import UiPathTraceManager
 from uipath.runtime import (
     UiPathExecuteOptions,
-    UiPathResumableStorageProtocol,
     UiPathRuntimeEvent,
     UiPathRuntimeFactorySettings,
     UiPathRuntimeProtocol,
     UiPathRuntimeResult,
     UiPathRuntimeStatus,
+    UiPathRuntimeStorageProtocol,
     UiPathStreamOptions,
 )
 from uipath.runtime.schema import UiPathRuntimeSchema
@@ -115,7 +115,7 @@ class MockFactory:
     def discover_entrypoints(self) -> list[str]:
         return ["test"]
 
-    async def get_storage(self) -> UiPathResumableStorageProtocol | None:
+    async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
         return None
 
     async def get_settings(self) -> UiPathRuntimeFactorySettings | None:

--- a/tests/cli/eval/test_evaluate.py
+++ b/tests/cli/eval/test_evaluate.py
@@ -5,12 +5,12 @@ from pydantic import BaseModel
 from uipath.core.tracing import UiPathTraceManager
 from uipath.runtime import (
     UiPathExecuteOptions,
-    UiPathResumableStorageProtocol,
     UiPathRuntimeEvent,
     UiPathRuntimeFactorySettings,
     UiPathRuntimeProtocol,
     UiPathRuntimeResult,
     UiPathRuntimeStatus,
+    UiPathRuntimeStorageProtocol,
     UiPathStreamOptions,
 )
 from uipath.runtime.schema import UiPathRuntimeSchema
@@ -77,7 +77,7 @@ async def test_evaluate():
         def discover_entrypoints(self) -> list[str]:
             return ["test"]
 
-        async def get_storage(self) -> UiPathResumableStorageProtocol | None:
+        async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
             return None
 
         async def get_settings(self) -> UiPathRuntimeFactorySettings | None:
@@ -181,7 +181,7 @@ async def test_eval_runtime_generates_uuid_when_no_custom_id():
         def discover_entrypoints(self) -> list[str]:
             return ["test"]
 
-        async def get_storage(self) -> UiPathResumableStorageProtocol | None:
+        async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
             return None
 
         async def get_settings(self) -> UiPathRuntimeFactorySettings | None:
@@ -270,7 +270,7 @@ async def test_eval_runtime_works_without_exporters():
         def discover_entrypoints(self) -> list[str]:
             return ["test"]
 
-        async def get_storage(self) -> UiPathResumableStorageProtocol | None:
+        async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
             return None
 
         async def get_settings(self) -> UiPathRuntimeFactorySettings | None:

--- a/tests/cli/eval/test_live_tracking_span_processor.py
+++ b/tests/cli/eval/test_live_tracking_span_processor.py
@@ -10,8 +10,7 @@ from opentelemetry import context as context_api
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from uipath.runtime import UiPathRuntimeFactorySettings
 
-from uipath._cli._evals._live_tracking_processor import LiveTrackingSpanProcessor
-from uipath.tracing import SpanStatus
+from uipath.tracing import LiveTrackingSpanProcessor, SpanStatus
 
 
 class TestLiveTrackingSpanProcessor:
@@ -42,7 +41,9 @@ class TestLiveTrackingSpanProcessor:
                 )
             )
         )
-        return LiveTrackingSpanProcessor(mock_exporter, settings=settings)
+        return LiveTrackingSpanProcessor(
+            mock_exporter, settings=settings.trace_settings
+        )
 
     def create_mock_span(self, attributes: dict[str, Any] | None = None):
         """Create a mock span with attributes."""
@@ -61,7 +62,6 @@ class TestLiveTrackingSpanProcessor:
         processor = LiveTrackingSpanProcessor(mock_exporter)
 
         assert processor.exporter == mock_exporter
-        assert processor.span_status == SpanStatus
 
     def test_init_with_no_settings(self, mock_exporter):
         """Test processor initialization with no settings."""
@@ -80,7 +80,9 @@ class TestLiveTrackingSpanProcessor:
                 )
             )
         )
-        processor = LiveTrackingSpanProcessor(mock_exporter, settings=settings)
+        processor = LiveTrackingSpanProcessor(
+            mock_exporter, settings=settings.trace_settings
+        )
 
         assert processor.span_filter is not None
 

--- a/tests/cli/eval/test_progress_reporter.py
+++ b/tests/cli/eval/test_progress_reporter.py
@@ -36,7 +36,7 @@ def progress_reporter(mock_exporter, monkeypatch):
     monkeypatch.setenv("UIPATH_PROJECT_ID", "test-project-id")
     monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
 
-    reporter = StudioWebProgressReporter(mock_exporter)
+    reporter = StudioWebProgressReporter()
     return reporter
 
 


### PR DESCRIPTION
## Description

This PR refactors the live tracking functionality by moving `LiveTrackingSpanProcessor` from `uipath._cli._evals` to `uipath.tracing` module, establishing a cleaner separation of concerns. The processor's interface has been simplified to accept `UiPathTraceSettings` directly instead of `UiPathRuntimeFactorySettings`, removing unnecessary dependencies between the tracing layer and the runtime factory.

**Changes:**
- Moved `LiveTrackingSpanProcessor` from CLI internal module to public `uipath.tracing` module
- Updated processor to accept `UiPathTraceSettings` instead of `UiPathRuntimeFactorySettings`
- Removed the `create_and_register` factory method in favor of direct instantiation
- Updated all call sites in CLI commands (run, eval, debug) to extract `trace_settings` from `factory_settings` before passing to the processor
- Removed `spans_exporter` dependency from `StudioWebProgressReporter`

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.6.17.dev1012084389",

  # Any version from PR
  "uipath>=2.6.17.dev1012080000,<2.6.17.dev1012090000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.6.17.dev1012080000,<2.6.17.dev1012090000",
]
```
<!-- DEV_PACKAGE_END -->