### PR TITLE
feat: update vendor endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.6.22"
+version = "2.6.23"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/platform/_uipath.py
+++ b/src/uipath/platform/_uipath.py
@@ -6,7 +6,13 @@ from pydantic import ValidationError
 from .._utils._auth import resolve_config_from_env
 from .action_center import TasksService
 from .agenthub._agenthub_service import AgentHubService
-from .chat import ConversationsService, UiPathLlmChatService, UiPathOpenAIService
+from .chat import (
+    ConversationsService,
+    UiPathBedrockService,
+    UiPathLlmChatService,
+    UiPathOpenAIService,
+    UiPathVertexService,
+)
 from .common import (
     ApiClient,
     ExternalApplicationService,
@@ -132,6 +138,14 @@ class UiPath:
     @property
     def llm(self) -> UiPathLlmChatService:
         return UiPathLlmChatService(self._config, self._execution_context)
+
+    @property
+    def llm_vertex(self) -> UiPathVertexService:
+        return UiPathVertexService(self._config, self._execution_context)
+
+    @property
+    def llm_bedrock(self) -> UiPathBedrockService:
+        return UiPathBedrockService(self._config, self._execution_context)
 
     @property
     def entities(self) -> EntitiesService:

--- a/src/uipath/platform/chat/__init__.py
+++ b/src/uipath/platform/chat/__init__.py
@@ -7,13 +7,19 @@ This module provides services for chat-related functionality including:
 
 from ._conversations_service import ConversationsService
 from ._llm_gateway_service import (
+    APIFlavor,
+    BedrockModels,
     ChatModels,
     EmbeddingModels,
+    GeminiModels,
+    UiPathBedrockService,
     UiPathLlmChatService,
     UiPathOpenAIService,
+    UiPathVertexService,
 )
 from .llm_gateway import (
     AutoToolChoice,
+    BedrockCompletion,
     ChatCompletion,
     ChatCompletionChoice,
     ChatCompletionUsage,
@@ -29,6 +35,7 @@ from .llm_gateway import (
     ToolFunctionDefinition,
     ToolParametersDefinition,
     ToolPropertyDefinition,
+    VertexCompletion,
 )
 from .llm_throttle import get_llm_semaphore, set_llm_concurrency
 
@@ -36,10 +43,15 @@ __all__ = [
     # Conversations Service
     "ConversationsService",
     # LLM Gateway Services
+    "APIFlavor",
+    "BedrockModels",
     "ChatModels",
     "EmbeddingModels",
+    "GeminiModels",
+    "UiPathBedrockService",
     "UiPathLlmChatService",
     "UiPathOpenAIService",
+    "UiPathVertexService",
     # LLM Throttling
     "get_llm_semaphore",
     "set_llm_concurrency",
@@ -55,6 +67,8 @@ __all__ = [
     "ChatCompletionChoice",
     "ChatCompletionUsage",
     "ChatCompletion",
+    "VertexCompletion",
+    "BedrockCompletion",
     "EmbeddingItem",
     "EmbeddingUsage",
     "TextEmbedding",

--- a/src/uipath/platform/chat/llm_gateway.py
+++ b/src/uipath/platform/chat/llm_gateway.py
@@ -126,3 +126,76 @@ class ChatCompletion(BaseModel):
     model: str
     choices: List[ChatCompletionChoice]
     usage: ChatCompletionUsage
+
+
+class VertexPart(BaseModel):
+    """Model representing a part in a Vertex AI response."""
+
+    text: Optional[str] = None
+
+
+class VertexContent(BaseModel):
+    """Model representing content in a Vertex AI response."""
+
+    role: str
+    parts: List[VertexPart]
+
+
+class VertexCandidate(BaseModel):
+    """Model representing a candidate in a Vertex AI response."""
+
+    content: VertexContent
+    finishReason: Optional[str] = None
+    avgLogprobs: Optional[float] = None
+
+
+class VertexUsageMetadata(BaseModel):
+    """Model representing usage metadata in a Vertex AI response."""
+
+    promptTokenCount: Optional[int] = None
+    candidatesTokenCount: Optional[int] = None
+    totalTokenCount: Optional[int] = None
+
+
+class VertexCompletion(BaseModel):
+    """Model representing a Vertex AI (Gemini) completion response."""
+
+    candidates: List[VertexCandidate]
+    usageMetadata: Optional[VertexUsageMetadata] = None
+    modelVersion: Optional[str] = None
+
+
+class BedrockContentBlock(BaseModel):
+    """Model representing a content block in a Bedrock response."""
+
+    text: Optional[str] = None
+
+
+class BedrockMessage(BaseModel):
+    """Model representing a message in a Bedrock response."""
+
+    role: str
+    content: List[BedrockContentBlock]
+
+
+class BedrockOutput(BaseModel):
+    """Model representing output in a Bedrock response."""
+
+    message: BedrockMessage
+
+
+class BedrockUsage(BaseModel):
+    """Model representing usage statistics in a Bedrock response."""
+
+    inputTokens: Optional[int] = None
+    outputTokens: Optional[int] = None
+    totalTokens: Optional[int] = None
+
+
+class BedrockCompletion(BaseModel):
+    """Model representing an AWS Bedrock completion response."""
+
+    output: BedrockOutput
+    stopReason: Optional[str] = None
+    usage: Optional[BedrockUsage] = None
+    metrics: Optional[Dict[str, Any]] = None

--- a/testcases/apicalls-testcase/main.py
+++ b/testcases/apicalls-testcase/main.py
@@ -6,7 +6,7 @@ from uipath.platform.orchestrator import AssetsService, AttachmentsService, Buck
 from uipath.platform.action_center import TasksService
 from uipath.platform.connections import ConnectionsService
 from uipath.platform.context_grounding import ContextGroundingService
-from uipath.platform.chat import ConversationsService
+from uipath.platform.chat import ConversationsService, UiPathVertexService, UiPathBedrockService, GeminiModels, BedrockModels, APIFlavor
 from uipath.platform.documents import DocumentsService
 from uipath.platform.entities import EntitiesService
 from uipath.platform.resource_catalog import ResourceCatalogService
@@ -36,6 +36,62 @@ async def test_llm(sdk: UiPath):
         "LLM Normalized Response: %s", result_normalized.choices[0].message.content
     )
 
+
+async def test_llm_vertex(sdk: UiPath):
+    contents = [
+        {
+            "role": "user",
+            "parts": [{"text": "What is the capital of France? Answer in one word."}]
+        }
+    ]
+
+    result = await sdk.llm_vertex.generate_content(
+        contents,
+        model=GeminiModels.gemini_2_5_flash,
+        generation_config={
+            "temperature": 0.7,
+            "maxOutputTokens": 100,
+        }
+    )
+    logger.info("LLM Vertex Response: %s", result)
+
+
+async def test_llm_bedrock(sdk: UiPath):
+    messages = [
+        {
+            "role": "user",
+            "content": [{"text": "What is the capital of France? Answer in one word."}]
+        }
+    ]
+
+    result_converse = await sdk.llm_bedrock.converse(
+        messages,
+        model=BedrockModels.anthropic_claude_haiku_4_5,
+        inference_config={
+            "maxTokens": 100,
+            "temperature": 0.7,
+        }
+    )
+    logger.info("LLM Bedrock Converse Response: %s", result_converse)
+
+    messages_invoke = [
+        {
+            "role": "user",
+            "content": [{"text": "What is the capital of Germany? Answer in one word."}]
+        }
+    ]
+
+    result_invoke = await sdk.llm_bedrock.converse(
+        messages_invoke,
+        model=BedrockModels.anthropic_claude_haiku_4_5,
+        inference_config={
+            "maxTokens": 100,
+            "temperature": 0.7,
+        },
+        api_flavor=APIFlavor.AWS_BEDROCK_INVOKE,
+    )
+    logger.info("LLM Bedrock Invoke Response: %s", result_invoke)
+
 async def test_imports(sdk: UiPath):
     logger.info("BucketsService imported: %s", BucketsService)
     logger.info("QueuesService imported: %s", QueuesService)
@@ -52,6 +108,10 @@ async def test_imports(sdk: UiPath):
     logger.info("ProcessesService imported: %s", ProcessesService)
     logger.info("ResourceCatalogService imported: %s", ResourceCatalogService)
     logger.info("TasksService imported: %s", TasksService)
+    logger.info("UiPathVertexService imported: %s", UiPathVertexService)
+    logger.info("UiPathBedrockService imported: %s", UiPathBedrockService)
+    logger.info("GeminiModels imported: %s", GeminiModels)
+    logger.info("BedrockModels imported: %s", BedrockModels)
     logger.info("Imports test passed.")
 
 @dataclass
@@ -68,6 +128,8 @@ async def main(input: EchoIn) -> EchoOut:
     sdk = UiPath()
 
     await test_llm(sdk)
+    await test_llm_vertex(sdk)
+    await test_llm_bedrock(sdk)
     await test_imports(sdk)
 
     return EchoOut(message=input.message)

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.22"
+version = "2.6.23"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
This PR updates the passthrough endpoint used for chat clients and introduces 2 new clients:
* UiPathBedrockService
* UiPathVertexService