### PR TITLE
refactor: make invocation link clickable

### DIFF
--- a/src/uipath/_cli/cli_invoke.py
+++ b/src/uipath/_cli/cli_invoke.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import tomllib
+import urllib.parse
 
 import click
 import httpx
@@ -113,7 +114,14 @@ def invoke(entrypoint: str | None, input: str | None, file: str | None) -> None:
                     console.error("Error: Failed to get job key from response")
                 if job_key:
                     with console.spinner("Starting job ..."):
-                        job_url = f"{base_url}/orchestrator_/jobs(sidepanel:sidepanel/jobs/{job_key}/details)?fid={personal_workspace_folder_id}"
+                        url_params = {"fid": str(personal_workspace_folder_id)}
+                        job_url_path = urllib.parse.quote(
+                            f"orchestrator_/jobs(sidepanel:sidepanel/jobs/{job_key}/details)"
+                        )
+                        job_url_full_path = urllib.parse.urljoin(base_url, job_url_path)
+                        job_url = (
+                            f"{job_url_full_path}?{urllib.parse.urlencode(url_params)}"
+                        )
                         console.magic("Job started successfully!")
                         console.link("Monitor your job here: ", job_url)
             else:


### PR DESCRIPTION
# Summary
- Resolves issue: #1390 . Make the job invocation link clickable at the terminal console.

# Changes
- Utilize urllib to handle proper encoding of special characters, including both path parameters and query parameters.
- "?" is preserved to separates the path from the query string.
- Special characters in `workspace_folder_id` will also be encoded.

# Screenshoot
<img width="1449" height="117" alt="Untitled design" src="https://github.com/user-attachments/assets/9997c374-01ef-486f-a1ac-314089116367" />
