### PR TITLE
chore: expose ephemeral index interrupt models

### DIFF
--- a/src/uipath/platform/common/__init__.py
+++ b/src/uipath/platform/common/__init__.py
@@ -13,6 +13,7 @@ from .auth import TokenData
 from .interrupt_models import (
     CreateBatchTransform,
     CreateDeepRag,
+    CreateEphemeralIndex,
     CreateEscalation,
     CreateTask,
     DocumentExtraction,
@@ -21,6 +22,7 @@ from .interrupt_models import (
     WaitBatchTransform,
     WaitDeepRag,
     WaitDocumentExtraction,
+    WaitEphemeralIndex,
     WaitEscalation,
     WaitJob,
     WaitSystemAgent,
@@ -52,4 +54,6 @@ __all__ = [
     "WaitDocumentExtraction",
     "InvokeSystemAgent",
     "WaitSystemAgent",
+    "CreateEphemeralIndex",
+    "WaitEphemeralIndex",
 ]


### PR DESCRIPTION
- expose ephemeral index interrupt models

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.6.10.dev1012094344",

  # Any version from PR
  "uipath>=2.6.10.dev1012090000,<2.6.10.dev1012100000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.6.10.dev1012090000,<2.6.10.dev1012100000",
]
```
<!-- DEV_PACKAGE_END -->