### PR TITLE
refactor(RemoveRedundantDefinitions): remove redundant evaluator definitions

### DIFF
--- a/src/uipath/_cli/_evals/_evaluator_factory.py
+++ b/src/uipath/_cli/_evals/_evaluator_factory.py
@@ -10,12 +10,12 @@ from uipath._cli._evals._helpers import (  # type: ignore # Remove after gnarly 
     try_extract_file_and_class_name,
 )
 from uipath._cli._evals._models._evaluator import (
-    EqualsEvaluatorParams,
     EvaluatorConfig,
-    JsonSimilarityEvaluatorParams,
+    LegacyEqualsEvaluatorParams,
     LegacyEvaluator,
-    LLMEvaluatorParams,
-    TrajectoryEvaluatorParams,
+    LegacyJsonSimilarityEvaluatorParams,
+    LegacyLLMEvaluatorParams,
+    LegacyTrajectoryEvaluatorParams,
 )
 from uipath._cli._evals._models._evaluator_base_params import EvaluatorBaseParams
 from uipath._utils.constants import EVALS_FOLDER
@@ -401,15 +401,15 @@ class EvaluatorFactory:
         params: EvaluatorBaseParams = TypeAdapter(LegacyEvaluator).validate_python(data)
 
         match params:
-            case EqualsEvaluatorParams():
+            case LegacyEqualsEvaluatorParams():
                 return EvaluatorFactory._create_legacy_exact_match_evaluator(params)
-            case JsonSimilarityEvaluatorParams():
+            case LegacyJsonSimilarityEvaluatorParams():
                 return EvaluatorFactory._create_legacy_json_similarity_evaluator(params)
-            case LLMEvaluatorParams():
+            case LegacyLLMEvaluatorParams():
                 return EvaluatorFactory._create_legacy_llm_as_judge_evaluator(
                     params, agent_model
                 )
-            case TrajectoryEvaluatorParams():
+            case LegacyTrajectoryEvaluatorParams():
                 return EvaluatorFactory._create_legacy_trajectory_evaluator(
                     params, agent_model
                 )
@@ -418,21 +418,21 @@ class EvaluatorFactory:
 
     @staticmethod
     def _create_legacy_exact_match_evaluator(
-        params: EqualsEvaluatorParams,
+        params: LegacyEqualsEvaluatorParams,
     ) -> LegacyExactMatchEvaluator:
         """Create a deterministic evaluator."""
         return LegacyExactMatchEvaluator(**params.model_dump(), config={})
 
     @staticmethod
     def _create_legacy_json_similarity_evaluator(
-        params: JsonSimilarityEvaluatorParams,
+        params: LegacyJsonSimilarityEvaluatorParams,
     ) -> LegacyJsonSimilarityEvaluator:
         """Create a deterministic evaluator."""
         return LegacyJsonSimilarityEvaluator(**params.model_dump(), config={})
 
     @staticmethod
     def _create_legacy_llm_as_judge_evaluator(
-        params: LLMEvaluatorParams,
+        params: LegacyLLMEvaluatorParams,
         agent_model: str | None = None,
     ) -> LegacyBaseEvaluator[Any]:
         """Create an LLM-as-a-judge evaluator or context precision evaluator based on type."""
@@ -465,7 +465,7 @@ class EvaluatorFactory:
 
     @staticmethod
     def _create_legacy_trajectory_evaluator(
-        params: TrajectoryEvaluatorParams,
+        params: LegacyTrajectoryEvaluatorParams,
         agent_model: str | None = None,
     ) -> LegacyTrajectoryEvaluator:
         """Create a trajectory evaluator."""

--- a/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/src/uipath/_cli/_evals/_progress_reporter.py
@@ -16,7 +16,6 @@ from uipath._cli._evals._models._evaluation_set import (
     EvaluationItem,
     EvaluationStatus,
 )
-from uipath._cli._evals._models._evaluator import Evaluator
 from uipath._cli._evals._models._sw_reporting import (
     StudioWebAgentSnapshot,
     StudioWebProgressItem,
@@ -453,7 +452,7 @@ class StudioWebProgressReporter:
     async def update_eval_run(
         self,
         sw_progress_item: StudioWebProgressItem,
-        evaluators: dict[str, Evaluator],
+        evaluators: dict[str, BaseEvaluator[Any, Any, Any]],
         is_coded: bool = False,
         spans: list[Any] | None = None,
     ):

--- a/src/uipath/agent/models/evals.py
+++ b/src/uipath/agent/models/evals.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from pydantic import Field
 
 from uipath._cli._evals._models._evaluation_set import EvaluationSet
-from uipath._cli._evals._models._evaluator import Evaluator
+from uipath._cli._evals._models._evaluator import LegacyEvaluator
 from uipath.agent.models.agent import (
     AgentDefinition,
 )
@@ -22,6 +22,6 @@ class AgentEvalsDefinition(AgentDefinition):
         alias="evaluationSets",
         description="List of agent evaluation sets",
     )
-    evaluators: Optional[List[Evaluator]] = Field(
+    evaluators: Optional[List[LegacyEvaluator]] = Field(
         None, description="List of agent evaluators"
     )


### PR DESCRIPTION
<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.6.28.dev1012514503",

  # Any version from PR
  "uipath>=2.6.28.dev1012510000,<2.6.28.dev1012520000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.6.28.dev1012510000,<2.6.28.dev1012520000",
]
```
<!-- DEV_PACKAGE_END -->