### PR TITLE
feat(mcp-server-bindings): add mcpServer resource type to bindings

### DIFF
--- a/samples/resource-overrides/bindings.json
+++ b/samples/resource-overrides/bindings.json
@@ -121,6 +121,27 @@
         "Connector": "",
         "UseConnectionService": "True"
       }
+    },
+    {
+      "resource": "mcpServer",
+      "key": "mcp_server_slug.folder_path",
+      "value": {
+        "name": {
+          "defaultValue": "mcp_server_slug",
+          "isExpression": false,
+          "displayName": "Name"
+        },
+        "folderPath": {
+          "defaultValue": "folder_path",
+          "isExpression": false,
+          "displayName": "Folder Path"
+        }
+      },
+      "metadata": {
+        "ActivityName": "retrieve_async",
+        "BindingsVersion": "2.2",
+        "DisplayLabel": "FullName"
+      }
     }
   ]
 }

--- a/samples/resource-overrides/main.py
+++ b/samples/resource-overrides/main.py
@@ -54,4 +54,11 @@ async def main() -> Response:
     )
     response.resources.append(Resource(name="process_result", value=str(process_result.model_dump())))
 
+    # MCP Servers - retrieve MCP server
+    mcp_server = await uipath.mcp.retrieve_async(
+        slug="mcp_server_slug",
+        folder_path="folder_path",
+    )
+    response.resources.append(Resource(name="mcp_server", value=str(mcp_server.model_dump())))
+
     return response

--- a/specs/bindings.schema.json
+++ b/specs/bindings.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://cloud.uipath.com/draft/2024-12/bindings",
   "title": "UiPath Resources Configuration",
-  "description": "Configuration file for UiPath resource bindings including assets, processes, buckets, indexes, and connections",
+  "description": "Configuration file for UiPath resource bindings including assets, processes, buckets, indexes, apps, connections and MCP servers",
   "type": "object",
   "required": [
     "version",
@@ -41,7 +41,8 @@
               "bucket",
               "index",
               "app",
-              "connection"
+              "connection",
+              "mcpServer"
             ]
           },
           "key": {
@@ -53,7 +54,7 @@
             "description": "Resource configuration values",
             "oneOf": [
               {
-                "title": "Asset/Process/Bucket/App/Index Value",
+                "title": "Asset/Process/Bucket/App/Index/McpServer Value",
                 "properties": {
                   "name": {
                     "$ref": "#/definitions/propertyDefinition",

--- a/specs/bindings.spec.md
+++ b/specs/bindings.spec.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The resources configuration file defines bindings for UiPath resources including assets, processes, buckets, indexes, apps and connections. This file enables declarative configuration of resource references used throughout your UiPath project.
+The resources configuration file defines bindings for UiPath resources including assets, processes, buckets, indexes, apps, connections and MCP servers. This file enables declarative configuration of resource references used throughout your UiPath project.
 
 **File Name:** `bindings.json`
 
@@ -41,8 +41,9 @@ The configuration supports multiple resource types:
 2. **process** - Workflow processes
 3. **bucket** - Storage buckets
 4. **index** - Search indexes
-5. **apps** - Action center apps
+5. **app** - Action center apps
 6. **connection** - External connections
+7. **mcpServer** - MCP servers
 
 
 ---
@@ -53,7 +54,7 @@ Each resource in the `resources` array has the following structure:
 
 ```json
 {
-  "resource": "asset|process|bucket|index|connection",
+  "resource": "asset|process|bucket|index|app|connection|mcpServer",
   "key": "unique_key",
   "value": { ... },
   "metadata": { ... }
@@ -64,7 +65,7 @@ Each resource in the `resources` array has the following structure:
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `resource` | `string` | Yes | Resource type (one of the five types) |
+| `resource` | `string` | Yes | Resource type (one of the supported types) |
 | `key` | `string` | Yes | Unique identifier for this resource |
 | `value` | `object` | Yes | Resource-specific configuration |
 | `metadata` | `object` | No | Additional metadata for the binding |
@@ -303,6 +304,47 @@ Connections define external system integrations.
 
 ---
 
+### 7. MCP Server
+
+MCP servers provide an MCP endpoint that coded agents can connect to.
+
+**Key Format:** `slug.folder_path`
+
+> **Note:** The `value.name.defaultValue` field holds the MCP server **slug** — the same value passed to `uipath.mcp.retrieve_async(slug=...)` in your code.
+
+**Example:**
+
+```json
+{
+  "resource": "mcpServer",
+  "key": "my-mcp-server.MyFolder",
+  "value": {
+    "name": {
+      "defaultValue": "my-mcp-server",
+      "isExpression": false,
+      "displayName": "Slug"
+    },
+    "folderPath": {
+      "defaultValue": "MyFolder",
+      "isExpression": false,
+      "displayName": "Folder Path"
+    }
+  },
+  "metadata": {
+    "ActivityName": "retrieve_async",
+    "BindingsVersion": "2.2",
+    "DisplayLabel": "FullName"
+  }
+}
+```
+
+**Common Metadata:**
+- `ActivityName`: Typically `"retrieve_async"`
+- `BindingsVersion`: `"2.2"`
+- `DisplayLabel`: `"FullName"`
+
+---
+
 ## Value Object Structure
 
 ### For Assets, Processes, Buckets, Apps and Indexes
@@ -352,9 +394,9 @@ Metadata provides additional context about the resource binding.
 
 | Field | Type | Description | Applicable To |
 |-------|------|-------------|---------------|
-| `ActivityName` | `string` | Activity used to access the resource | asset, process, bucket, index |
+| `ActivityName` | `string` | Activity used to access the resource | asset, process, bucket, index, app, mcpServer |
 | `BindingsVersion` | `string` | Version of the bindings schema | All resources |
-| `DisplayLabel` | `string` | Label format for display | asset, process, bucket, index |
+| `DisplayLabel` | `string` | Label format for display | asset, process, bucket, index, app, mcpServer |
 | `Connector` | `string` | Type of connector | connection |
 | `UseConnectionService` | `string` | Whether to use connection service | connection |
 
@@ -486,6 +528,27 @@ Metadata provides additional context about the resource binding.
                 "BindingsVersion": "2.2",
                 "Connector": "Salesforce",
                 "UseConnectionService": "True"
+            }
+        },
+        {
+            "resource": "mcpServer",
+            "key": "my-mcp-server.MyFolder",
+            "value": {
+                "name": {
+                    "defaultValue": "my-mcp-server",
+                    "isExpression": false,
+                    "displayName": "Slug"
+                },
+                "folderPath": {
+                    "defaultValue": "MyFolder",
+                    "isExpression": false,
+                    "displayName": "Folder Path"
+                }
+            },
+            "metadata": {
+                "ActivityName": "retrieve_async",
+                "BindingsVersion": "2.2",
+                "DisplayLabel": "FullName"
             }
         }
     ]


### PR DESCRIPTION
This pull request introduces support for a new resource type, `mcpServer`, across the resource binding configuration and documentation. The changes add the ability to define, retrieve, and document MCP server resources, enabling coded agents to connect to MCP endpoints using a standardized format.

**Resource Type Expansion**

* Added `mcpServer` as a recognized resource type in the resource bindings schema (`specs/bindings.schema.json`) and documented its purpose and key format in the specification (`specs/bindings.spec.md`). [[1]](diffhunk://#diff-2d5a10e83680871de180a31322bba0b78db4ed0d9882e5a0436f4a3c9602ed92L44-R45) [[2]](diffhunk://#diff-c30b29826e3b27fc9ef457e87efc1e47f2107eec5a5b04eb8921d36710036295R46) [[3]](diffhunk://#diff-c30b29826e3b27fc9ef457e87efc1e47f2107eec5a5b04eb8921d36710036295R307-R345)

**Sample and Example Updates**

* Provided sample configuration and metadata for `mcpServer` in both the bindings JSON (`samples/resource-overrides/bindings.json`) and the documentation, illustrating the expected structure and usage. [[1]](diffhunk://#diff-af888f4c0e8d173a52d4efef9e41ab46cdc3281bcd62bcdc91f08ceeaf1f78bfR124-R144) [[2]](diffhunk://#diff-c30b29826e3b27fc9ef457e87efc1e47f2107eec5a5b04eb8921d36710036295R530-R550)
* Updated the sample Python code to demonstrate retrieving an MCP server resource via the `retrieve_async` method and appending the result to the response (`samples/resource-overrides/main.py`).