### PR TITLE
fix: add graph visualization on cli init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.1"
+version = "2.8.2"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -21,6 +21,7 @@ dependencies = [
   "python-socketio>=5.15.0, <6.0.0",
   "coverage>=7.8.2",
   "mermaid-builder==0.0.3",
+  "graphtty==0.1.6",
   "applicationinsights>=0.11.10",
 ]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphtty"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/06/96130c4d3e2cdaf965f1060143bea276905b7050adf324a00ed705a84617/graphtty-0.1.6.tar.gz", hash = "sha256:1d989baf901d2bfe125f1e2aee730fd4b143c0dd4b4640fef9dcf42535430386", size = 549561, upload-time = "2026-02-09T13:20:16.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/69/d3e359238c1846aead328c7efcf6875028b326e54253d3d7d65645943d5e/graphtty-0.1.6-py3-none-any.whl", hash = "sha256:163e0f8a35ebab9bd37d834619088aa2aa36a112a3c1f9577030cef1b9be8663", size = 22853, upload-time = "2026-02-09T13:20:15.011Z" },
+]
+
+[[package]]
 name = "griffe"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2491,12 +2500,13 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.1"
+version = "2.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
     { name = "click" },
     { name = "coverage" },
+    { name = "graphtty" },
     { name = "httpx" },
     { name = "mermaid-builder" },
     { name = "mockito" },
@@ -2547,6 +2557,7 @@ requires-dist = [
     { name = "applicationinsights", specifier = ">=0.11.10" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "coverage", specifier = ">=7.8.2" },
+    { name = "graphtty", specifier = "==0.1.6" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mermaid-builder", specifier = "==0.0.3" },
     { name = "mockito", specifier = ">=1.5.4" },


### PR DESCRIPTION
## Description

Adds a graph visualization on CLI init using https://github.com/uipath/graphtty

<img width="1397" height="470" alt="image" src="https://github.com/user-attachments/assets/98af4bba-8568-4781-8c27-d285ac452b5d" />

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.8.2.dev1012794631",

  # Any version from PR
  "uipath>=2.8.2.dev1012790000,<2.8.2.dev1012800000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.8.2.dev1012790000,<2.8.2.dev1012800000",
]
```
<!-- DEV_PACKAGE_END -->