### PR TITLE
fix: remove extra configs from vs escalation properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.11"
+version = "2.8.12"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -21,7 +21,6 @@ from uipath.core.guardrails import (
 )
 
 from uipath.platform.connections import Connection
-from uipath.platform.documents import ActionPriority
 from uipath.platform.guardrails import (
     BuiltInValidatorGuardrail,
 )
@@ -554,8 +553,6 @@ class AgentIxpVsEscalationProperties(BaseCfg):
     """VS escalation properties model."""
 
     ixp_tool_id: str = Field(..., alias="ixpToolId")
-    action_title: str | None = Field(default=None, alias="actionTitle")
-    action_priority: ActionPriority | None = Field(default=None, alias="actionPriority")
     storage_bucket_name: str = Field(..., alias="storageBucketName")
     storage_bucket_folder_path: str = Field(..., alias="storageBucketFolderPath")
 

--- a/src/uipath/platform/documents/documents.py
+++ b/src/uipath/platform/documents/documents.py
@@ -1,5 +1,7 @@
 """Document service payload models."""
 
+from __future__ import annotations
+
 from enum import Enum
 from typing import IO, Any, List, Optional, Union
 
@@ -34,6 +36,16 @@ class ActionPriority(str, Enum):
     """High priority"""
     CRITICAL = "Critical"
     """Critical priority"""
+
+    @classmethod
+    def from_str(cls, value: str | None) -> ActionPriority:
+        """Creates an ActionPriority from a string."""
+        if not value:
+            return cls.MEDIUM
+        try:
+            return cls[value.upper()]
+        except (KeyError, AttributeError):
+            return cls.MEDIUM
 
 
 class ProjectType(str, Enum):

--- a/tests/agent/models/test_agent.py
+++ b/tests/agent/models/test_agent.py
@@ -2457,6 +2457,8 @@ class TestAgentBuilderConfig:
                             "outcomeMapping": None,
                             "recipients": [],
                             "type": "actionCenter",
+                            "taskTitle": "Test IXP Escalation",
+                            "priority": "High",
                             "properties": {
                                 "appName": None,
                                 "appVersion": 1,

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.11"
+version = "2.8.12"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- remove extra configs from vs escalation properties
- `taskTitle` and `priority` as configured as part of action channels