### PR TITLE
feat: graph node ID uses last body line + phase lifecycle events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.36"
+version = "2.8.37"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.36"
+version = "2.8.37"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Graph node IDs now use the **last body line** instead of the first, so breakpoints derived from graph nodes fire where all local variables are visible for inspection
- `UiPathFunctionsRuntime.stream()` emits **STARTED/COMPLETED/FAULTED** phase lifecycle events around execution, giving consumers visibility into the execution lifecycle
- Debug trace callback emits **started** phase on function call and **completed** phase on function return, with `__return__` key in the completed payload
- Bumps version to 2.8.37

## Test plan
- [x] Added `test_node_id_uses_last_body_line` and `test_node_id_last_line_with_docstring` to graph builder tests
- [x] Updated existing debug tests for 2 state events per function (started + completed)
- [x] Added `test_state_events_have_started_and_completed_phases` verifying both phases fire with correct payloads
- [x] Added `test_stream_phase_events_from_functions_runtime` for stream-level phase events
- [x] All 1997 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)