### PR TITLE
feat(cli): add --wait-for-triggers flag for local execution without orchestrator (WIP)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.2.0, <0.3.0",
-  "uipath-runtime>=0.6.0, <0.7.0",
+  # TODO: Change back to "uipath-runtime>=0.7.0, <0.8.0" once PR #74 is merged and released
+  "uipath-runtime @ git+https://github.com/UiPath/uipath-runtime-python.git@feature/wait-for-triggers",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",


### PR DESCRIPTION
## Summary

- Add `--wait-for-triggers` CLI flag to poll triggers until completion instead of suspending
- Add `--trigger-poll-interval` CLI flag for configurable poll interval (default: 5.0s)
- Update `pyproject.toml` to reference `uipath-runtime` from PR #74 branch

This enables running agents locally with tool calls (InvokeProcess, CreateTask, etc.) without requiring serverless/orchestrator infrastructure.

## Usage

```bash
# Run with wait-for-triggers enabled (polls every 5 seconds by default)
uipath run my_agent.main '{"query": "hello"}' --wait-for-triggers

# With custom poll interval (10 seconds)
uipath run my_agent.main '{"query": "hello"}' --wait-for-triggers --trigger-poll-interval 10.0
```

## Dependencies

- **Depends on:** https://github.com/UiPath/uipath-runtime-python/pull/74

> ⚠️ **Note:** The `pyproject.toml` currently references the git branch from PR #74. Once that PR is merged and released, update the dependency back to a version constraint like `uipath-runtime>=0.7.0, <0.8.0`.

## Test plan

- [ ] Test `uipath run` with `--wait-for-triggers` flag locally
- [ ] Verify triggers are polled and execution resumes automatically
- [ ] Test with different trigger types (Job, Task, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)