### PR TITLE
fix: handle non-str error attribute in OTEL exporter

### DIFF
--- a/src/uipath/tracing/_otel_exporters.py
+++ b/src/uipath/tracing/_otel_exporters.py
@@ -292,9 +292,9 @@ class LlmOpsHttpExporter(SpanExporter):
 
         return result
 
-    def _determine_status(self, error: Optional[str]) -> int:
+    def _determine_status(self, error: Optional[Any]) -> int:
         if error:
-            if error and error.startswith("GraphInterrupt("):
+            if isinstance(error, str) and error.startswith("GraphInterrupt("):
                 return self.Status.INTERRUPTED
             return self.Status.ERROR
         return self.Status.SUCCESS


### PR DESCRIPTION
`error` is of type Any, but _determine_status only handled strings. The span would fail to upsert when error was not a string.