### PR TITLE
fix: assets service connection data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.6.14"
+version = "2.6.15"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/platform/orchestrator/assets.py
+++ b/src/uipath/platform/orchestrator/assets.py
@@ -15,9 +15,9 @@ class CredentialsConnectionData(BaseModel):
         arbitrary_types_allowed=True,
         extra="allow",
     )
-    url: str
-    body: str
-    bearer_token: str = Field(alias="bearerToken")
+    url: str = Field(alias="Url")
+    body: str = Field(alias="Body")
+    bearer_token: str = Field(alias="BearerToken")
 
 
 class UserAsset(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.14"
+version = "2.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
# Description 
3 validation errors for UserAsset ConnectionData.url Field required [type=missing, input_value={'Url': 'https://uipathcr...IIvvLY8EcD5DKsdMdOWlRA'}, input_type=dict] For further information visit https://errors.pydantic.dev/2.12/v/missing ConnectionData.body Field required [type=missing, input_value={'Url': 'https://uipathcr...IIvvLY8EcD5DKsdMdOWlRA'}, input_type=dict] For further information visit https://errors.pydantic.dev/2.12/v/missing ConnectionData.bearerToken Field required [type=missing, input_value={'Url': 'https://uipathcr...IIvvLY8EcD5DKsdMdOWlRA'}, input_type=dict] For further information visit https://errors.pydantic.dev/2.12/v/missing

Orchestrator ones. 
<img width="613" height="508" alt="image" src="https://github.com/user-attachments/assets/836c12a6-c668-44c3-86bb-bfe162ac4467" />
