### PR TITLE
fix: reconfigure stdout/stderr to UTF-8 on Windows to prevent charmap encoding errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.9.14"
+version = "2.9.15"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -9,6 +9,13 @@ from uipath._cli._utils._context import CliContext
 from uipath._utils._logs import setup_logging
 from uipath._utils.constants import DOTENV_FILE
 
+# Windows console uses codepages (e.g. cp1252) that can't encode Unicode
+# characters used by Rich spinners (Braille) and emoji output.
+if sys.platform == "win32":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
+
 # DO NOT ADD HEAVY IMPORTS HERE
 #
 # Every import at the top of this file runs on EVERY command.

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.9.14"
+version = "2.9.15"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Summary

  - Fix 'charmap' codec can't encode character errors on Windows by reconfiguring stdout/stderr to UTF-8 early in CLI
  initialization
  - Windows console defaults to codepages (e.g. cp1252) that can't encode Unicode characters used by Rich spinners
  (Braille) and emoji output

  Why this approach

  Most popular Python CLIs (Rich, Click, pip) don't fix this themselves, they either document PYTHONUTF8=1 as a
  user-side workaround, or avoid Unicode characters entirely.

  Python 3.15 will make UTF-8 the default everywhere (https://peps.python.org/pep-0686/), but until then every Python
  CLI on Windows is affected.

  We chose `sys.stdout.reconfigure(encoding="utf-8")` over alternatives because:
  - PYTHONUTF8=1 can't be set programmatically: Python reads it at startup, so it would require users to configure it
  themselves
  - Avoiding Unicode characters limits UX (no spinners, no emoji)
  - reconfigure is scoped to stdout/stderr only, doesn't change behavior of open() or file system encoding, and is
  automatic for the user

  Modern terminals (Windows Terminal, PowerShell 7, VS Code) already expect UTF-8, this fix just aligns Python's output
   encoding with what they want. On legacy terminals, it prevents crashes (characters may render imperfectly but won't
  throw exceptions).