### PR TITLE
fix: make context and web search format explicit NO-JIRA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.9.12"
+version = "2.9.13"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/agent/react/conversational_prompts.py
+++ b/src/uipath/agent/react/conversational_prompts.py
@@ -83,12 +83,13 @@ WHAT TO CITE:
 - Any information drawn from Context Grounding documents.
 
 CITATION FORMAT (self-closing tag after each sentence with cited information):
-<uip:cite title="Document Title" reference="https://url" page_number="1"/>
+- Web results: <uip:cite title="Document Title" url="https://url"/>
+- Context Grounding: <uip:cite title="Document Title" reference="https://url" page_number="1"/>
 
 TOOL RESULT PATTERNS REQUIRING CITATION:
 Tool results containing these fields indicate citable sources:
-- Web results: "url", "title" fields -> use title and url attributes
-- Context Grounding: objects with "reference", "source", "page_number" -> use title (from source), reference, page_number attributes
+- Web results: "url", "title" fields -> use url, title attributes
+- Context Grounding: objects with "reference", "source", "page_number" -> use reference, title (from source), page_number attributes
 
 RULES:
 - Place citation tag immediately after the sentence containing the cited fact
@@ -96,6 +97,8 @@ RULES:
 - For web results: use title and url attributes
 - For context grounding: use title, reference, and page_number attributes
 - Never include citations in tool inputs
+- Do not mix attributes between citation types: web results use only title/url, context grounding uses only title/reference/page_number
+- Do not add a space before the citation tag
 
 EXAMPLES OF CORRECT USAGE:
 AI adoption is growing rapidly.<uip:cite title="Industry Study" url="https://example.com/study"/>

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.9.12"
+version = "2.9.13"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
# Problem:
https://github.com/user-attachments/assets/5f68a15c-0a6a-46df-b4dd-287ce45af8ff


# Solution
I'm making the web search vs context grounding citation more explicit like this (+ minor consistency nit for field mapping)

On langchain side, I don't think we should be programmatically prioritize/correct towards a web search vs context grounding format when the LLM does make a mistake and emit both - because we don't know what's going to be correct when it hallucinates. For example if we have a heuristic like "if page number doesn't exists in the citation format, correct it to web search" that could be wrong if the LLM hallucinates a page number for web search result

(fyi the mapping is url -> url and reference -> download_url )