### PR TITLE
fix: ixp triggers with wait models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.16"
+version = "2.8.17"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/platform/common/interrupt_models.py
+++ b/src/uipath/platform/common/interrupt_models.py
@@ -222,3 +222,4 @@ class WaitDocumentExtractionValidation(BaseModel):
     """Model representing a wait document extraction task creation."""
 
     extraction_validation: StartExtractionValidationResponse
+    task_url: str | None = None

--- a/src/uipath/platform/documents/_documents_service.py
+++ b/src/uipath/platform/documents/_documents_service.py
@@ -19,7 +19,7 @@ from .documents import (
     FileContent,
     ProjectType,
     StartExtractionResponse,
-    StartOperationResponse,
+    StartExtractionValidationResponse,
     ValidateClassificationAction,
     ValidateExtractionAction,
 )
@@ -1252,7 +1252,6 @@ class DocumentsService(FolderContext, BaseService):
                 error=response.get("error"),
                 operation_name=operation_name,
             )
-
         return response.get("result")
 
     async def _retrieve_operation_result_async(
@@ -1285,7 +1284,6 @@ class DocumentsService(FolderContext, BaseService):
                 error=response.get("error"),
                 operation_name=operation_name,
             )
-
         return response.get("result")
 
     @traced(name="documents_retrieve_ixp_extraction_result", run_type="uipath")
@@ -1690,7 +1688,7 @@ class DocumentsService(FolderContext, BaseService):
         storage_bucket_name: Optional[str],
         storage_bucket_directory_path: Optional[str],
         extraction_response: ExtractionResponse,
-    ) -> StartOperationResponse:
+    ) -> StartExtractionValidationResponse:
         if tag is None:
             url = Endpoint(
                 f"/du_/api/framework/projects/{project_id}/extractors/{extractor_id}/validation/start"
@@ -1718,7 +1716,7 @@ class DocumentsService(FolderContext, BaseService):
             },
         ).json()["operationId"]
 
-        return StartOperationResponse(
+        return StartExtractionValidationResponse(
             operation_id=operation_id,
             document_id=extraction_response.extraction_result.document_id,
             project_id=project_id,
@@ -1738,7 +1736,7 @@ class DocumentsService(FolderContext, BaseService):
         storage_bucket_name: Optional[str],
         storage_bucket_directory_path: Optional[str],
         extraction_response: ExtractionResponse,
-    ) -> StartOperationResponse:
+    ) -> StartExtractionValidationResponse:
         if tag is None:
             url = Endpoint(
                 f"/du_/api/framework/projects/{project_id}/extractors/{extractor_id}/validation/start"
@@ -1768,7 +1766,7 @@ class DocumentsService(FolderContext, BaseService):
             )
         ).json()["operationId"]
 
-        return StartOperationResponse(
+        return StartExtractionValidationResponse(
             operation_id=operation_id,
             document_id=extraction_response.extraction_result.document_id,
             project_id=project_id,
@@ -1785,7 +1783,7 @@ class DocumentsService(FolderContext, BaseService):
         action_folder: Optional[str] = None,
         storage_bucket_name: Optional[str] = None,
         storage_bucket_directory_path: Optional[str] = None,
-    ) -> StartOperationResponse:
+    ) -> StartExtractionValidationResponse:
         """Start an IXP extraction validation action without waiting for results (non-blocking).
 
         Args:
@@ -1798,7 +1796,7 @@ class DocumentsService(FolderContext, BaseService):
             storage_bucket_directory_path (str, optional): The directory path within the storage bucket.
 
         Returns:
-            StartOperationResponse: Contains the operation_id, document_id, project_id, and tag.
+            StartExtractionValidationResponse: Contains the operation_id, document_id, project_id, and tag.
 
         Examples:
             ```python
@@ -1846,7 +1844,7 @@ class DocumentsService(FolderContext, BaseService):
         action_folder: Optional[str] = None,
         storage_bucket_name: Optional[str] = None,
         storage_bucket_directory_path: Optional[str] = None,
-    ) -> StartOperationResponse:
+    ) -> StartExtractionValidationResponse:
         """Asynchronous version of the [`start_ixp_extraction_validation`][uipath.platform.documents._documents_service.DocumentsService.start_ixp_extraction_validation] method."""
         return await self._start_extraction_validation_async(
             project_id=extraction_response.project_id,
@@ -2550,5 +2548,4 @@ class DocumentsService(FolderContext, BaseService):
         if validation_action.project_type == ProjectType.IXP:
             return ExtractionResponseIXP.model_validate(response)
 
-        return ExtractionResponse.model_validate(response)
         return ExtractionResponse.model_validate(response)

--- a/src/uipath/platform/resume_triggers/_protocol.py
+++ b/src/uipath/platform/resume_triggers/_protocol.py
@@ -701,6 +701,10 @@ class UiPathResumeTriggerCreator:
         resume_trigger.folder_path = resume_trigger.folder_key = None
         if isinstance(value, WaitDocumentExtraction):
             resume_trigger.item_key = value.extraction.operation_id
+            # add project_id and tag to the payload dict (needed when reading the trigger)
+            assert isinstance(resume_trigger.payload, dict)
+            resume_trigger.payload.setdefault("project_id", value.extraction.project_id)
+            resume_trigger.payload.setdefault("tag", value.extraction.tag)
         elif isinstance(value, DocumentExtraction):
             uipath = UiPath()
             document_extraction = await uipath.documents.start_ixp_extraction_async(
@@ -742,6 +746,13 @@ class UiPathResumeTriggerCreator:
 
         if isinstance(value, WaitDocumentExtractionValidation):
             resume_trigger.item_key = value.extraction_validation.operation_id
+
+            # add project_id and tag to the payload dict (needed when reading the trigger)
+            assert isinstance(resume_trigger.payload, dict)
+            resume_trigger.payload.setdefault(
+                "project_id", value.extraction_validation.project_id
+            )
+            resume_trigger.payload.setdefault("tag", value.extraction_validation.tag)
         elif isinstance(value, DocumentExtractionValidation):
             uipath = UiPath()
             extraction_validation = (

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.16"
+version = "2.8.17"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- save project id and tag for wait ixp models when creating the triggers
- return correct `StartExtractionValidationResponse` model in document_service
- add task_url `WaitDocumentExtractionValidation` (to be include in the interrupt span)