### PR TITLE
fix(tracing): prevent agent span attribute corruption in LlmOps exporter WIP

### DIFF
--- a/src/uipath/tracing/_live_tracking_processor.py
+++ b/src/uipath/tracing/_live_tracking_processor.py
@@ -57,7 +57,7 @@ class LiveTrackingSpanProcessor(SpanProcessor):
 
         def _upsert():
             try:
-                if status_override:
+                if status_override is not None:
                     self.exporter.upsert_span(span, status_override=status_override)
                 else:
                     self.exporter.upsert_span(span)

--- a/src/uipath/tracing/_utils.py
+++ b/src/uipath/tracing/_utils.py
@@ -276,7 +276,7 @@ class _SpanUtils:
         reference_id = attributes_dict.get("referenceId")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
-        uipath_source = attributes_dict.get("uipath.source")
+        uipath_source = attributes_dict.get("uipath.source", attributes_dict.get("source"))
         source = uipath_source if isinstance(uipath_source, int) else DEFAULT_SOURCE
 
         attachments = None


### PR DESCRIPTION
OpenInference-specific attribute mappings (_map_llm_call_attributes, _map_tool_call_attributes) were unconditionally applied to all spans, destroying correctly formatted attributes on agent manual spans from UiPathTracer. Guard these mappings behind an openinference.span.kind check. Also fix Source field fallback to check "source" key (not just "uipath.source"), and fix truthiness bug where SpanStatus.UNSET (0) was treated as falsy in LiveTrackingSpanProcessor.