### PR TITLE
feat: coded functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.9.15"
+version = "2.10.0"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -369,7 +369,7 @@ def init(no_agents_md_override: bool) -> None:
 
                     if not entrypoints:
                         console.warning(
-                            'No function entrypoints found. Add them to `uipath.json` under "functions": {"my_function": "src/main.py:main"}'
+                            'No entrypoints found. Add them to `uipath.json` under "functions" or "agents": {"my_function": "src/main.py:main"}'
                         )
 
                     # Gather schemas from all discovered runtimes

--- a/src/uipath/_cli/models/uipath_json_schema.py
+++ b/src/uipath/_cli/models/uipath_json_schema.py
@@ -89,6 +89,12 @@ class UiPathJsonConfig(BaseModelWithDefaultConfig):
         "Each key is an entrypoint name, and each value is a path in format 'file_path:function_name'",
     )
 
+    agents: dict[str, str] = Field(
+        default_factory=dict,
+        description="Entrypoint definitions for agent scripts. "
+        "Each key is an entrypoint name, and each value is a path in format 'file_path:agent_name'",
+    )
+
     def to_json_string(self, indent: int = 2) -> str:
         """Export to JSON string with proper formatting."""
         return self.model_dump_json(
@@ -110,6 +116,7 @@ class UiPathJsonConfig(BaseModelWithDefaultConfig):
                 include_uv_lock=True,
             ),
             functions={},
+            agents={},
         )
 
     @classmethod

--- a/src/uipath/functions/factory.py
+++ b/src/uipath/functions/factory.py
@@ -45,22 +45,18 @@ class UiPathFunctionsRuntimeFactory:
         return self._config
 
     def discover_entrypoints(self) -> list[str]:
-        """Discover all function entrypoints from uipath.json."""
+        """Discover all entrypoints (functions and agents) from uipath.json."""
         config = self._load_config()
-        return list(config.get("functions", {}).keys())
+        functions = list(config.get("functions", {}).keys())
+        agents = list(config.get("agents", {}).keys())
+        return functions + agents
 
     async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
         """Get storage protocol if any (placeholder for protocol compliance)."""
         return None
 
     async def get_settings(self) -> UiPathRuntimeFactorySettings | None:
-        """Get factory settings for coded functions.
-
-        Coded functions don't need span filtering - all spans are relevant
-        since developers have full control over instrumentation.
-
-        Low-code agents (LangGraph) need filtering due to framework overhead.
-        """
+        """Get factory settings for coded functions."""
         return None
 
     async def new_runtime(
@@ -77,14 +73,21 @@ class UiPathFunctionsRuntimeFactory:
         """Create runtime instance from entrypoint specification."""
         config = self._load_config()
         functions = config.get("functions", {})
+        agents = config.get("agents", {})
 
-        if entrypoint not in functions:
+        # Check both functions and agents
+        if entrypoint in functions:
+            func_spec = functions[entrypoint]
+            entrypoint_type = "function"
+        elif entrypoint in agents:
+            func_spec = agents[entrypoint]
+            entrypoint_type = "agent"
+        else:
+            available = list(functions.keys()) + list(agents.keys())
             raise ValueError(
                 f"Entrypoint '{entrypoint}' not found in uipath.json. "
-                f"Available: {', '.join(functions.keys())}"
+                f"Available: {', '.join(available)}"
             )
-
-        func_spec = functions[entrypoint]
 
         if ":" not in func_spec:
             raise ValueError(
@@ -98,7 +101,9 @@ class UiPathFunctionsRuntimeFactory:
         if not full_path.exists():
             raise ValueError(f"File not found: {full_path}")
 
-        inner = UiPathFunctionsRuntime(str(full_path), function_name, entrypoint)
+        inner = UiPathFunctionsRuntime(
+            str(full_path), function_name, entrypoint, entrypoint_type
+        )
         return UiPathDebugFunctionsRuntime(
             delegate=inner,
             entrypoint_path=str(full_path),

--- a/src/uipath/functions/runtime.py
+++ b/src/uipath/functions/runtime.py
@@ -39,11 +39,25 @@ logger = logging.getLogger(__name__)
 class UiPathFunctionsRuntime:
     """Runtime wrapper for a single Python function with full script executor compatibility."""
 
-    def __init__(self, file_path: str, function_name: str, entrypoint_name: str):
-        """Initialize the function runtime."""
+    def __init__(
+        self,
+        file_path: str,
+        function_name: str,
+        entrypoint_name: str,
+        entrypoint_type: str = "function",
+    ):
+        """Initialize the function runtime.
+
+        Args:
+            file_path: Path to the Python file containing the function
+            function_name: Name of the function to execute
+            entrypoint_name: Name of the entrypoint
+            entrypoint_type: Type of entrypoint - 'function' or 'agent'
+        """
         self.file_path = Path(file_path)
         self.function_name = function_name
         self.entrypoint_name = entrypoint_name
+        self.entrypoint_type = entrypoint_type
         self._function: Callable[..., Any] | None = None
         self._module: ModuleType | None = None
 
@@ -240,7 +254,7 @@ class UiPathFunctionsRuntime:
         return UiPathRuntimeSchema(
             filePath=self.entrypoint_name,
             uniqueId=str(uuid.uuid4()),
-            type="agent",
+            type=self.entrypoint_type,
             input=input_schema,
             output=output_schema,
             graph=graph,

--- a/tests/functions/test_unwrap_decorated.py
+++ b/tests/functions/test_unwrap_decorated.py
@@ -71,3 +71,28 @@ async def test_execute_unwraps_decorated_function(decorated_module):
     assert isinstance(result.output, dict)
     assert result.output["total_nodes"] == 1
     assert result.output["max_value"] == 42
+
+
+@pytest.mark.asyncio
+async def test_schema_type_defaults_to_function(decorated_module):
+    """Schema type should be 'function' by default."""
+    runtime = UiPathFunctionsRuntime(str(decorated_module), "main", "decorated")
+    schema = await runtime.get_schema()
+
+    assert schema.type == "function"
+
+
+@pytest.mark.asyncio
+async def test_schema_type_reflects_entrypoint_type(decorated_module):
+    """Schema type should reflect the entrypoint_type passed to the runtime."""
+    runtime_fn = UiPathFunctionsRuntime(
+        str(decorated_module), "main", "decorated", entrypoint_type="function"
+    )
+    schema_fn = await runtime_fn.get_schema()
+    assert schema_fn.type == "function"
+
+    runtime_agent = UiPathFunctionsRuntime(
+        str(decorated_module), "main", "decorated", entrypoint_type="agent"
+    )
+    schema_agent = await runtime_agent.get_schema()
+    assert schema_agent.type == "agent"

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.9.15"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Description


  - Add agents entrypoint type alongside existing functions in uipath.json, allowing agent scripts to be registered
  separately from plain functions
  - Breaking change: The runtime schema type field was previously hardcoded to "agent" for all entrypoints. It now
  correctly reflects the entrypoint type, "function" for entries in functions and "agent" for entries in agents.
  Existing functions entrypoints that were previously reported as "agent" will now be reported as "function".
  - Update entrypoint discovery, resolution, and CLI warning messages to handle both functions and agents sections
  - Bump version to 2.10.0

 ## Breaking changes

Entrypoints declared under "functions" in uipath.json previously had their schema type set to "agent". They now correctly resolve to "function". 

**If you have entrypoints that should be treated as agents, move them from the "functions" section to the new "agents" section in uipath.json.**

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.0.dev1012545080",

  # Any version from PR
  "uipath>=2.10.0.dev1012540000,<2.10.0.dev1012550000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.10.0.dev1012540000,<2.10.0.dev1012550000",
]
```
<!-- DEV_PACKAGE_END -->