### PR TITLE
feat(debug): call graph, state events, and breakpoint improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.28"
+version = "2.8.29"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/functions/factory.py
+++ b/src/uipath/functions/factory.py
@@ -102,4 +102,5 @@ class UiPathFunctionsRuntimeFactory:
         return UiPathDebugFunctionsRuntime(
             delegate=inner,
             entrypoint_path=str(full_path),
+            function_name=function_name,
         )

--- a/src/uipath/functions/graph_builder.py
+++ b/src/uipath/functions/graph_builder.py
@@ -1,0 +1,335 @@
+"""AST-based call graph builder for Python function runtimes.
+
+Parses user code starting from an entrypoint function and builds a
+UiPathRuntimeGraph of function call relationships. Only follows calls
+into local project files (skips external dependencies).
+
+Node IDs use the "file:line" format so they can double as breakpoint
+locations for the debug runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import os
+from pathlib import Path
+
+from uipath.runtime.schema import (
+    UiPathRuntimeEdge,
+    UiPathRuntimeGraph,
+    UiPathRuntimeNode,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_DEPTH = 3
+
+
+def build_call_graph(
+    file_path: str,
+    function_name: str,
+    *,
+    project_dir: str | None = None,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> UiPathRuntimeGraph:
+    """Build a call graph starting from *function_name* in *file_path*.
+
+    Parameters
+    ----------
+    file_path:
+        Absolute or relative path to the Python source file containing the
+        entrypoint function.
+    function_name:
+        Name of the entrypoint function inside *file_path*.
+    project_dir:
+        Root directory of the project. Only files under this directory are
+        followed. Defaults to the parent of *file_path*.
+    max_depth:
+        Maximum recursion depth for following function calls.
+
+    UiPathRuntimeGraph
+        A graph with nodes (id="relative/path.py:line") and edges
+        representing call relationships.
+    """
+    abs_file = os.path.abspath(file_path)
+    if project_dir is None:
+        project_dir = str(Path(abs_file).parent)
+    project_dir = os.path.abspath(project_dir)
+
+    ctx = _BuildContext(project_dir=project_dir, max_depth=max_depth)
+    ctx.visit_function(abs_file, function_name, depth=0)
+    return UiPathRuntimeGraph(nodes=ctx.nodes, edges=ctx.edges)
+
+
+class _BuildContext:
+    """Accumulates nodes and edges while walking the call graph."""
+
+    def __init__(self, project_dir: str, max_depth: int) -> None:
+        self.project_dir = project_dir
+        self.max_depth = max_depth
+        self.nodes: list[UiPathRuntimeNode] = []
+        self.edges: list[UiPathRuntimeEdge] = []
+        self._visited: set[str] = set()  # node IDs already processed
+        self._ast_cache: dict[str, ast.Module] = {}
+
+    def _parse_file(self, abs_path: str) -> ast.Module | None:
+        """Parse a Python file, returning the cached AST or None on failure."""
+        if abs_path in self._ast_cache:
+            return self._ast_cache[abs_path]
+        try:
+            with open(abs_path, encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=abs_path)
+            self._ast_cache[abs_path] = tree
+            return tree
+        except Exception:
+            logger.debug("Failed to parse %s", abs_path, exc_info=True)
+            return None
+
+    def _relative_path(self, abs_path: str) -> str:
+        """Return a forward-slash relative path from the project dir."""
+        try:
+            return str(Path(abs_path).relative_to(self.project_dir)).replace("\\", "/")
+        except ValueError:
+            return Path(abs_path).name
+
+    def _node_id(self, abs_path: str, line: int) -> str:
+        return f"{self._relative_path(abs_path)}:{line}"
+
+    def _is_project_file(self, abs_path: str) -> bool:
+        return abs_path.startswith(self.project_dir) and "site-packages" not in abs_path
+
+    def _find_function_def(
+        self, tree: ast.Module, name: str
+    ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+        """Find a top-level function definition by name."""
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == name:
+                    return node
+        return None
+
+    def _resolve_imports(
+        self, tree: ast.Module, abs_file: str
+    ) -> dict[str, _ImportInfo]:
+        """Build a map of imported names → their source locations.
+
+        Only resolves imports that point to local project files.
+        """
+        result: dict[str, _ImportInfo] = {}
+        file_dir = os.path.dirname(abs_file)
+
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.ImportFrom):
+                module_path = self._resolve_module_path(
+                    node.module, node.level, file_dir
+                )
+                if module_path is None or not self._is_project_file(module_path):
+                    continue
+                for alias in node.names:
+                    imported_name = alias.asname if alias.asname else alias.name
+                    result[imported_name] = _ImportInfo(
+                        abs_path=module_path,
+                        original_name=alias.name,
+                    )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    module_path = self._resolve_module_path(alias.name, 0, file_dir)
+                    if module_path is None or not self._is_project_file(module_path):
+                        continue
+                    local_name = alias.asname if alias.asname else alias.name
+                    result[local_name] = _ImportInfo(
+                        abs_path=module_path,
+                        original_name=None,  # module-level import
+                    )
+        return result
+
+    def _resolve_module_path(
+        self, module: str | None, level: int, file_dir: str
+    ) -> str | None:
+        """Resolve a module name to an absolute file path, or None."""
+        if module is None and level == 0:
+            return None
+
+        if level > 0:
+            # Relative import: go up (level - 1) directories from file_dir
+            base = file_dir
+            for _ in range(level - 1):
+                base = os.path.dirname(base)
+            if module:
+                parts = module.split(".")
+                candidate = os.path.join(base, *parts)
+            else:
+                candidate = base
+        else:
+            # Absolute import: try from project dir
+            parts = module.split(".")  # type: ignore[union-attr]
+            candidate = os.path.join(self.project_dir, *parts)
+
+        # Check file.py then package/__init__.py
+        as_file = candidate + ".py"
+        if os.path.isfile(as_file):
+            return os.path.abspath(as_file)
+
+        as_pkg = os.path.join(candidate, "__init__.py")
+        if os.path.isfile(as_pkg):
+            return os.path.abspath(as_pkg)
+
+        return None
+
+    def _collect_calls(
+        self, func_node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> list[_CallSite]:
+        """Walk the function body and collect all function call sites."""
+        calls: list[_CallSite] = []
+        for node in ast.walk(func_node):
+            if not isinstance(node, ast.Call):
+                continue
+            info = self._extract_call_info(node)
+            if info is not None:
+                calls.append(info)
+        return calls
+
+    def _extract_call_info(self, call_node: ast.Call) -> _CallSite | None:
+        """Extract the callable name and line from a Call AST node."""
+        func = call_node.func
+        line = call_node.lineno
+
+        if isinstance(func, ast.Name):
+            # Simple call: foo()
+            return _CallSite(name=func.id, attr=None, line=line)
+        elif isinstance(func, ast.Attribute):
+            # Attribute call: module.foo() or obj.method()
+            if isinstance(func.value, ast.Name):
+                return _CallSite(name=func.value.id, attr=func.attr, line=line)
+        return None
+
+    @staticmethod
+    def _first_body_line(
+        func_def: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> int:
+        """Return the line number of the first executable statement in the body.
+
+        Skips leading docstrings so the resulting line sits *inside* the
+        function, not on the ``def`` line.  This matters for breakpoints:
+        a ``def`` line is a module-level statement executed during import,
+        whereas the first body line only fires when the function is called.
+        """
+        for stmt in func_def.body:
+            # Skip docstring (Expr wrapping a Constant string)
+            if (
+                isinstance(stmt, ast.Expr)
+                and isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, str)
+            ):
+                continue
+            return stmt.lineno
+        # Fallback: function has only a docstring (or is empty)
+        return func_def.body[0].lineno if func_def.body else func_def.lineno
+
+    def visit_function(self, abs_file: str, func_name: str, depth: int) -> str | None:
+        """Process a function: create its node and recurse into its calls.
+
+        Returns the node ID if the function was found, otherwise None.
+        """
+        tree = self._parse_file(abs_file)
+        if tree is None:
+            return None
+
+        func_def = self._find_function_def(tree, func_name)
+        if func_def is None:
+            return None
+
+        node_id = self._node_id(abs_file, self._first_body_line(func_def))
+
+        # Add node even if already visited (we need the ID for edges)
+        if node_id in self._visited:
+            return node_id
+
+        self._visited.add(node_id)
+        self.nodes.append(
+            UiPathRuntimeNode(
+                id=node_id,
+                name=func_name,
+                type="function",
+                metadata={"file": self._relative_path(abs_file)},
+            )
+        )
+
+        if depth >= self.max_depth:
+            return node_id
+
+        # Resolve imports and local definitions
+        imports = self._resolve_imports(tree, abs_file)
+        local_funcs = self._collect_local_function_names(tree)
+        calls = self._collect_calls(func_def)
+
+        for call in calls:
+            target_id = self._resolve_and_visit_call(
+                call, abs_file, tree, imports, local_funcs, depth
+            )
+            if target_id is not None:
+                self.edges.append(UiPathRuntimeEdge(source=node_id, target=target_id))
+
+        return node_id
+
+    def _collect_local_function_names(self, tree: ast.Module) -> set[str]:
+        """Collect names of all top-level functions defined in a module."""
+        names: set[str] = set()
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                names.add(node.name)
+        return names
+
+    def _resolve_and_visit_call(
+        self,
+        call: _CallSite,
+        caller_file: str,
+        caller_tree: ast.Module,
+        imports: dict[str, _ImportInfo],
+        local_funcs: set[str],
+        depth: int,
+    ) -> str | None:
+        """Resolve a call site to a target function and visit it.
+
+        Returns the target node ID, or None if unresolvable / external.
+        """
+        if call.attr is None:
+            # Simple call: foo()
+            if call.name in imports:
+                imp = imports[call.name]
+                if imp.original_name is not None:
+                    return self.visit_function(
+                        imp.abs_path, imp.original_name, depth + 1
+                    )
+            if call.name in local_funcs:
+                return self.visit_function(caller_file, call.name, depth + 1)
+        else:
+            # Attribute call: module.foo()
+            if call.name in imports:
+                imp = imports[call.name]
+                if imp.original_name is None:
+                    # Module-level import: import module → module.func()
+                    return self.visit_function(imp.abs_path, call.attr, depth + 1)
+        return None
+
+
+class _ImportInfo:
+    """Tracks where an imported name comes from."""
+
+    __slots__ = ("abs_path", "original_name")
+
+    def __init__(self, abs_path: str, original_name: str | None) -> None:
+        self.abs_path = abs_path
+        self.original_name = original_name
+
+
+class _CallSite:
+    """A function call found in the AST."""
+
+    __slots__ = ("name", "attr", "line")
+
+    def __init__(self, name: str, attr: str | None, line: int) -> None:
+        self.name = name
+        self.attr = attr
+        self.line = line

--- a/tests/functions/test_graph_builder.py
+++ b/tests/functions/test_graph_builder.py
@@ -1,0 +1,290 @@
+"""Tests for the AST-based call graph builder."""
+
+import textwrap
+
+import pytest
+
+from uipath.functions.graph_builder import build_call_graph
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    """Create a small multi-file project for testing."""
+    # main.py — the entrypoint
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent("""\
+        from helpers import process_data
+        from utils import format_output
+
+        def main(input):
+            result = process_data(input)
+            return format_output(result)
+        """)
+    )
+
+    # helpers.py — calls into a deeper utility
+    (tmp_path / "helpers.py").write_text(
+        textwrap.dedent("""\
+        from deep import transform
+
+        def process_data(data):
+            return transform(data)
+
+        def unused_function():
+            pass
+        """)
+    )
+
+    # utils.py — leaf function
+    (tmp_path / "utils.py").write_text(
+        textwrap.dedent("""\
+        def format_output(data):
+            return str(data)
+        """)
+    )
+
+    # deep.py — deeper than default depth
+    (tmp_path / "deep.py").write_text(
+        textwrap.dedent("""\
+        def transform(data):
+            return data
+        """)
+    )
+
+    return tmp_path
+
+
+def test_basic_graph_structure(project_dir):
+    """Entrypoint node and its direct callees are discovered."""
+    graph = build_call_graph(
+        str(project_dir / "main.py"),
+        "main",
+        project_dir=str(project_dir),
+        max_depth=3,
+    )
+
+    node_names = {n.name for n in graph.nodes}
+
+    # Should contain main, process_data, format_output, transform
+    assert "main" in node_names
+    assert "process_data" in node_names
+    assert "format_output" in node_names
+    assert "transform" in node_names
+
+    # unused_function should NOT appear
+    assert "unused_function" not in node_names
+
+
+def test_node_ids_are_file_line(project_dir):
+    """Node IDs must follow the file:line format for breakpoints."""
+    graph = build_call_graph(
+        str(project_dir / "main.py"),
+        "main",
+        project_dir=str(project_dir),
+    )
+
+    for node in graph.nodes:
+        parts = node.id.rsplit(":", 1)
+        assert len(parts) == 2, f"Node ID '{node.id}' is not in file:line format"
+        assert parts[1].isdigit(), f"Line part of '{node.id}' is not a number"
+
+
+def test_edges_connect_caller_to_callee(project_dir):
+    """Edges should go from caller to callee."""
+    graph = build_call_graph(
+        str(project_dir / "main.py"),
+        "main",
+        project_dir=str(project_dir),
+    )
+
+    id_to_name = {n.id: n.name for n in graph.nodes}
+    edge_pairs = {(id_to_name[e.source], id_to_name[e.target]) for e in graph.edges}
+
+    assert ("main", "process_data") in edge_pairs
+    assert ("main", "format_output") in edge_pairs
+    assert ("process_data", "transform") in edge_pairs
+
+
+def test_max_depth_limits_recursion(project_dir):
+    """Setting max_depth=1 should only include the entrypoint and its direct calls."""
+    graph = build_call_graph(
+        str(project_dir / "main.py"),
+        "main",
+        project_dir=str(project_dir),
+        max_depth=1,
+    )
+
+    node_names = {n.name for n in graph.nodes}
+
+    assert "main" in node_names
+    assert "process_data" in node_names
+    assert "format_output" in node_names
+    # transform is 2 levels deep, should be excluded
+    assert "transform" not in node_names
+
+
+def test_no_duplicates_on_repeated_calls(tmp_path):
+    """A function called multiple times should appear as one node."""
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent("""\
+        def helper():
+            pass
+
+        def main():
+            helper()
+            helper()
+            helper()
+        """)
+    )
+
+    graph = build_call_graph(
+        str(tmp_path / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    names = [n.name for n in graph.nodes]
+    assert names.count("helper") == 1
+    # But there can be multiple edges (one per call site)
+
+
+def test_local_function_calls(tmp_path):
+    """Functions defined in the same file are resolved."""
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent("""\
+        def step_a():
+            pass
+
+        def step_b():
+            step_a()
+
+        def main():
+            step_b()
+        """)
+    )
+
+    graph = build_call_graph(
+        str(tmp_path / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    node_names = {n.name for n in graph.nodes}
+    assert node_names == {"main", "step_b", "step_a"}
+
+
+def test_async_functions(tmp_path):
+    """Async function definitions and await calls are handled."""
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent("""\
+        async def helper():
+            pass
+
+        async def main():
+            await helper()
+        """)
+    )
+
+    graph = build_call_graph(
+        str(tmp_path / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    node_names = {n.name for n in graph.nodes}
+    assert node_names == {"main", "helper"}
+
+
+def test_external_calls_ignored(tmp_path):
+    """Calls to external/unknown functions produce no nodes."""
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent("""\
+        import json
+
+        def main(data):
+            return json.dumps(data)
+        """)
+    )
+
+    graph = build_call_graph(
+        str(tmp_path / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    assert len(graph.nodes) == 1
+    assert graph.nodes[0].name == "main"
+    assert len(graph.edges) == 0
+
+
+def test_missing_function_returns_empty_graph(tmp_path):
+    """If the entrypoint function doesn't exist, return an empty graph."""
+    (tmp_path / "main.py").write_text("def other(): pass\n")
+
+    graph = build_call_graph(
+        str(tmp_path / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    assert len(graph.nodes) == 0
+    assert len(graph.edges) == 0
+
+
+def test_relative_import(tmp_path):
+    """Relative imports (from .module import func) are resolved."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+
+    (pkg / "main.py").write_text(
+        textwrap.dedent("""\
+        from .helpers import do_work
+
+        def main():
+            do_work()
+        """)
+    )
+    (pkg / "helpers.py").write_text(
+        textwrap.dedent("""\
+        def do_work():
+            pass
+        """)
+    )
+
+    graph = build_call_graph(
+        str(pkg / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    node_names = {n.name for n in graph.nodes}
+    assert "main" in node_names
+    assert "do_work" in node_names
+
+
+def test_module_attribute_call(tmp_path):
+    """import module; module.func() pattern is resolved."""
+    (tmp_path / "mymod.py").write_text(
+        textwrap.dedent("""\
+        def compute():
+            pass
+        """)
+    )
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent("""\
+        import mymod
+
+        def main():
+            mymod.compute()
+        """)
+    )
+
+    graph = build_call_graph(
+        str(tmp_path / "main.py"),
+        "main",
+        project_dir=str(tmp_path),
+    )
+
+    node_names = {n.name for n in graph.nodes}
+    assert "compute" in node_names

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.28"
+version = "2.8.29"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- **AST-based call graph builder** (`graph_builder.py`): parses user code from an entrypoint function, builds a `UiPathRuntimeGraph` with `file:line` node IDs that double as breakpoint locations
- **State events during execution**: emits `UiPathRuntimeStateEvent` for every call-graph function entry (even without breakpoints), so the debug bridge can visualise execution flow through graph nodes
- **OTEL context propagation**: copies `contextvars` to the background trace thread so `@traced` decorator spans are properly linked to the parent trace
- **Breakpoint reliability fixes**:
  - Node IDs point to the first executable body line (skipping docstrings) instead of the `def` line, preventing false breakpoint hits during module imports
  - `<module>` frame line events are skipped in the trace callback
  - Per-frame deduplication prevents multiline expressions (e.g. `return Foo(arg=bar(...))`) from triggering the same breakpoint twice due to bytecode line bouncing

<img width="1914" height="952" alt="image" src="https://github.com/user-attachments/assets/fbfbc7ba-0294-4c96-86a6-d60bd0306b09" />

## Test plan
- [x] 11 tests for AST call graph builder (multi-file, async, relative imports, depth limits, etc.)
- [x] E2E tests for state events: with/without breakpoints, through decorator wrappers, external function exclusion
- [x] Test for multiline expression breakpoint deduplication
- [x] All 1968 existing tests pass
- [x] ruff check, ruff format, mypy all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)