### PR TITLE
(wip) fix: upload batch transform result as attachment

### DIFF
--- a/src/uipath/platform/resume_triggers/_protocol.py
+++ b/src/uipath/platform/resume_triggers/_protocol.py
@@ -301,7 +301,15 @@ class UiPathResumeTriggerReader:
                             f"{e.message}",
                         ) from e
 
-                    return f"Batch transform completed. Modified file available at {os.path.abspath(destination_path)}"
+                    attachment_key = await uipath.attachments.upload_async(
+                        name=os.path.basename(destination_path),
+                        source_path=destination_path,
+                    )
+                    return {
+                        "ID": str(attachment_key),
+                        "FullName": os.path.basename(destination_path),
+                        "MimeType": "text/csv",
+                    }
 
             case UiPathResumeTriggerType.IXP_EXTRACTION:
                 if trigger.item_key:


### PR DESCRIPTION
## Summary
- Batch transform resume trigger now uploads the output file as a platform attachment via `uipath.attachments.upload_async()`
- Returns structured `{ID, FullName, MimeType}` dict instead of a plain string
- Matches the context grounding tool result schema used by C# Agents
- Enables downstream OTEL span instrumentation to extract attachment metadata

## Test plan
- [ ] Run batch transform agent end-to-end, verify output file is uploaded as attachment
- [ ] Confirm trace spans show correct `ID`, `FullName`, `MimeType` attributes
- [ ] Verify non-batch-transform resume triggers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)