### PR TITLE
refactor(DecoupleLoadFromRuntime): decouple eval load from eval runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.6.26"
+version = "2.6.27"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/_span_utils.py
+++ b/src/uipath/_cli/_evals/_span_utils.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Type hint for runtime protocol (avoids circular imports)
 try:
-    from uipath.runtime import UiPathRuntimeProtocol
+    from uipath.runtime import UiPathRuntimeProtocol, UiPathRuntimeSchema
 except ImportError:
     UiPathRuntimeProtocol = Any  # type: ignore
 
@@ -192,8 +192,7 @@ async def configure_eval_set_run_span(
     span: Span,
     evaluator_averages: Dict[str, float],
     execution_id: str,
-    runtime: Any,
-    get_schema_func: Any,
+    schema: UiPathRuntimeSchema,
     success: bool = True,
 ) -> None:
     """Configure Evaluation Set Run span with output and metadata.
@@ -216,7 +215,6 @@ async def configure_eval_set_run_span(
 
     # Get runtime schemas
     try:
-        schema = await get_schema_func(runtime)
         input_schema = schema.input
         output_schema = schema.output
     except Exception:

--- a/tests/cli/eval/test_eval_span_utils.py
+++ b/tests/cli/eval/test_eval_span_utils.py
@@ -286,8 +286,7 @@ class TestHighLevelConfigurationFunctions:
             "eval2": 90.0,
         }
 
-        # Mock runtime and get_schema_func
-        mock_runtime = MagicMock()
+        # Mock schema
         mock_schema = MagicMock()
         mock_schema.input = {
             "type": "object",
@@ -295,15 +294,11 @@ class TestHighLevelConfigurationFunctions:
         }
         mock_schema.output = {"type": "string"}
 
-        async def mock_get_schema(runtime):
-            return mock_schema
-
         await configure_eval_set_run_span(
             span=span,  # type: ignore[arg-type]
             evaluator_averages=evaluator_averages,
             execution_id="exec-complete",
-            runtime=mock_runtime,
-            get_schema_func=mock_get_schema,
+            schema=mock_schema,
             success=True,
         )
 
@@ -331,16 +326,16 @@ class TestHighLevelConfigurationFunctions:
 
         evaluator_averages = {"eval1": 75.0}
 
-        # Mock get_schema_func that raises exception
-        async def mock_get_schema_error(runtime):
-            raise Exception("Schema not found")
+        # Mock schema with missing fields
+        mock_schema = MagicMock()
+        mock_schema.input = None
+        mock_schema.output = None
 
         await configure_eval_set_run_span(
             span=span,  # type: ignore[arg-type]
             evaluator_averages=evaluator_averages,
             execution_id="exec-no-schema",
-            runtime=MagicMock(),
-            get_schema_func=mock_get_schema_error,
+            schema=mock_schema,
             success=True,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.6.26"
+version = "2.6.27"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
This allows customers to run evals dynamically without having to materialize to files.


<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.6.27.dev1012444492",

  # Any version from PR
  "uipath>=2.6.27.dev1012440000,<2.6.27.dev1012450000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.6.27.dev1012440000,<2.6.27.dev1012450000",
]
```
<!-- DEV_PACKAGE_END -->