### PR TITLE
feat(Mocking): make it easier to match any input in mockito

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.7.5"
+version = "2.7.6"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_evals/mocks/types.py
+++ b/src/uipath/_cli/_evals/mocks/types.py
@@ -67,7 +67,7 @@ class MockingAnswer(BaseModel):
 
 class MockingBehavior(BaseModel):
     function: str = Field(..., alias="function")
-    arguments: MockingArgument = Field(..., alias="arguments")
+    arguments: MockingArgument | None = Field(default=None, alias="arguments")
     then: list[MockingAnswer] = Field(..., alias="then")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.7.5"
+version = "2.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
This PR makes it easier to set up Mockito deterministic mocks in the case where we want it to always return a constant value (probably the most common case in practice).

Current design - explicit matching required using `mockito.matchers.Any`
                                                                                         
```
  {                                                                                                                                       
    "function": "my_tool",                                                                                                                
    "arguments": {                                                                                                                        
      "kwargs": {                                                                                                                         
        "param1": {"_target_": "mockito.matchers.Any"},                                                                                   
        "param2": {"_target_": "mockito.matchers.Any"}                                                                                    
      }                                                                                                                                   
    },                                                                                                                                    
    "then": [{"type": "return", "value": "result"}]                                                                                       
  }
```

Improved design: arguments is optional, if omitted, always match

```
  {                                                                                                                                       
    "function": "my_tool",                                                                                                                
    "then": [{"type": "return", "value": "result"}]                                                                                       
  }
```