### PR TITLE
fix: remove extras dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.27"
+version = "2.8.28"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/cli_dev.py
+++ b/src/uipath/_cli/cli_dev.py
@@ -26,19 +26,6 @@ def _check_dev_dependency(interface: str) -> None:
             "  uv add uipath-dev --dev\n\n"
         )
 
-    if interface == "web":
-        from uipath.dev.server import HAS_EXTRAS  # type: ignore[import-untyped]
-
-        if not HAS_EXTRAS:
-            raise ImportError(
-                "The 'uipath-dev[server]' package is required to use the web interface.\n"
-                "Please install it with the server extras:\n\n"
-                "  # Using pip:\n"
-                "  pip install uipath-dev[server]\n\n"
-                "  # Using uv:\n"
-                '  uv add "uipath-dev[server]" --dev\n\n'
-            )
-
 
 @click.command()
 @click.argument(
@@ -116,7 +103,7 @@ def dev(interface: str, debug: bool, debug_port: int) -> None:
     elif interface == "web":
 
         async def run_web() -> None:
-            from uipath.dev.server import (
+            from uipath.dev.server import (  # type: ignore[import-untyped]
                 UiPathDeveloperServer,
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.27"
+version = "2.8.28"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Description

This PR bumps the uipath package version and removes the CLI dev command’s check that previously enforced the uipath-dev[server] extra for the web interface.