### PR TITLE
fix: set default query settings for context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.9.7"
+version = "2.9.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/agent/models/agent.py
+++ b/src/uipath/agent/models/agent.py
@@ -358,7 +358,9 @@ class AgentContextSettings(BaseCfg):
     # Allow Unknown explicitly so we can serialize deterministically
     retrieval_mode: AgentContextRetrievalMode = Field(alias="retrievalMode")
     threshold: float = Field(default=0)
-    query: Optional[AgentContextQuerySetting] = Field(None)
+    query: AgentContextQuerySetting = Field(
+        default_factory=lambda: AgentContextQuerySetting(variant="dynamic")
+    )
     folder_path_prefix: Optional[Union[Dict[str, Any], AgentContextValueSetting]] = (
         Field(None, alias="folderPathPrefix")
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.9.7"
+version = "2.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
uipath-agents-python throws if query is None. This is not backwards compatible.

`dynamic` is the default value used by the frontend migration, so we should also default to it when parsing the agent.