### PR TITLE
fix(AE-999): remove duplicate root span and change evaluation span_type to 'eval'

### DIFF
--- a/src/uipath/_cli/_evals/_runtime.py
+++ b/src/uipath/_cli/_evals/_runtime.py
@@ -506,7 +506,7 @@ class UiPathEvalRuntime:
                 "Evaluation",
                 attributes={
                     "execution.id": execution_id,
-                    "span_type": "evaluation",
+                    "span_type": "eval",
                     "eval_item_id": eval_item.id,
                     "eval_item_name": eval_item.name,
                     "uipath.custom_instrumentation": True,
@@ -814,11 +814,6 @@ class UiPathEvalRuntime:
         input_overrides: dict[str, Any] | None = None,
     ) -> UiPathEvalRunExecutionOutput:
         log_handler = self._setup_execution_logging(execution_id)
-        attributes: dict[str, Any] = {
-            "evalId": eval_item.id,
-            "span_type": "eval",
-            "uipath.custom_instrumentation": True,
-        }
 
         # Create a new runtime with runtime_id for this eval execution.
         # Use eval_item.id to maintain consistent thread_id across suspend and resume.
@@ -835,8 +830,6 @@ class UiPathEvalRuntime:
                 delegate=eval_runtime,
                 trace_manager=self.trace_manager,
                 log_handler=log_handler,
-                execution_id=execution_id,
-                span_attributes=attributes,
             )
 
             start_time = time()

--- a/testcases/eval-spans-testcase/src/assert.py
+++ b/testcases/eval-spans-testcase/src/assert.py
@@ -118,8 +118,8 @@ def assert_evaluation_spans(traces: list[dict[str, Any]]) -> None:
         print(f"    Name: {name}")
 
         # Check span_type attribute
-        assert attrs.get("span_type") == "evaluation", (
-            f"Expected span_type 'evaluation', got '{attrs.get('span_type')}'"
+        assert attrs.get("span_type") == "eval", (
+            f"Expected span_type 'eval', got '{attrs.get('span_type')}'"
         )
         print(f"    span_type: {attrs.get('span_type')}")
 

--- a/tests/cli/eval/test_eval_runtime_spans.py
+++ b/tests/cli/eval/test_eval_runtime_spans.py
@@ -2,7 +2,7 @@
 
 Tests the spans added for eval tracing:
 1. "Evaluation Set Run" - span_type: "eval_set_run"
-2. "Evaluation" - span_type: "evaluation"
+2. "Evaluation" - span_type: "eval"
 3. "Evaluator: {name}" - span_type: "evaluator"
 4. "Evaluation output" - span_type: "evalOutput"
 """
@@ -158,15 +158,15 @@ class TestEvaluationSpan:
 
     def test_span_has_evaluation_span_type(self):
         """Test that span_type attribute is 'evaluation'."""
-        span_attributes = {"span_type": "evaluation"}
-        assert span_attributes["span_type"] == "evaluation"
+        span_attributes = {"span_type": "eval"}
+        assert span_attributes["span_type"] == "eval"
 
     def test_span_includes_execution_id(self):
         """Test that execution.id is included in the span attributes."""
         execution_id = str(uuid.uuid4())
         span_attributes = {
             "execution.id": execution_id,
-            "span_type": "evaluation",
+            "span_type": "eval",
         }
         assert "execution.id" in span_attributes
         assert span_attributes["execution.id"] == execution_id
@@ -175,7 +175,7 @@ class TestEvaluationSpan:
         """Test that eval_item_id is included in the span attributes."""
         eval_item_id = "test-eval-item-123"
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "eval_item_id": eval_item_id,
         }
         assert "eval_item_id" in span_attributes
@@ -185,7 +185,7 @@ class TestEvaluationSpan:
         """Test that eval_item_name is included in the span attributes."""
         eval_item_name = "Test Evaluation Item"
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "eval_item_name": eval_item_name,
         }
         assert "eval_item_name" in span_attributes
@@ -199,7 +199,7 @@ class TestEvaluationSpan:
 
         span_attributes = {
             "execution.id": execution_id,
-            "span_type": "evaluation",
+            "span_type": "eval",
             "eval_item_id": eval_item_id,
             "eval_item_name": eval_item_name,
         }
@@ -218,7 +218,7 @@ class TestEvaluationSpan:
         output_json = json.dumps(output_data)
 
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "output": output_json,
         }
 
@@ -231,7 +231,7 @@ class TestEvaluationSpan:
         """Test that span has agentId metadata attribute."""
         execution_id = "eval-exec-456"
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "agentId": execution_id,
         }
         assert "agentId" in span_attributes
@@ -240,7 +240,7 @@ class TestEvaluationSpan:
     def test_span_has_agent_name(self):
         """Test that span has agentName metadata attribute."""
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "agentName": "N/A",
         }
         assert "agentName" in span_attributes
@@ -252,7 +252,7 @@ class TestEvaluationSpan:
 
         input_schema = {"type": "object"}
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "inputSchema": json.dumps(input_schema),
         }
         assert "inputSchema" in span_attributes
@@ -265,7 +265,7 @@ class TestEvaluationSpan:
 
         output_schema = {"type": "object"}
         span_attributes = {
-            "span_type": "evaluation",
+            "span_type": "eval",
             "outputSchema": json.dumps(output_schema),
         }
         assert "outputSchema" in span_attributes
@@ -344,20 +344,20 @@ class TestSpanHierarchy:
         # This is a conceptual test - in the actual code, the Evaluation span
         # is created inside the context of the Evaluation Set Run span
         parent_span_type = "eval_set_run"
-        child_span_type = "evaluation"
+        child_span_type = "eval"
 
         # The parent-child relationship is enforced by span context nesting
         assert parent_span_type == "eval_set_run"
-        assert child_span_type == "evaluation"
+        assert child_span_type == "eval"
 
     def test_evaluator_span_is_child_of_evaluation(self):
         """Test that Evaluator spans should be children of Evaluation."""
         # This is a conceptual test - in the actual code, the Evaluator span
         # is created inside the context of the Evaluation span
-        parent_span_type = "evaluation"
+        parent_span_type = "eval"
         child_span_type = "evaluator"
 
-        assert parent_span_type == "evaluation"
+        assert parent_span_type == "eval"
         assert child_span_type == "evaluator"
 
 
@@ -366,7 +366,7 @@ class TestSpanAttributeValues:
 
     def test_span_type_values_are_lowercase(self):
         """Test that span_type values are lowercase strings."""
-        span_types = ["eval_set_run", "evaluation", "evaluator"]
+        span_types = ["eval_set_run", "eval", "evaluator"]
 
         for span_type in span_types:
             assert span_type == span_type.lower()
@@ -446,13 +446,13 @@ class TestSpanCreationLogic:
 
         span_attributes = {
             "execution.id": execution_id,
-            "span_type": "evaluation",
+            "span_type": "eval",
             "eval_item_id": eval_item_id,
             "eval_item_name": eval_item_name,
         }
 
         assert span_attributes["execution.id"] == "exec-123"
-        assert span_attributes["span_type"] == "evaluation"
+        assert span_attributes["span_type"] == "eval"
         assert span_attributes["eval_item_id"] == "item-456"
         assert span_attributes["eval_item_name"] == "Test Item"
 
@@ -493,7 +493,7 @@ class TestEvalItemSpanAttributes:
 
         span_attributes = {
             "execution.id": str(uuid.uuid4()),
-            "span_type": "evaluation",
+            "span_type": "eval",
             "eval_item_id": eval_item.id,
             "eval_item_name": eval_item.name,
         }
@@ -521,14 +521,14 @@ class TestSpanTypeConsistency:
 
     def test_all_span_types_are_strings(self):
         """Test that all span_type values are strings."""
-        span_types = ["eval_set_run", "evaluation", "evaluator"]
+        span_types = ["eval_set_run", "eval", "evaluator"]
 
         for span_type in span_types:
             assert isinstance(span_type, str)
 
     def test_span_types_use_snake_case(self):
         """Test that span_type values use snake_case naming."""
-        span_types = ["eval_set_run", "evaluation", "evaluator"]
+        span_types = ["eval_set_run", "eval", "evaluator"]
 
         for span_type in span_types:
             # No uppercase letters
@@ -620,7 +620,7 @@ class TestExecutionIdPropagation:
 
         span_attributes = {
             "execution.id": execution_id,
-            "span_type": "evaluation",
+            "span_type": "eval",
             "eval_item_id": "item-123",
             "eval_item_name": "Test Item",
         }

--- a/tests/cli/eval/test_eval_tracing_integration.py
+++ b/tests/cli/eval/test_eval_tracing_integration.py
@@ -298,12 +298,12 @@ class TestEvaluationSpanCreation:
             await runtime._execute_eval(mock_eval_item, [])
 
         # Verify Evaluation span was created
-        evaluation_spans = capturing_tracer.get_spans_by_type("evaluation")
+        evaluation_spans = capturing_tracer.get_spans_by_type("eval")
         assert len(evaluation_spans) == 1
 
         span = evaluation_spans[0]
         assert span["name"] == "Evaluation"
-        assert span["attributes"]["span_type"] == "evaluation"
+        assert span["attributes"]["span_type"] == "eval"
         assert span["attributes"]["eval_item_id"] == "item-123"
         assert span["attributes"]["eval_item_name"] == "Test Evaluation"
         assert "execution.id" in span["attributes"]
@@ -521,7 +521,7 @@ class TestSpanAttributeValues:
                 await runtime._execute_eval(eval_item, [])
 
         # Get execution IDs from spans
-        evaluation_spans = capturing_tracer.get_spans_by_type("evaluation")
+        evaluation_spans = capturing_tracer.get_spans_by_type("eval")
         execution_ids = [s["attributes"]["execution.id"] for s in evaluation_spans]
 
         # All execution IDs should be unique
@@ -779,7 +779,7 @@ class TestSpanOutputAttributes:
                 await runtime._execute_eval(eval_item, [evaluator])
 
         # Check that Evaluation span has output attribute
-        eval_spans = self.capturing_tracer.get_spans_by_type("evaluation")
+        eval_spans = self.capturing_tracer.get_spans_by_type("eval")
         assert len(eval_spans) > 0
 
         eval_span = eval_spans[0]
@@ -857,7 +857,7 @@ class TestSpanOutputAttributes:
                 await runtime._execute_eval(eval_item, [evaluator])
 
         # Check metadata attributes on Evaluation span
-        eval_spans = self.capturing_tracer.get_spans_by_type("evaluation")
+        eval_spans = self.capturing_tracer.get_spans_by_type("eval")
         assert len(eval_spans) > 0
 
         eval_span = eval_spans[0]


### PR DESCRIPTION
## Summary

Fixes two issues reported in AE-999:

1. **Removed duplicate root span**: The extra root span with `span_type="eval"` wrapping agent execution has been removed
2. **Changed span_type**: The Evaluation span now uses `span_type="eval"` instead of `"evaluation"` for consistency

## Changes Made

### 1. Removed Duplicate Root Span (Commit a7592a7)
- Removed the intermediate root span that was accidentally re-introduced
- Removed `execution_id` and `span_attributes` parameters from UiPathExecutionRuntime
- This span was previously removed in commit 27f913e but got re-added

**File:** `src/uipath/_cli/_evals/_runtime.py:817-821, 838-839`

### 2. Changed Evaluation Span Type (Commit dcb3fe1)
- Changed `span_type` from `"evaluation"` to `"eval"` 
- Updated all Python tests to expect the new span type
- This maintains consistency with the temporal backend and avoids confusion with the removed root span

**Files:**
- `src/uipath/_cli/_evals/_runtime.py:509`
- `tests/cli/eval/test_eval_runtime_spans.py`
- `tests/cli/eval/test_eval_tracing_integration.py`
- `testcases/eval-spans-testcase/src/assert.py`

## New Span Hierarchy

```
Evaluation Set Run (span_type="eval_set_run")
├── Evaluation (span_type="eval") ← Changed from "evaluation"
│   ├── Agent execution spans (no extra wrapping)
│   └── Evaluator (span_type="evaluator")
│       └── evalOutput (span_type="evalOutput")
```

## Testing

- ✅ All 1919 tests pass
- ✅ Linting passed
- ✅ Formatting passed  
- ✅ Type checking passed
- ✅ Build successful

## Frontend Changes Required

⚠️ **Note**: The Agents repo (StudioWeb) frontend needs corresponding updates to filter by the new span type:

**File:** `frontend-sw/src/components/coded-evaluator/EvalRunTraceDialog/EvalRunTraceDialog.tsx`
- Line 138: Change `span.SpanType === "evaluation"` to `span.SpanType === "eval"`

**File:** `frontend-sw/src/components/coded-evaluator/EvalRunTraceDialog/EvalRunTraceDialog.test.tsx`
- Line 65: Change filter condition
- Lines 148+: Update all test mocks from `"evaluation"` to `"eval"`

## Related Issues

Fixes: https://uipath.atlassian.net/browse/AE-999

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.8.7.dev1012894671",

  # Any version from PR
  "uipath>=2.8.7.dev1012890000,<2.8.7.dev1012900000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.8.7.dev1012890000,<2.8.7.dev1012900000",
]
```
<!-- DEV_PACKAGE_END -->