### PR TITLE
fix: support Claude 4.5 models in LLM evaluators and gateway

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.15"
+version = "2.8.16"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/samples/calculator/evaluations/eval-sets/default.json
+++ b/samples/calculator/evaluations/eval-sets/default.json
@@ -9,7 +9,9 @@
     "LLMJudgeOutputEvaluator",
     "LLMJudgeStrictJSONSimilarityOutputEvaluator",
     "TrajectoryEvaluator",
-    "CorrectOperatorEvaluator"
+    "CorrectOperatorEvaluator",
+    "LLMJudgeHaiku45",
+    "LLMJudgeSonnet45"
   ],
   "evaluations": [
     {
@@ -49,6 +51,16 @@
         },
         "TrajectoryEvaluator": {
           "expectedAgentBehavior": "The agent should correctly parse the multiply operation, perform the calculation 2 * 4, and return the result 8.0"
+        },
+        "LLMJudgeHaiku45": {
+          "expectedOutput": {
+            "result": 8.0
+          }
+        },
+        "LLMJudgeSonnet45": {
+          "expectedOutput": {
+            "result": 8.0
+          }
         }
       },
       "mockingStrategy": {
@@ -87,7 +99,9 @@
         "LLMJudgeOutputEvaluator": null,
         "LLMJudgeStrictJSONSimilarityOutputEvaluator": null,
         "TrajectoryEvaluator": null,
-        "CorrectOperatorEvaluator": null
+        "CorrectOperatorEvaluator": null,
+        "LLMJudgeHaiku45": null,
+        "LLMJudgeSonnet45": null
       }
     },
     {
@@ -127,6 +141,16 @@
         },
         "TrajectoryEvaluator": {
           "expectedAgentBehavior": "The agent should correctly parse the multiply operation, perform the calculation 2 * 4, and return the result 8.0"
+        },
+        "LLMJudgeHaiku45": {
+          "expectedOutput": {
+            "result": 8.0
+          }
+        },
+        "LLMJudgeSonnet45": {
+          "expectedOutput": {
+            "result": 8.0
+          }
         }
       }
     },

--- a/samples/calculator/evaluations/eval-sets/legacy.json
+++ b/samples/calculator/evaluations/eval-sets/legacy.json
@@ -8,7 +8,9 @@
     "equality-with-target-key",
     "llm-as-a-judge",
     "json-similarity",
-    "trajectory"
+    "trajectory",
+    "llm-as-a-judge-haiku-4.5",
+    "llm-as-a-judge-sonnet-4.5"
   ],
   "evaluations": [
     {

--- a/samples/calculator/evaluations/evaluators/legacy-llm-as-a-judge-haiku-4.5.json
+++ b/samples/calculator/evaluations/evaluators/legacy-llm-as-a-judge-haiku-4.5.json
@@ -1,0 +1,14 @@
+{
+  "fileName": "llm-as-a-judge-haiku-4.5.json",
+  "id": "llm-as-a-judge-haiku-4.5",
+  "name": "LLMAsAJudge Haiku 4.5 Evaluator",
+  "description": "An evaluator that judges the agent based on it's run history and expected behavior using Claude Haiku 4.5",
+  "category": 3,
+  "type": 7,
+  "prompt": "As an expert evaluator, determine how well the agent did on a scale of 0-100. Focus on if the simulation was successful and if the agent behaved according to the expected output accounting for alternative valid expressions, and reasonable variations in language while maintaining high standards for accuracy and completeness. Provide your score with a justification, explaining briefly and concisely why you gave that score.\n----\nUserOrSyntheticInputGivenToAgent:\n{{UserOrSyntheticInput}}\n----\nSimulationInstructions:\n{{SimulationInstructions}}\n----\nExpectedAgentBehavior:\n{{ExpectedAgentBehavior}}\n----\nAgentRunHistory:\n{{AgentRunHistory}}\n",
+  "targetOutputKey": "*",
+  "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+  "maxTokens": 8000,
+  "createdAt": "2026-02-04T00:00:00.000Z",
+  "updatedAt": "2026-02-04T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/evaluators/legacy-llm-as-a-judge-sonnet-4.5.json
+++ b/samples/calculator/evaluations/evaluators/legacy-llm-as-a-judge-sonnet-4.5.json
@@ -1,0 +1,14 @@
+{
+  "fileName": "llm-as-a-judge-sonnet-4.5.json",
+  "id": "llm-as-a-judge-sonnet-4.5",
+  "name": "LLMAsAJudge Sonnet 4.5 Evaluator",
+  "description": "An evaluator that judges the agent based on it's run history and expected behavior using Claude Sonnet 4.5",
+  "category": 3,
+  "type": 7,
+  "prompt": "As an expert evaluator, determine how well the agent did on a scale of 0-100. Focus on if the simulation was successful and if the agent behaved according to the expected output accounting for alternative valid expressions, and reasonable variations in language while maintaining high standards for accuracy and completeness. Provide your score with a justification, explaining briefly and concisely why you gave that score.\n----\nUserOrSyntheticInputGivenToAgent:\n{{UserOrSyntheticInput}}\n----\nSimulationInstructions:\n{{SimulationInstructions}}\n----\nExpectedAgentBehavior:\n{{ExpectedAgentBehavior}}\n----\nAgentRunHistory:\n{{AgentRunHistory}}\n",
+  "targetOutputKey": "*",
+  "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "maxTokens": 8000,
+  "createdAt": "2026-02-04T00:00:00.000Z",
+  "updatedAt": "2026-02-04T00:00:00.000Z"
+}

--- a/samples/calculator/evaluations/evaluators/llm-judge-haiku-4.5.json
+++ b/samples/calculator/evaluations/evaluators/llm-judge-haiku-4.5.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0",
+  "id": "LLMJudgeHaiku45",
+  "description": "Uses Claude Haiku 4.5 to judge semantic similarity between expected and actual output.",
+  "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
+  "evaluatorConfig": {
+    "name": "LLMJudgeHaiku45",
+    "targetOutputKey": "*",
+    "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+    "prompt": "Compare the following outputs and evaluate their semantic similarity.\n\nActual Output: {{ActualOutput}}\nExpected Output: {{ExpectedOutput}}\n\nProvide a score from 0-100 where 100 means semantically identical and 0 means completely different.",
+    "temperature": 0.0,
+    "maxTokens": 8000,
+    "defaultEvaluationCriteria": {
+      "expectedOutput": {
+        "result": 5.0
+      }
+    }
+  }
+}

--- a/samples/calculator/evaluations/evaluators/llm-judge-sonnet-4.5.json
+++ b/samples/calculator/evaluations/evaluators/llm-judge-sonnet-4.5.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0",
+  "id": "LLMJudgeSonnet45",
+  "description": "Uses Claude Sonnet 4.5 to judge semantic similarity between expected and actual output.",
+  "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
+  "evaluatorConfig": {
+    "name": "LLMJudgeSonnet45",
+    "targetOutputKey": "*",
+    "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "prompt": "Compare the following outputs and evaluate their semantic similarity.\n\nActual Output: {{ActualOutput}}\nExpected Output: {{ExpectedOutput}}\n\nProvide a score from 0-100 where 100 means semantically identical and 0 means completely different.",
+    "temperature": 0.0,
+    "maxTokens": 8000,
+    "defaultEvaluationCriteria": {
+      "expectedOutput": {
+        "result": 5.0
+      }
+    }
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.15"
+version = "2.8.16"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Fix Claude 4.5 (Haiku, Sonnet) models failing with HTTP 400 when used as LLM-as-judge evaluators
- Add comprehensive tests for Claude 4.5 model support

## Root Cause Analysis

Using mitmproxy to capture HTTP traffic between the SDK and the UiPath LLM Gateway, we identified two issues causing Claude 4.5 models to return `400 Bad Request`:

### 1. OpenAI-specific parameters sent to Claude models
The `_llm_gateway_service.py` was sending `n`, `frequency_penalty`, `presence_penalty`, and `top_p` to ALL models. The UiPath Normalized API gateway passes these through to the underlying provider, and Claude/Anthropic rejects them with an opaque error:
```json
{"error":{"message":null,"type":null,"param":null,"code":null}}
```

**Fix**: Detect Claude models via `"claude" in model.lower()` and exclude these params.

### 2. Function calling for structured output (evaluator)
The evaluator now uses function calling (`tools`/`tool_choice`) for ALL models via the Normalized API, replacing the previous approach that used `response_format` for OpenAI and prompt-based JSON for non-OpenAI models. Function calling works consistently across all providers.

### 3. Claude 4.5 max_tokens default
Claude 4.5 models require `max_tokens` to be set explicitly. The evaluator now defaults to `8000` when not configured for these models.

## Changes

### `src/uipath/platform/chat/_llm_gateway_service.py`
- Skip `n`, `frequency_penalty`, `presence_penalty` for Claude models
- Only send `top_p` when not None (for non-Claude models)
- Debug logging for LLM gateway requests

### `src/uipath/eval/evaluators/llm_as_judge_evaluator.py`
- Use function calling (`submit_evaluation` tool) for structured output across all models
- Auto-default `max_tokens=8000` for Claude 4.5 models
- Enhanced error logging with HTTP status details

### `tests/evaluators/test_evaluator_methods.py`
New `TestClaude45ModelSupport` test class:
- Verify Claude 4.5 evaluators use function calling
- Verify default `max_tokens=8000` for Claude 4.5
- Verify explicit `max_tokens` config overrides the default
- Parametrized for both Haiku 4.5 and Sonnet 4.5

### `tests/sdk/services/test_llm_service.py`
New `TestNormalizedLlmServiceClaudeFiltering` test class:
- Verify Claude models exclude OpenAI-specific params from request body
- Verify OpenAI models still include all standard params
- Verify Claude Sonnet 4.5 specifically (production failure case)

### `samples/calculator/evaluations/`
- Added evaluator configs for Claude Haiku 4.5 and Sonnet 4.5
- Updated eval sets to include Claude 4.5 evaluators

## Test plan
- [x] All 8 new tests pass
- [x] Existing test suite passes (1856 tests)
- [x] E2E verified: all 9 evaluators (including both Claude 4.5) score 1.0 on calculator sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.8.16.dev1012694743",

  # Any version from PR
  "uipath>=2.8.16.dev1012690000,<2.8.16.dev1012700000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.8.16.dev1012690000,<2.8.16.dev1012700000",
]
```
<!-- DEV_PACKAGE_END -->