### PR TITLE
fix: constrain graph render on cli init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.30"
+version = "2.8.31"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -21,7 +21,7 @@ dependencies = [
   "python-socketio>=5.15.0, <6.0.0",
   "coverage>=7.8.2",
   "mermaid-builder==0.0.3",
-  "graphtty==0.1.6",
+  "graphtty==0.1.8",
   "applicationinsights>=0.11.10",
 ]
 classifiers = [

--- a/src/uipath/_cli/cli_init.py
+++ b/src/uipath/_cli/cli_init.py
@@ -309,7 +309,7 @@ def _display_entrypoint_graphs(entry_point_schemas: list[UiPathRuntimeSchema]) -
             _enrich_graph_node_descriptions(graph_data)
 
             ascii_graph = AsciiGraph(**graph_data)
-            options = RenderOptions(theme=TOKYO_NIGHT)
+            options = RenderOptions(theme=TOKYO_NIGHT, max_breadth=3, max_depth=5)
             rendered = render(ascii_graph, options)
             click.echo(_render_graph(rendered))
         except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -699,11 +699,11 @@ wheels = [
 
 [[package]]
 name = "graphtty"
-version = "0.1.6"
+version = "0.1.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/06/96130c4d3e2cdaf965f1060143bea276905b7050adf324a00ed705a84617/graphtty-0.1.6.tar.gz", hash = "sha256:1d989baf901d2bfe125f1e2aee730fd4b143c0dd4b4640fef9dcf42535430386", size = 549561, upload-time = "2026-02-09T13:20:16.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/b3/0756e1b1e46b61a4db4a463a76ca113e62113742f97ac6cf383dd05d6a97/graphtty-0.1.8.tar.gz", hash = "sha256:069cd84764cc64d414928451071fc9c97c05becbf564c2f0278691a6451a8240", size = 638011, upload-time = "2026-02-15T12:47:17.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/69/d3e359238c1846aead328c7efcf6875028b326e54253d3d7d65645943d5e/graphtty-0.1.6-py3-none-any.whl", hash = "sha256:163e0f8a35ebab9bd37d834619088aa2aa36a112a3c1f9577030cef1b9be8663", size = 22853, upload-time = "2026-02-09T13:20:15.011Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a9/66d01580a4a92b576c056e9967d552a28ed836540eaf73b436474c514bc2/graphtty-0.1.8-py3-none-any.whl", hash = "sha256:4e19e6d66b9ef79e2715377163f61a6542b5b9ee00d50406b80a40d0ba094f67", size = 25474, upload-time = "2026-02-15T12:47:16.377Z" },
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.30"
+version = "2.8.31"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2588,7 +2588,7 @@ requires-dist = [
     { name = "applicationinsights", specifier = ">=0.11.10" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "coverage", specifier = ">=7.8.2" },
-    { name = "graphtty", specifier = "==0.1.6" },
+    { name = "graphtty", specifier = "==0.1.8" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mermaid-builder", specifier = "==0.0.3" },
     { name = "mockito", specifier = ">=1.5.4" },


### PR DESCRIPTION
## Description

This PR adds graph rendering constraints to the CLI init command by updating the graphtty dependency from 0.1.6 to 0.1.8 and configuring `RenderOptions` with `max_breadth` and `max_depth` parameters to limit the size of rendered ASCII graphs.

<img width="1014" height="556" alt="image" src="https://github.com/user-attachments/assets/cb8370ad-e49a-4e9e-ad28-2f978e14a9a5" />
