### PR TITLE
fix: resolve PEP 563 annotations and propagate errors in FunctionsRuntime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.2"
+version = "2.10.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath/functions/runtime.py
+++ b/src/uipath/functions/runtime.py
@@ -19,7 +19,6 @@ from uipath.runtime import (
 from uipath.runtime.errors import (
     UiPathErrorCategory,
     UiPathErrorCode,
-    UiPathErrorContract,
     UiPathRuntimeError,
 )
 from uipath.runtime.events import UiPathRuntimeStateEvent, UiPathRuntimeStatePhase
@@ -125,9 +124,16 @@ class UiPathFunctionsRuntime:
             result = await func() if is_async else func()
             return convert_from_class(result) if result is not None else {}
 
-        # Get first parameter info
+        # Get first parameter info.
+        # Use get_type_hints() to resolve PEP 563 stringified annotations
+        # (from `from __future__ import annotations`).  inspect.signature()
+        # returns raw strings in that case, which breaks type detection.
         input_param = params[0]
-        input_type = input_param.annotation
+        try:
+            hints = get_type_hints(unwrapped)
+            input_type = hints.get(input_param.name, inspect.Parameter.empty)
+        except Exception:
+            input_type = input_param.annotation
 
         # Typed parameter (class, dataclass, or Pydantic)
         if input_type != inspect.Parameter.empty and (
@@ -161,17 +167,12 @@ class UiPathFunctionsRuntime:
         except UiPathRuntimeError:
             raise
         except Exception as e:
-            logger.exception(f"Function execution failed: {e}")
-            return UiPathRuntimeResult(
-                output=None,
-                status=UiPathRuntimeStatus.FAULTED,
-                error=UiPathErrorContract(
-                    code=UiPathErrorCode.FUNCTION_EXECUTION_ERROR,
-                    category=UiPathErrorCategory.USER,
-                    title=f"Function execution failed: {self.function_name}",
-                    detail=str(e),
-                ),
-            )
+            raise UiPathRuntimeError(
+                UiPathErrorCode.FUNCTION_EXECUTION_ERROR,
+                f"Function execution failed: {self.function_name}",
+                str(e),
+                UiPathErrorCategory.USER,
+            ) from e
 
     async def stream(
         self,
@@ -189,27 +190,28 @@ class UiPathFunctionsRuntime:
             payload=input or {},
         )
 
-        result = await self.execute(input, options)
-
-        if result.status == UiPathRuntimeStatus.FAULTED and result.error is not None:
+        try:
+            result = await self.execute(input, options)
+        except UiPathRuntimeError as e:
             yield UiPathRuntimeStateEvent(
                 node_name=self.function_name,
                 phase=UiPathRuntimeStatePhase.FAULTED,
-                payload={"error": result.error.model_dump()},
+                payload={"error": str(e)},
             )
+            raise
+
+        output = result.output
+        if output is None:
+            completed_payload: dict[str, Any] = {}
+        elif isinstance(output, dict):
+            completed_payload = output
         else:
-            output = result.output
-            if output is None:
-                completed_payload: dict[str, Any] = {}
-            elif isinstance(output, dict):
-                completed_payload = output
-            else:
-                completed_payload = {"output": str(output)}
-            yield UiPathRuntimeStateEvent(
-                node_name=self.function_name,
-                phase=UiPathRuntimeStatePhase.COMPLETED,
-                payload=completed_payload,
-            )
+            completed_payload = {"output": str(output)}
+        yield UiPathRuntimeStateEvent(
+            node_name=self.function_name,
+            phase=UiPathRuntimeStatePhase.COMPLETED,
+            payload=completed_payload,
+        )
 
         yield result
 

--- a/tests/functions/test_unwrap_decorated.py
+++ b/tests/functions/test_unwrap_decorated.py
@@ -5,6 +5,8 @@ import textwrap
 import pytest
 
 from uipath.functions.runtime import UiPathFunctionsRuntime
+from uipath.runtime.errors import UiPathRuntimeError
+from uipath.runtime.events import UiPathRuntimeStateEvent, UiPathRuntimeStatePhase
 
 
 @pytest.fixture
@@ -96,3 +98,79 @@ async def test_schema_type_reflects_entrypoint_type(decorated_module):
     )
     schema_agent = await runtime_agent.get_schema()
     assert schema_agent.type == "agent"
+
+
+@pytest.fixture
+def future_annotations_module(tmp_path):
+    """Create a module using `from __future__ import annotations` (PEP 563)."""
+    (tmp_path / "future_ann.py").write_text(
+        textwrap.dedent("""\
+        from __future__ import annotations
+
+        from pydantic import BaseModel
+
+
+        class OrderInput(BaseModel):
+            customer_name: str
+            quantity: int = 1
+
+
+        class OrderOutput(BaseModel):
+            accepted: bool
+            total: float
+
+
+        def main(order: OrderInput) -> OrderOutput:
+            return OrderOutput(accepted=True, total=order.quantity * 9.99)
+        """)
+    )
+    return tmp_path / "future_ann.py"
+
+
+@pytest.mark.asyncio
+async def test_execute_resolves_future_annotations(future_annotations_module):
+    """PEP 563 stringified annotations should be resolved via get_type_hints."""
+    runtime = UiPathFunctionsRuntime(
+        str(future_annotations_module), "main", "future_ann"
+    )
+    result = await runtime.execute({"customer_name": "Alice", "quantity": 2})
+
+    assert result.output == {"accepted": True, "total": 19.98}
+
+
+@pytest.fixture
+def failing_module(tmp_path):
+    """Create a module whose function always raises."""
+    (tmp_path / "failing.py").write_text(
+        textwrap.dedent("""\
+        def main(data: dict) -> dict:
+            raise ValueError("something went wrong")
+        """)
+    )
+    return tmp_path / "failing.py"
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_on_function_error(failing_module):
+    """Function errors should propagate as UiPathRuntimeError, not return FAULTED."""
+    runtime = UiPathFunctionsRuntime(str(failing_module), "main", "failing")
+
+    with pytest.raises(UiPathRuntimeError, match="something went wrong"):
+        await runtime.execute({"key": "value"})
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_faulted_then_raises(failing_module):
+    """stream() should yield STARTED, then FAULTED, then raise UiPathRuntimeError."""
+    runtime = UiPathFunctionsRuntime(str(failing_module), "main", "failing")
+
+    events = []
+    with pytest.raises(UiPathRuntimeError, match="something went wrong"):
+        async for event in runtime.stream({"key": "value"}):
+            events.append(event)
+
+    assert len(events) == 2
+    assert isinstance(events[0], UiPathRuntimeStateEvent)
+    assert events[0].phase == UiPathRuntimeStatePhase.STARTED
+    assert isinstance(events[1], UiPathRuntimeStateEvent)
+    assert events[1].phase == UiPathRuntimeStatePhase.FAULTED

--- a/tests/resource_overrides/test_resource_overrides.py
+++ b/tests/resource_overrides/test_resource_overrides.py
@@ -207,6 +207,7 @@ class TestResourceOverrides:
                         "State": "Running",
                         "StartTime": "2024-01-01T00:00:00Z",
                         "Id": 123,
+                        "FolderKey": "test-folder-key",
                     }
                 ]
             },

--- a/uv.lock
+++ b/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.2"
+version = "2.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Description

- Use `get_type_hints()` instead of `inspect.signature()` to resolve stringified annotations from `from __future__ import annotations`, which broke type detection for Pydantic/dataclass inputs
- Re-raise exceptions in `execute()` as `UiPathRuntimeError` instead of swallowing them into FAULTED results, consistent with all other runtimes (LangGraph, AgentFramework, PydanticAI, GoogleADK, OpenAI)
 - `stream()` now yields FAULTED event then re-raises for proper lifecycle
 - Fix incomplete mock response in `test_resource_overrides` (missing FolderKey field was hidden by the old error-swallowing behavior)
 - Add tests for annotation resolution, error propagation, and stream lifecycle