### PR TITLE
feat: create external trigger for ephemeral index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.6.11"
+version = "2.6.12"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.2.0, <0.3.0",
-  "uipath-runtime>=0.6.0, <0.7.0",
+  "uipath-runtime>=0.6.1, <0.7.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/src/uipath/platform/resume_triggers/_enums.py
+++ b/src/uipath/platform/resume_triggers/_enums.py
@@ -26,6 +26,7 @@ class ExternalTriggerType(str, Enum):
     DEEP_RAG = "deepRag"
     BATCH_TRANSFORM = "batchTransform"
     IXP_EXTRACTION = "ixpExtraction"
+    INDEX_INGESTION = "indexIngestion"
 
 
 class ExternalTrigger(BaseModel):

--- a/src/uipath/platform/resume_triggers/_protocol.py
+++ b/src/uipath/platform/resume_triggers/_protocol.py
@@ -241,7 +241,7 @@ class UiPathResumeTriggerReader:
 
                     return trigger_response
 
-            case UiPathResumeTriggerType.EPHEMERAL_INDEX:
+            case UiPathResumeTriggerType.INDEX_INGESTION:
                 if trigger.item_key:
                     index = await uipath.context_grounding.retrieve_by_id_async(
                         trigger.item_key
@@ -392,7 +392,7 @@ class UiPathResumeTriggerCreator:
                     await self._handle_deep_rag_job_trigger(
                         suspend_value, resume_trigger
                     )
-                case UiPathResumeTriggerType.EPHEMERAL_INDEX:
+                case UiPathResumeTriggerType.INDEX_INGESTION:
                     await self._handle_ephemeral_index_job_trigger(
                         suspend_value, resume_trigger
                     )
@@ -449,7 +449,7 @@ class UiPathResumeTriggerCreator:
         if isinstance(value, (CreateDeepRag, WaitDeepRag)):
             return UiPathResumeTriggerType.DEEP_RAG
         if isinstance(value, (CreateEphemeralIndex, WaitEphemeralIndex)):
-            return UiPathResumeTriggerType.EPHEMERAL_INDEX
+            return UiPathResumeTriggerType.INDEX_INGESTION
         if isinstance(value, (CreateBatchTransform, WaitBatchTransform)):
             return UiPathResumeTriggerType.BATCH_RAG
         if isinstance(value, (DocumentExtraction, WaitDocumentExtraction)):
@@ -477,7 +477,7 @@ class UiPathResumeTriggerCreator:
         if isinstance(value, (CreateDeepRag, WaitDeepRag)):
             return UiPathResumeTriggerName.DEEP_RAG
         if isinstance(value, (CreateEphemeralIndex, WaitEphemeralIndex)):
-            return UiPathResumeTriggerName.EPHEMERAL_INDEX
+            return UiPathResumeTriggerName.INDEX_INGESTION
         if isinstance(value, (CreateBatchTransform, WaitBatchTransform)):
             return UiPathResumeTriggerName.BATCH_RAG
         if isinstance(value, (DocumentExtraction, WaitDocumentExtraction)):
@@ -568,6 +568,12 @@ class UiPathResumeTriggerCreator:
                 await uipath.context_grounding.create_ephemeral_index_async(
                     usage=value.usage,
                     attachments=value.attachments,
+                )
+            )
+            await self._create_external_trigger(
+                ExternalTrigger(
+                    type=ExternalTriggerType.INDEX_INGESTION,
+                    external_id=ephemeral_index.id,
                 )
             )
             if not ephemeral_index:

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -590,7 +590,7 @@ class TestHitlReader:
             new=mock_retrieve_by_id,
         ):
             resume_trigger = UiPathResumeTrigger(
-                trigger_type=UiPathResumeTriggerType.EPHEMERAL_INDEX,
+                trigger_type=UiPathResumeTriggerType.INDEX_INGESTION,
                 item_key=index_id,
             )
             reader = UiPathResumeTriggerReader()
@@ -622,7 +622,7 @@ class TestHitlReader:
             new=mock_retrieve_by_id,
         ):
             resume_trigger = UiPathResumeTrigger(
-                trigger_type=UiPathResumeTriggerType.EPHEMERAL_INDEX,
+                trigger_type=UiPathResumeTriggerType.INDEX_INGESTION,
                 item_key=index_id,
             )
 
@@ -650,7 +650,7 @@ class TestHitlReader:
             new=mock_retrieve_by_id,
         ):
             resume_trigger = UiPathResumeTrigger(
-                trigger_type=UiPathResumeTriggerType.EPHEMERAL_INDEX,
+                trigger_type=UiPathResumeTriggerType.INDEX_INGESTION,
                 item_key=index_id,
             )
 
@@ -1009,7 +1009,7 @@ class TestHitlProcessor:
 
             assert resume_trigger is not None
             assert (
-                resume_trigger.trigger_type == UiPathResumeTriggerType.EPHEMERAL_INDEX
+                resume_trigger.trigger_type == UiPathResumeTriggerType.INDEX_INGESTION
             )
             assert resume_trigger.item_key == index_id
             mock_create_ephemeral_index.assert_called_once_with(
@@ -1035,7 +1035,7 @@ class TestHitlProcessor:
         resume_trigger = await processor.create_trigger(wait_ephemeral_index)
 
         assert resume_trigger is not None
-        assert resume_trigger.trigger_type == UiPathResumeTriggerType.EPHEMERAL_INDEX
+        assert resume_trigger.trigger_type == UiPathResumeTriggerType.INDEX_INGESTION
         assert resume_trigger.item_key == index_id
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.11"
+version = "2.6.12"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2560,7 +2560,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", specifier = ">=0.2.0,<0.3.0" },
-    { name = "uipath-runtime", specifier = ">=0.6.0,<0.7.0" },
+    { name = "uipath-runtime", specifier = ">=0.6.1,<0.7.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2608,14 +2608,14 @@ wheels = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e3/eb104949fd2bcd2a96870ca3ebda0229f23ff3768db3b6c1e0f33864283c/uipath_runtime-0.6.0.tar.gz", hash = "sha256:3b000ffe72ab2126ba6fa9f818220e35f60ea120412a8bbd2e18119b4b730184", size = 103627, upload-time = "2026-01-25T15:19:04.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/48/3c518940ddf54b675930c8aa1e1dade9aa99a42840ebe849e91e9f73edc1/uipath_runtime-0.6.1.tar.gz", hash = "sha256:af6753ee233a887ac1d88724bdd656a2105a2e3b5d75fb88fd24e96ec33398b9", size = 103622, upload-time = "2026-01-27T11:41:11.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/d1/2207f96ee870ca2fd1a76ec5c4ae864f55813f4562adab606cd9d30f4b35/uipath_runtime-0.6.0-py3-none-any.whl", hash = "sha256:cb78420475fa355d57c98fcbe731b5c8213a44cdc886b14ee2ed7fd78da0d7a8", size = 40764, upload-time = "2026-01-25T15:19:02.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/96/c1bbee3f82ccbffe650d51f1ab4e1f578bb83bebb44eacf9407ab9ef9de7/uipath_runtime-0.6.1-py3-none-any.whl", hash = "sha256:7ff5d0794611b30de02c9ef41960baa5f569beb997e89e98761be0c8bbf0b33c", size = 40762, upload-time = "2026-01-27T11:41:10.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
-  create external trigger for ephemeral index
depends on https://github.com/UiPath/uipath-runtime-python/pull/72
<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.6.12.dev1012124355",

  # Any version from PR
  "uipath>=2.6.12.dev1012120000,<2.6.12.dev1012130000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.6.12.dev1012120000,<2.6.12.dev1012130000",
]
```
<!-- DEV_PACKAGE_END -->