### PR TITLE
fix: apply bindings on ixp buckets

### DIFF
--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -21,6 +21,7 @@ from uipath.core.guardrails import (
 )
 
 from uipath.platform.connections import Connection
+from uipath.platform.documents import ActionPriority
 from uipath.platform.guardrails import (
     BuiltInValidatorGuardrail,
 )
@@ -444,10 +445,10 @@ def _resolve_task_title(v: Any) -> Any:
 class AgentEscalationChannelProperties(BaseResourceProperties):
     """Agent escalation channel properties model."""
 
-    app_name: str | None = Field(..., alias="appName")
+    app_name: str | None = Field(default=None, alias="appName")
     app_version: int = Field(..., alias="appVersion")
     folder_name: Optional[str] = Field(None, alias="folderName")
-    resource_key: str | None = Field(..., alias="resourceKey")
+    resource_key: str | None = Field(default=None, alias="resourceKey")
     is_actionable_message_enabled: Optional[bool] = Field(
         None, alias="isActionableMessageEnabled"
     )
@@ -500,6 +501,8 @@ class AgentIxpVsEscalationProperties(BaseCfg):
     """VS escalation properties model."""
 
     ixp_tool_id: str = Field(..., alias="ixpToolId")
+    action_title: str | None = Field(default=None, alias="actionTitle")
+    action_priority: ActionPriority | None = Field(default=None, alias="actionPriority")
     storage_bucket_name: str = Field(..., alias="storageBucketName")
     storage_bucket_folder_path: str = Field(..., alias="storageBucketFolderPath")
 

--- a/src/uipath/platform/documents/_documents_service.py
+++ b/src/uipath/platform/documents/_documents_service.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 from uuid import UUID
 
-from ..._utils import Endpoint
+from ..._utils import Endpoint, resource_override
 from ...tracing import traced
 from ..common import BaseService, FolderContext, UiPathApiConfig, UiPathExecutionContext
 from ..errors import OperationFailedException, OperationNotCompleteException
@@ -1546,6 +1546,11 @@ class DocumentsService(FolderContext, BaseService):
             extraction_response=extraction_response,
         )
 
+    @resource_override(
+        resource_type="bucket",
+        resource_identifier="storage_bucket_name",
+        folder_identifier="action_folder",
+    )
     @traced(
         name="documents_start_ixp_extraction_validation_async",
         run_type="uipath",
@@ -1575,6 +1580,11 @@ class DocumentsService(FolderContext, BaseService):
             extraction_response=extraction_response,
         )
 
+    @resource_override(
+        resource_type="bucket",
+        resource_identifier="storage_bucket_name",
+        folder_identifier="action_folder",
+    )
     @traced(
         name="documents_retrieve_ixp_extraction_validation_result",
         run_type="uipath",


### PR DESCRIPTION
- apply bindings on ixp buckets
- include missing vs escalation fields