### PR TITLE
fix: subprocess encoding on windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.0"
+version = "2.10.1"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/_cli/__init__.py
+++ b/src/uipath/_cli/__init__.py
@@ -11,11 +11,15 @@ from uipath._utils.constants import DOTENV_FILE
 
 # Windows console uses codepages (e.g. cp1252) that can't encode Unicode
 # characters used by Rich spinners (Braille) and emoji output.
+# When piped (not a TTY), keep the system encoding so the parent process
+# can decode our output, but use errors="replace" to avoid write-side crashes.
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):
         if hasattr(_stream, "reconfigure"):
-            _stream.reconfigure(encoding="utf-8")
-
+            if _stream.isatty():
+                _stream.reconfigure(encoding="utf-8")
+            else:
+                _stream.reconfigure(errors="replace")
 # DO NOT ADD HEAVY IMPORTS HERE
 #
 # Every import at the top of this file runs on EVERY command.

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.0"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Description

This PR fixes subprocess encoding issues on Windows by improving how stdout/stderr encoding is configured. The fix addresses a problem where parent processes couldn't properly decode output when the CLI was invoked as a subprocess with piped output.