### PR TITLE
fix: send phase on debug state events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.34"
+version = "2.8.35"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_debug/_bridge.py
+++ b/src/uipath/_cli/_debug/_bridge.py
@@ -564,6 +564,7 @@ class SignalRDebugBridge:
                 "executionId": state_event.execution_id,
                 "nodeName": state_event.node_name,
                 "qualifiedNodeName": state_event.qualified_node_name,
+                "phase": state_event.phase,
                 "state": state_event.payload,
             },
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.34"
+version = "2.8.35"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Description

This PR fixes a bug in the debug state event handling by adding the missing phase field to the state update payload sent to the remote debugger via SignalR. The change ensures that debug state events include all relevant execution phase information.