### PR TITLE
feat: move bindings resolution before runtime instantiation on debug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.43"
+version = "2.8.44"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -210,7 +210,6 @@ class TestRun:
                         output_file_path,
                     ],
                 )
-                print(result.output)
                 assert result.exit_code == 0
                 assert "Successful execution." in result.output
                 assert result.output.count("Hello world") >= 2

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.43"
+version = "2.8.44"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- move bindings resolution before runtime instantiation on debug

<!-- DEV_PACKAGE_START -->
## Development Package

- Use `uipath pack --nolock` to get the latest dev build from this PR (requires version range).
- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.8.44.dev1013484920",

  # Any version from PR
  "uipath>=2.8.44.dev1013480000,<2.8.44.dev1013490000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.8.44.dev1013480000,<2.8.44.dev1013490000",
]
```
<!-- DEV_PACKAGE_END -->