### PR TITLE
fix: remove the extra exporter and processor for studioweb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.7.10"
+version = "2.7.11"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/cli_eval.py
+++ b/src/uipath/_cli/cli_eval.py
@@ -344,22 +344,12 @@ def eval(
                         factory_settings.trace_settings if factory_settings else None
                     )
 
-                    if ctx.job_id:
-                        # Orchestrator live tracking
+                    if ctx.job_id or should_register_progress_reporter:
+                        # Live tracking for Orchestrator or Studio Web
+                        # Uses UIPATH_TRACE_ID from environment for trace correlation
                         trace_manager.add_span_processor(
                             LiveTrackingSpanProcessor(
                                 LlmOpsHttpExporter(),
-                                settings=trace_settings,
-                            )
-                        )
-
-                    if should_register_progress_reporter:
-                        # Studio Web live tracking
-                        trace_manager.add_span_processor(
-                            LiveTrackingSpanProcessor(
-                                LlmOpsHttpExporter(
-                                    trace_id=eval_context.eval_set_run_id
-                                ),
                                 settings=trace_settings,
                             )
                         )

--- a/uv.lock
+++ b/uv.lock
@@ -2491,7 +2491,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.7.10"
+version = "2.7.11"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Removed extra exporter and processor for studioweb from CLI eval module
- Bumped version to 2.7.2

## Changes
- Cleaned up redundant telemetry configuration in `src/uipath/_cli/cli_eval.py`
- Updated package version in `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


need to wait for Agents Pr  to merge https://github.com/UiPath/Agents/pull/4271