### PR TITLE
feat: extend invoke process with attachments support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.6.17"
+version = "2.6.18"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/platform/attachments/attachments.py
+++ b/src/uipath/platform/attachments/attachments.py
@@ -3,7 +3,7 @@
 import uuid
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -18,10 +18,10 @@ class AttachmentMode(str, Enum):
 class Attachment(BaseModel):
     """Model representing an attachment. Id 'None' is used for uploads."""
 
-    id: Optional[uuid.UUID] = Field(None, alias="ID")
+    id: uuid.UUID = Field(..., alias="ID")
     full_name: str = Field(..., alias="FullName")
     mime_type: str = Field(..., alias="MimeType")
-    metadata: Optional[dict[str, str]] = Field(None, alias="Metadata")
+    metadata: Optional[dict[str, Any]] = Field(None, alias="Metadata")
     model_config = {
         "title": "UiPathAttachment",
         "validate_by_name": True,

--- a/src/uipath/platform/common/interrupt_models.py
+++ b/src/uipath/platform/common/interrupt_models.py
@@ -9,6 +9,7 @@ from uipath.platform.context_grounding.context_grounding_index import (
 )
 
 from ..action_center.tasks import Task, TaskRecipient
+from ..attachments import Attachment
 from ..context_grounding import (
     BatchTransformCreationResponse,
     BatchTransformOutputColumn,
@@ -33,6 +34,7 @@ class InvokeProcess(BaseModel):
     process_folder_path: str | None = None
     process_folder_key: str | None = None
     input_arguments: dict[str, Any] | None
+    attachments: list[Attachment] | None = None
 
 
 class WaitJob(BaseModel):

--- a/src/uipath/platform/resume_triggers/_protocol.py
+++ b/src/uipath/platform/resume_triggers/_protocol.py
@@ -774,6 +774,7 @@ class UiPathResumeTriggerCreator:
             job = await uipath.processes.invoke_async(
                 name=value.name,
                 input_arguments=value.input_arguments,
+                attachments=value.attachments,
                 folder_path=value.process_folder_path,
                 folder_key=value.process_folder_key,
             )

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -891,6 +891,7 @@ class TestHitlProcessor:
             mock_process_invoke_async.assert_called_once_with(
                 name=invoke_process.name,
                 input_arguments=invoke_process.input_arguments,
+                attachments=None,
                 folder_path=invoke_process.process_folder_path,
                 folder_key=None,
             )

--- a/tests/sdk/services/test_attachments_service.py
+++ b/tests/sdk/services/test_attachments_service.py
@@ -993,6 +993,7 @@ class TestAttachmentsService:
         file_name = "test_write_file.txt"
         file_content = b"Content to write"
         attachment = Attachment(  # type: ignore[call-arg]
+            ID=uuid.uuid4(),
             FullName=file_name,
             MimeType="text/plain",
         )
@@ -1144,6 +1145,7 @@ class TestAttachmentsService:
         file_name = "test_write_file_async.txt"
         file_content = b"Content to write async"
         attachment = Attachment(  # type: ignore[call-arg]
+            ID=uuid.uuid4(),
             FullName=file_name,
             MimeType="text/plain",
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.17"
+version = "2.6.18"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## What changed?
- add Attachment on InvokeProcess model
- add Attachment argument on invoke process to further leverage starting jobs with existing attachments
- fix attachment metadata
- update tests to new assertions