### PR TITLE
fix: serialize UUIDs explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.7.3"
+version = "2.7.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -1,5 +1,6 @@
 import json
 import os
+import uuid
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
@@ -89,6 +90,9 @@ def serialize_object(obj):
             return serialize_object(dict(obj))
         except (TypeError, ValueError):
             return obj
+    # UUIDs must be serialized explicitly
+    elif isinstance(obj, uuid.UUID):
+        return str(obj)
     # Return primitive types as is
     else:
         return obj

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.7.3"
+version = "2.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
json.dumps does not implicitly serialize UUIDs, instead throwing an exception.
Job attachment IDs are UUIDs