### PR TITLE
feat: debug functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.2"
+version = "2.8.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/functions/__init__.py
+++ b/src/uipath/functions/__init__.py
@@ -2,6 +2,7 @@
 
 from uipath.runtime import UiPathRuntimeFactoryRegistry
 
+from .debug import UiPathDebugFunctionsRuntime
 from .factory import UiPathFunctionsRuntimeFactory
 from .runtime import UiPathFunctionsRuntime
 
@@ -19,6 +20,7 @@ def register_default_runtime_factory():
 
 
 __all__ = [
+    "UiPathDebugFunctionsRuntime",
     "UiPathFunctionsRuntimeFactory",
     "UiPathFunctionsRuntime",
     "register_default_runtime_factory",

--- a/src/uipath/functions/debug.py
+++ b/src/uipath/functions/debug.py
@@ -1,0 +1,390 @@
+"""Debug wrapper for function runtimes with Python-level breakpoint support.
+
+Provides UiPathDebugFunctionsRuntime, a delegate wrapper that adds
+sys.settrace-based line-level breakpoints to any runtime.  When
+breakpoints are present in the execution options the delegate's
+execute() runs in a background thread with tracing enabled, yielding
+UiPathBreakpointResult events that carry captured local variables for
+inspection.
+
+Composition chain (debug command):
+
+    UiPathDebugRuntime                      → bridge I/O, resume loop
+      └─ UiPathDebugFunctionsRuntime        → trace-based line breakpoints
+           └─ UiPathFunctionsRuntime        → loads & executes user code
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import queue
+import sys
+import threading
+from pathlib import Path
+from types import FrameType
+from typing import Any, AsyncGenerator, Literal
+
+from uipath.runtime import (
+    UiPathBreakpointResult,
+    UiPathExecuteOptions,
+    UiPathRuntimeEvent,
+    UiPathRuntimeProtocol,
+    UiPathRuntimeResult,
+    UiPathStreamOptions,
+)
+from uipath.runtime.schema import UiPathRuntimeSchema
+
+logger = logging.getLogger(__name__)
+
+
+def _capture_frame_locals(frame: FrameType) -> dict[str, Any]:
+    """Snapshot local variables from a live frame for variable inspection.
+
+    Primitives and JSON-serialisable collections are kept as-is so the
+    bridge can render them natively. Everything else is repr()-ed to
+    guarantee safe serialisation over the wire.
+    """
+    snapshot: dict[str, Any] = {}
+    for name, value in frame.f_locals.items():
+        try:
+            if isinstance(value, (bool, int, float, str, type(None))):
+                snapshot[name] = value
+            elif isinstance(value, (dict, list, tuple)):
+                json.dumps(value, default=str)  # serialisability probe
+                snapshot[name] = value
+            else:
+                snapshot[name] = repr(value)
+        except Exception:
+            try:
+                snapshot[name] = repr(value)
+            except Exception:
+                snapshot[name] = "<unrepresentable>"
+    return snapshot
+
+
+def _format_location(filepath: str, line: int) -> str:
+    """Return a human-readable file:line breakpoint identifier."""
+    try:
+        relative = Path(filepath).relative_to(Path.cwd())
+    except ValueError:
+        relative = Path(Path(filepath).name)
+    return f"{relative}:{line}"
+
+
+class BreakpointController:
+    """Synchronises a sys.settrace-instrumented thread with an async stream.
+
+    Lifecycle
+    ---------
+    1. Created with breakpoint locations and a project directory.
+    2. start() launches delegate.execute() in a daemon thread with
+       tracing enabled.
+    3. When a matching line is reached the thread pauses and a
+       ("breakpoint", …) event is enqueued.
+    4. The async stream dequeues the event and yields a
+       UiPathBreakpointResult.
+    5. resume() unblocks the thread so it continues to the next
+       breakpoint or completion.
+    6. stop() terminates the thread gracefully.
+    """
+
+    def __init__(
+        self,
+        project_dir: str,
+        breakpoints: list[str] | Literal["*"],
+        entrypoint_path: str | None = None,
+    ) -> None:
+        """Initialize the controller with project directory, breakpoints, and optional entrypoint path."""
+        self._project_dir = project_dir
+        self._entrypoint_path = (
+            os.path.abspath(entrypoint_path) if entrypoint_path else None
+        )
+        self._step_mode: bool = breakpoints == "*"
+        self._file_breakpoints: dict[str, set[int]] = {}
+        if isinstance(breakpoints, list):
+            self._parse_breakpoints(breakpoints)
+
+        self._events: queue.Queue[tuple[str, Any]] = queue.Queue()
+        self._resume_event = threading.Event()
+        self._stopped = False
+        self._thread: threading.Thread | None = None
+        self._abspath_cache: dict[str, str] = {}
+
+    # Breakpoint management
+
+    def _parse_breakpoints(self, breakpoints: list[str]) -> None:
+        """Parse breakpoint strings into *file → line-numbers* mappings.
+
+        Supported formats::
+
+            "42"          → line 42 in the entrypoint file
+            "main.py:42"  → line 42 in main.py (resolved relative to cwd)
+        """
+        for bp in breakpoints:
+            if ":" in bp:
+                file_part, line_str = bp.rsplit(":", 1)
+                try:
+                    line = int(line_str)
+                except ValueError:
+                    continue
+                resolved = os.path.abspath(file_part)
+                self._file_breakpoints.setdefault(resolved, set()).add(line)
+            else:
+                try:
+                    line = int(bp)
+                except ValueError:
+                    continue  # non-numeric tokens (agent node names) are ignored
+                if self._entrypoint_path is not None:
+                    self._file_breakpoints.setdefault(self._entrypoint_path, set()).add(
+                        line
+                    )
+
+    def update_breakpoints(self, breakpoints: list[str] | Literal["*"] | None) -> None:
+        """Replace the active breakpoint set (called between resume cycles)."""
+        self._step_mode = breakpoints == "*"
+        self._file_breakpoints.clear()
+        if isinstance(breakpoints, list):
+            self._parse_breakpoints(breakpoints)
+
+    # Tracing
+
+    def _abspath(self, path: str) -> str:
+        """Cached os.path.abspath to avoid repeated resolution in the hot path."""
+        result = self._abspath_cache.get(path)
+        if result is None:
+            result = os.path.abspath(path)
+            self._abspath_cache[path] = result
+        return result
+
+    def _is_project_file(self, abspath: str) -> bool:
+        """Return *True* for files under the project directory that are not vendored."""
+        return abspath.startswith(self._project_dir) and "site-packages" not in abspath
+
+    def _trace_callback(self, frame: FrameType, event: str, arg: Any) -> Any:
+        """sys.settrace callback — dispatched for every frame event."""
+        if self._stopped:
+            return None
+
+        try:
+            filepath = self._abspath(frame.f_code.co_filename)
+
+            if event == "call":
+                # Decide whether to trace *into* this function's frame.
+                if self._step_mode:
+                    return (
+                        self._trace_callback
+                        if self._is_project_file(filepath)
+                        else None
+                    )
+                return (
+                    self._trace_callback if filepath in self._file_breakpoints else None
+                )
+
+            if event == "line":
+                lineno = frame.f_lineno
+                should_break = (
+                    self._step_mode and self._is_project_file(filepath)
+                ) or (lineno in self._file_breakpoints.get(filepath, ()))
+
+                if should_break:
+                    self._events.put(
+                        (
+                            "breakpoint",
+                            {
+                                "file": filepath,
+                                "line": lineno,
+                                "function": frame.f_code.co_name,
+                                "locals": _capture_frame_locals(frame),
+                            },
+                        )
+                    )
+                    # Pause the thread until the bridge signals resume.
+                    self._resume_event.wait()
+                    self._resume_event.clear()
+
+                    if self._stopped:
+                        return None
+
+            return self._trace_callback
+
+        except Exception:
+            # Never let our own errors propagate — that would disable tracing.
+            return self._trace_callback
+
+    # Thread lifecycle
+
+    def start(
+        self,
+        delegate: UiPathRuntimeProtocol,
+        input: dict[str, Any] | None,
+        options: UiPathExecuteOptions | None,
+    ) -> None:
+        """Launch delegate.execute() in a traced daemon thread."""
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(delegate, input, options),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(
+        self,
+        delegate: UiPathRuntimeProtocol,
+        input: dict[str, Any] | None,
+        options: UiPathExecuteOptions | None,
+    ) -> None:
+        """Thread entry-point: install the trace, execute, report result."""
+        try:
+            sys.settrace(self._trace_callback)
+            loop = asyncio.new_event_loop()
+            try:
+                result = loop.run_until_complete(delegate.execute(input, options))
+            finally:
+                loop.close()
+            sys.settrace(None)
+            self._events.put(("completed", result))
+        except Exception as exc:
+            sys.settrace(None)
+            self._events.put(("error", exc))
+
+    # Inter-thread communication
+
+    def wait_for_event(self) -> tuple[str, Any]:
+        """Block until the next breakpoint hit or execution completion."""
+        return self._events.get()
+
+    def resume(self) -> None:
+        """Unblock the trace thread so it continues past the current breakpoint."""
+        self._resume_event.set()
+
+    def stop(self) -> None:
+        """Terminate the controller and join the background thread."""
+        self._stopped = True
+        self._resume_event.set()  # unblock if paused at a breakpoint
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+
+
+class UiPathDebugFunctionsRuntime:
+    """Delegate wrapper that adds Python-level breakpoint support via sys.settrace.
+
+    Follows the same composition pattern as UiPathDebugRuntime: wraps a UiPathRuntimeProtocol delegate and
+    intercepts stream() to inject breakpoint behaviour.
+
+    When no breakpoints are active every call delegates transparently.
+    When breakpoints **are** present the delegate's execute() runs in
+    a background thread with sys.settrace enabled.  The trace callback
+    pauses the thread at matching lines and this runtime yields
+    UiPathBreakpointResult events with captured local variables.
+
+    Works for both sync and async user functions — async functions run in
+    a dedicated asyncio event loop on the background thread.
+
+    Parameters
+    ----------
+    delegate:
+        The inner runtime to wrap (typically UiPathFunctionsRuntime).
+    entrypoint_path:
+        Absolute or relative path to the user's entrypoint file.  Used to
+        resolve bare line-number breakpoints (e.g. "42").
+    """
+
+    def __init__(
+        self,
+        delegate: UiPathRuntimeProtocol,
+        entrypoint_path: str | None = None,
+    ) -> None:
+        """Initialize the debug wrapper with a delegate runtime and optional entrypoint path."""
+        self.delegate = delegate
+        self._entrypoint_path = entrypoint_path
+        self._controller: BreakpointController | None = None
+
+    async def execute(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
+    ) -> UiPathRuntimeResult:
+        """Pass-through to delegate (no breakpoint support outside stream)."""
+        return await self.delegate.execute(input, options)
+
+    async def stream(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
+    ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
+        """Stream execution events with line-level breakpoint support.
+
+        Breakpoint formats (via options.breakpoints):
+
+        * "42"          — line 42 in the entrypoint file
+        * "main.py:42"  — line 42 in *main.py* (resolved from cwd)
+        * "*"           — **step mode**: break on every line in project files
+        """
+        breakpoints = options.breakpoints if options else None
+
+        # Resume from a previous breakpoint
+        if options and options.resume and self._controller is not None:
+            self._controller.update_breakpoints(breakpoints)
+            self._controller.resume()
+
+            event_type, data = await asyncio.to_thread(self._controller.wait_for_event)
+            yield self._to_runtime_event(event_type, data)
+            return
+
+        # No breakpoints, transparent delegation
+        if not breakpoints:
+            async for event in self.delegate.stream(input, options):
+                yield event
+            return
+
+        # First execution with breakpoints
+        controller = BreakpointController(
+            project_dir=str(Path.cwd()),
+            breakpoints=breakpoints,
+            entrypoint_path=self._entrypoint_path,
+        )
+        self._controller = controller
+
+        # Strip breakpoints from the options forwarded to the delegate —
+        # the delegate does not handle them; we do via the trace.
+        delegate_options = UiPathExecuteOptions(
+            resume=options.resume if options else False,
+        )
+        controller.start(self.delegate, input, delegate_options)
+
+        event_type, data = await asyncio.to_thread(controller.wait_for_event)
+        yield self._to_runtime_event(event_type, data)
+
+    async def get_schema(self) -> UiPathRuntimeSchema:
+        """Pass-through to delegate."""
+        return await self.delegate.get_schema()
+
+    async def dispose(self) -> None:
+        """Clean up the trace thread and delegate resources."""
+        if self._controller is not None:
+            self._controller.stop()
+            self._controller = None
+        await self.delegate.dispose()
+
+    def _to_runtime_event(self, event_type: str, data: Any) -> UiPathRuntimeEvent:
+        """Convert a BreakpointController event into a UiPathRuntimeEvent."""
+        if event_type == "breakpoint":
+            return UiPathBreakpointResult(
+                breakpoint_node=_format_location(data["file"], data["line"]),
+                breakpoint_type="before",
+                current_state=data["locals"],
+                next_nodes=[],
+            )
+
+        # Terminal events, release the controller.
+        self._controller = None
+
+        if event_type == "completed":
+            # data is already a UiPathRuntimeResult from delegate.execute().
+            return data
+
+        # "error", re-raise so UiPathDebugRuntime can emit_execution_error().
+        raise data

--- a/src/uipath/functions/factory.py
+++ b/src/uipath/functions/factory.py
@@ -11,6 +11,7 @@ from uipath.runtime import (
     UiPathRuntimeStorageProtocol,
 )
 
+from .debug import UiPathDebugFunctionsRuntime
 from .runtime import UiPathFunctionsRuntime
 
 logger = logging.getLogger(__name__)
@@ -97,4 +98,8 @@ class UiPathFunctionsRuntimeFactory:
         if not full_path.exists():
             raise ValueError(f"File not found: {full_path}")
 
-        return UiPathFunctionsRuntime(str(full_path), function_name, entrypoint)
+        inner = UiPathFunctionsRuntime(str(full_path), function_name, entrypoint)
+        return UiPathDebugFunctionsRuntime(
+            delegate=inner,
+            entrypoint_path=str(full_path),
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2500,7 +2500,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.2"
+version = "2.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Description

### The Three Main Pieces

1. `_capture_frame_locals`: "Take a snapshot of variables"
When the code pauses at a breakpoint, you want to see what your variables look like. This function grabs all the local variables from the current point in execution and makes a safe copy. Simple things (strings, numbers, lists) are kept as-is. Anything complex gets converted to a string with `repr()` so it won't cause problems when sent over the network.

2. `BreakpointController`: "The traffic light"
The code runs on a background thread.
A trace function (`_trace_callback`) is hooked into Python via `sys.settrace`. This is a special Python mechanism that lets you get notified every single time a new line of code is about to run.
When that line matches one of your breakpoints, the thread pauses (using `threading.Event.wait()`), takes a snapshot of variables, and puts a message in a queue saying "hey, I hit a breakpoint!"
The outside world reads that message, shows it to the user, and eventually calls `resume()` to let the thread continue.


3. `UiPathDebugFunctionsRuntime`: "The wrapper"

It wraps another runtime (the "real" one that actually runs user code) and adds debugging on top. The key idea:

- No breakpoints? Just pass everything through to the inner runtime. No overhead.
- Breakpoints set? Create a `BreakpointController`, run the inner runtime inside a traced thread, and yield breakpoint events back to the caller.
- Resuming? Tell the existing controller to keep going and wait for the next event.

### How Breakpoints Are Specified

Users pass breakpoints as strings:

- "42" → pause at line 42 of the main file
- "main.py:42" → pause at line 42 of main.py
- "*" → step mode, pause on every single line (like "step into" in a debugger)

### Notes

- `sys.settrace` is a low-level Python feature: it literally lets you install a callback that Python calls before executing each line. It's how debuggers like `pdb` work under the hood. The "call" event means "a function is being entered" (and the callback decides whether to trace inside it), while "line" means "a new line is about to execute" (where we check for breakpoints).
- Step mode pauses on **every line** of project code and traces **into function calls**:
  - **`call` event**: Decides whether to trace into a function. In step mode, it enters all project files but skips third-party code.
  - **`line` event**: Pauses execution on every line of every project file, captures local variables, and waits for a resume signal.
  - `_is_project_file()` ensures only user code is traced, preventing stepping into standard library or dependency internals.

<img width="2692" height="1640" alt="image" src="https://github.com/user-attachments/assets/b825d136-60a7-4c5a-8cc7-da18903f51e7" />

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.8.3.dev1012804637",

  # Any version from PR
  "uipath>=2.8.3.dev1012800000,<2.8.3.dev1012810000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.8.3.dev1012800000,<2.8.3.dev1012810000",
]
```
<!-- DEV_PACKAGE_END -->