### PR TITLE
feat: add internal tenant/account headers for local flow tracing

### DIFF
--- a/src/uipath/tracing/_otel_exporters.py
+++ b/src/uipath/tracing/_otel_exporters.py
@@ -128,8 +128,12 @@ class LlmOpsHttpExporter(SpanExporter):
         }
 
         if os.environ.get("UIPATH_TRACE_BASE_URL"):
-            self.headers["X-UiPath-Internal-TenantId"] = os.environ.get("UIPATH_TENANT_ID", "")
-            self.headers["X-UiPath-Internal-AccountId"] = os.environ.get("UIPATH_ORGANIZATION_ID", "")
+            self.headers["X-UiPath-Internal-TenantId"] = os.environ.get(
+                "UIPATH_TENANT_ID", ""
+            )
+            self.headers["X-UiPath-Internal-AccountId"] = os.environ.get(
+                "UIPATH_ORGANIZATION_ID", ""
+            )
 
         client_kwargs = get_httpx_client_kwargs()
 

--- a/tests/tracing/test_otel_exporters.py
+++ b/tests/tracing/test_otel_exporters.py
@@ -231,8 +231,14 @@ def test_internal_headers_set_when_trace_base_url_present():
         with patch("uipath.tracing._otel_exporters.httpx.Client"):
             exporter = LlmOpsHttpExporter()
 
-            assert exporter.headers["X-UiPath-Internal-TenantId"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-            assert exporter.headers["X-UiPath-Internal-AccountId"] == "11111111-2222-3333-4444-555555555555"
+            assert (
+                exporter.headers["X-UiPath-Internal-TenantId"]
+                == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+            )
+            assert (
+                exporter.headers["X-UiPath-Internal-AccountId"]
+                == "11111111-2222-3333-4444-555555555555"
+            )
 
 
 def test_internal_headers_not_set_without_trace_base_url():


### PR DESCRIPTION
## Summary
- When `UIPATH_TRACE_BASE_URL` is set (local flow mode), the `LlmOpsHttpExporter` now includes `X-UiPath-Internal-TenantId` and `X-UiPath-Internal-AccountId` headers in requests to the IngestSpans endpoint
- Headers are **not** added in cloud mode (when `UIPATH_TRACE_BASE_URL` is absent)
- Reads tenant ID from `UIPATH_TENANT_ID` and org ID from `UIPATH_ORGANIZATION_ID` environment variables

## Test plan
- [x] Added `test_internal_headers_set_when_trace_base_url_present` — verifies headers are included when `UIPATH_TRACE_BASE_URL` is set
- [x] Added `test_internal_headers_not_set_without_trace_base_url` — verifies headers are absent in cloud mode
- [x] All 1578 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)