### PR TITLE
Update citation prompt to use self-closing xml tags [JAR-8939]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.9.1"
+version = "2.9.2"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/tests/agent/react/test_conversational_prompts.py
+++ b/tests/agent/react/test_conversational_prompts.py
@@ -5,14 +5,8 @@ import re
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-import pytest
-
 from uipath.agent.react.conversational_prompts import (
-    CitationType,
     PromptUserSettings,
-    _get_citation_example_prompt,
-    _get_citation_format_prompt,
-    _get_citation_type,
     _get_user_settings_template,
     get_chat_system_prompt,
 )
@@ -155,49 +149,10 @@ class TestGenerateConversationalAgentSystemPrompt:
         assert "You are Unnamed Agent." in prompt
 
 
-class TestCitationType:
-    """Tests for citation type determination."""
-
-    @pytest.mark.parametrize(
-        "model",
-        [
-            "claude-3-sonnet",
-            "claude-3-opus",
-            "claude-3-haiku",
-            "gemini-pro",
-            "llama-3",
-            "mistral-large",
-        ],
-    )
-    def test_citation_type_wrapped_for_non_gpt_models(self, model):
-        """Non-GPT models get CitationType.WRAPPED."""
-        citation_type = _get_citation_type(model)
-
-        assert citation_type == CitationType.WRAPPED
-
-    @pytest.mark.parametrize(
-        "model",
-        [
-            "gpt-4",
-            "gpt-4o",
-            "gpt-4o-2024-11-20",
-            "gpt-3.5-turbo",
-            "GPT-4",  # Test case insensitivity
-            "GPT-4O-MINI",
-        ],
-    )
-    def test_citation_type_trailing_for_gpt_models(self, model):
-        """GPT models get CitationType.TRAILING."""
-        citation_type = _get_citation_type(model)
-
-        assert citation_type == CitationType.TRAILING
-
-
-class TestCitationFormatPrompt:
+class TestCitationFormat:
     """Tests for citation format in generated prompts."""
 
-    def test_citation_format_wrapped_in_prompt(self):
-        """Wrapped citation format appears in prompt for non-GPT models."""
+    def test_citation_format_claude(self):
         prompt = get_chat_system_prompt(
             model="claude-3-sonnet",
             system_message=SYSTEM_MESSAGE,
@@ -205,10 +160,12 @@ class TestCitationFormatPrompt:
             user_settings=None,
         )
 
-        assert "<uip:cite sources='[...]'>factual claim here</uip:cite>" in prompt
+        assert (
+            '<uip:cite title="Document Title" reference="https://url" page_number="1"/>'
+            in prompt
+        )
 
-    def test_citation_format_trailing_in_prompt(self):
-        """Trailing citation format appears in prompt for GPT models."""
+    def test_citation_format_gpt(self):
         prompt = get_chat_system_prompt(
             model="gpt-4o",
             system_message=SYSTEM_MESSAGE,
@@ -216,10 +173,12 @@ class TestCitationFormatPrompt:
             user_settings=None,
         )
 
-        assert "factual claim here<uip:cite sources='[...]'></uip:cite>" in prompt
+        assert (
+            '<uip:cite title="Document Title" reference="https://url" page_number="1"/>'
+            in prompt
+        )
 
-    def test_wrapped_citation_examples_in_prompt(self):
-        """Wrapped citation examples appear for non-GPT models."""
+    def test_citation_examples_in_prompt(self):
         prompt = get_chat_system_prompt(
             model="claude-3-sonnet",
             system_message=SYSTEM_MESSAGE,
@@ -227,79 +186,16 @@ class TestCitationFormatPrompt:
             user_settings=None,
         )
 
-        # Check wrapped example
+        assert "EXAMPLES OF CORRECT USAGE:" in prompt
         assert (
-            '<uip:cite sources=\'[{"title":"Study","url":"https://example.com"}]\'>AI adoption is growing</uip:cite>'
+            '<uip:cite title="Industry Study" url="https://example.com/study"/>'
             in prompt
         )
-        # Should NOT contain trailing example pattern
         assert (
-            'AI adoption is growing<uip:cite sources=\'[{"title":"Study","url":"https://example.com"}]\'></uip:cite>'
-            not in prompt
-        )
-
-    def test_trailing_citation_examples_in_prompt(self):
-        """Trailing citation examples appear for GPT models."""
-        prompt = get_chat_system_prompt(
-            model="gpt-4o",
-            system_message=SYSTEM_MESSAGE,
-            agent_name="Test Agent",
-            user_settings=None,
-        )
-
-        # Check trailing example
-        assert (
-            'AI adoption is growing<uip:cite sources=\'[{"title":"Study","url":"https://example.com"}]\'></uip:cite>'
+            '<uip:cite title="Policy Manual v2.pdf" reference="https://docs.example.com/ref" page_number="15"/>'
             in prompt
         )
-
-
-class TestGetCitationFormatPrompt:
-    """Tests for _get_citation_format_prompt helper."""
-
-    def test_wrapped_format(self):
-        """Returns wrapped format string."""
-        result = _get_citation_format_prompt(CitationType.WRAPPED)
-        assert "<uip:cite sources='[...]'>factual claim here</uip:cite>" in result
-
-    def test_trailing_format(self):
-        """Returns trailing format string."""
-        result = _get_citation_format_prompt(CitationType.TRAILING)
-        assert "factual claim here<uip:cite sources='[...]'></uip:cite>" in result
-
-    def test_none_format(self):
-        """Returns empty string for NONE type."""
-        result = _get_citation_format_prompt(CitationType.NONE)
-        assert result == ""
-
-
-class TestGetCitationExamplePrompt:
-    """Tests for _get_citation_example_prompt helper."""
-
-    def test_wrapped_example(self):
-        """Returns wrapped example string."""
-        result = _get_citation_example_prompt(CitationType.WRAPPED)
-        assert "EXAMPLES OF CORRECT USAGE:" in result
-        assert "CRITICAL ERRORS TO AVOID:" in result
-        assert (
-            '<uip:cite sources=\'[{"title":"Study","url":"https://example.com"}]\'>AI adoption is growing</uip:cite>'
-            in result
-        )
-
-    def test_trailing_example(self):
-        """Returns trailing example string."""
-        result = _get_citation_example_prompt(CitationType.TRAILING)
-        assert "EXAMPLES OF CORRECT USAGE:" in result
-        assert "CRITICAL ERRORS TO AVOID:" in result
-        assert (
-            'AI adoption is growing<uip:cite sources=\'[{"title":"Study","url":"https://example.com"}]\'></uip:cite>'
-            in result
-        )
-
-    def test_none_example(self):
-        """Returns empty string for NONE type."""
-        result = _get_citation_example_prompt(CitationType.NONE)
-        assert result == ""
+        assert "CRITICAL ERRORS TO AVOID:" in prompt
 
 
 class TestPromptUserSettings:

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.9.1"
+version = "2.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
# Description
- citation prompts are not unified for all model types
- remove citation format which uses xml with arrays
- use self-enclosing xml formats instead

# Research behind change
- [Prompt provided by ML team](https://github.com/UiPath/agents_gym/pull/853/changes#diff-02a867b370d734625e685702eccb104d3863d0749b447d1d99f3d272bf645986)
- [Research report by ML team](https://uipath.atlassian.net/wiki/spaces/JAR/pages/89941705037/Methods+for+improving+citation+consistency)
- +68% for sonnet 4.5
- +90% for gpt5

# Related PR
- Citation parser PR: https://github.com/UiPath/uipath-langchain-python/pull/597


https://uipath.atlassian.net/browse/JAR-8939