### PR TITLE
fix: handle exceptions in serialize_object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.8.42"
+version = "2.8.43"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/_utils/_common.py
+++ b/src/uipath/_cli/_utils/_common.py
@@ -82,6 +82,9 @@ def serialize_object(obj):
         return serialize_object(obj.dict())
     elif hasattr(obj, "to_dict"):
         return serialize_object(obj.to_dict())
+    # Special handling for UiPathBaseRuntimeErrors
+    elif hasattr(obj, "as_dict"):
+        return serialize_object(obj.as_dict)
     elif isinstance(obj, (datetime, date, time)):
         return obj.isoformat()
     # Handle dictionaries
@@ -90,6 +93,9 @@ def serialize_object(obj):
     # Handle lists
     elif isinstance(obj, list):
         return [serialize_object(item) for item in obj]
+    # Handle exceptions
+    elif isinstance(obj, Exception):
+        return str(obj)
     # Handle other iterable objects (convert to dict first)
     elif hasattr(obj, "__iter__") and not isinstance(obj, (str, bytes)):
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.8.42"
+version = "2.8.43"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Fixes payload serialization for SignalR events:
<img width="839" height="97" alt="image" src="https://github.com/user-attachments/assets/e11cb674-dd8d-46d9-a588-870831242994" />
