### PR TITLE
refactor: allow custom evaluator aggregation

### DIFF
--- a/src/uipath/eval/evaluators/base_evaluator.py
+++ b/src/uipath/eval/evaluators/base_evaluator.py
@@ -10,6 +10,7 @@ from pydantic.alias_generators import to_camel
 from .._helpers.helpers import track_evaluation_metrics
 from ..models import AgentExecution, EvaluationResult
 from ..models.models import (
+    EvaluationResultDto,
     UiPathEvaluationError,
     UiPathEvaluationErrorCategory,
 )
@@ -141,7 +142,8 @@ class GenericBaseEvaluator(BaseModel, Generic[T, C, J], ABC):
 
             # Validate and create the config object if config dict is provided
             try:
-                validated_config = config_type.model_validate(values.get("config", {}))
+                raw_config = values.get("config") or values.get("evaluatorConfig") or {}
+                validated_config = config_type.model_validate(raw_config)
                 values["evaluator_config"] = validated_config
             except Exception as e:
                 raise UiPathEvaluationError(
@@ -552,6 +554,24 @@ class GenericBaseEvaluator(BaseModel, Generic[T, C, J], ABC):
             "evaluationCriteriaSchema": cls.get_evaluation_criteria_schema(),
             "justificationSchema": cls.get_justification_schema(),
         }
+
+    def reduce_scores(self, results: list[EvaluationResultDto]) -> float:
+        """Reduce per-datapoint results into a single aggregated score.
+
+        Default implementation computes a simple average of scores. Subclasses
+        can override this to implement custom aggregation logic (e.g., precision,
+        recall) using the rich per-datapoint data in EvaluationResultDto.
+
+        Args:
+            results: List of per-datapoint results, each containing the score
+                and evaluation details/justification.
+
+        Returns:
+            The aggregated score
+        """
+        if not results:
+            return 0.0
+        return sum(r.score for r in results) / len(results)
 
     @abstractmethod
     async def validate_and_evaluate_criteria(

--- a/src/uipath/eval/models/__init__.py
+++ b/src/uipath/eval/models/__init__.py
@@ -6,6 +6,7 @@ from uipath.eval.models.models import (
     ErrorEvaluationResult,
     EvalItemResult,
     EvaluationResult,
+    EvaluationResultDto,
     EvaluatorType,
     LegacyEvaluatorCategory,
     LegacyEvaluatorType,
@@ -19,6 +20,7 @@ from uipath.eval.models.models import (
 __all__ = [
     "AgentExecution",
     "EvaluationResult",
+    "EvaluationResultDto",
     "LLMResponse",
     "LegacyEvaluatorCategory",
     "LegacyEvaluatorType",

--- a/src/uipath/eval/models/models.py
+++ b/src/uipath/eval/models/models.py
@@ -6,7 +6,9 @@ from enum import Enum, IntEnum
 from typing import Annotated, Any, Literal, Union
 
 from opentelemetry.sdk.trace import ReadableSpan
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
+from pydantic.alias_generators import to_camel
+from pydantic_core import core_schema
 
 
 class AgentExecution(BaseModel):
@@ -69,6 +71,56 @@ EvaluationResult = Annotated[
     Union[BooleanEvaluationResult, NumericEvaluationResult, ErrorEvaluationResult],
     Field(discriminator="score_type"),
 ]
+
+
+class EvaluationResultDto(BaseModel):
+    """Serializable evaluation result used for aggregation and transport."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    score: float
+    details: str | dict[str, Any] | None = None
+    evaluation_time: float | None = None
+
+    @model_serializer(mode="wrap")
+    def serialize_model(
+        self,
+        serializer: core_schema.SerializerFunctionWrapHandler,
+        info: core_schema.SerializationInfo,
+    ) -> Any:
+        """Omit 'details' key from serialized output when it is None."""
+        data = serializer(self)
+        if self.details is None and isinstance(data, dict):
+            data.pop("details", None)
+        return data
+
+    @classmethod
+    def from_evaluation_result(
+        cls, evaluation_result: EvaluationResult
+    ) -> "EvaluationResultDto":
+        """Convert an EvaluationResult to a serializable DTO."""
+        score_type = evaluation_result.score_type
+        score: float
+        if score_type == ScoreType.BOOLEAN:
+            score = 100 if evaluation_result.score else 0
+        elif score_type == ScoreType.ERROR:
+            score = 0
+        else:
+            score = evaluation_result.score
+
+        # Convert BaseModel details to dict so Pydantic doesn't lose subclass fields
+        if isinstance(evaluation_result.details, BaseModel):
+            details: str | dict[str, Any] | None = (
+                evaluation_result.details.model_dump()
+            )
+        else:
+            details = evaluation_result.details
+
+        return cls(
+            score=score,
+            details=details,
+            evaluation_time=evaluation_result.evaluation_time,
+        )
 
 
 class EvalItemResult(BaseModel):

--- a/src/uipath/eval/runtime/_types.py
+++ b/src/uipath/eval/runtime/_types.py
@@ -1,17 +1,13 @@
 import logging
-from collections import defaultdict
-from typing import Any
 
 from opentelemetry.sdk.trace import ReadableSpan
-from pydantic import BaseModel, ConfigDict, model_serializer
+from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
-from pydantic_core import core_schema
 
 from uipath.runtime import UiPathRuntimeResult
 
 from ..models.models import (
-    EvaluationResult,
-    ScoreType,
+    EvaluationResultDto,
     TrajectoryEvaluationTrace,
 )
 
@@ -49,52 +45,6 @@ def convert_eval_execution_output_to_serializable(
         result=output.result,
         trace=TrajectoryEvaluationTrace.from_readable_spans(output.spans),
     )
-
-
-class EvaluationResultDto(BaseModel):
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-
-    score: float
-    details: str | dict[str, Any] | None = None
-    evaluation_time: float | None = None
-
-    @model_serializer(mode="wrap")
-    def serialize_model(
-        self,
-        serializer: core_schema.SerializerFunctionWrapHandler,
-        info: core_schema.SerializationInfo,
-    ) -> Any:
-        data = serializer(self)
-        if self.details is None and isinstance(data, dict):
-            data.pop("details", None)
-        return data
-
-    @classmethod
-    def from_evaluation_result(
-        cls, evaluation_result: EvaluationResult
-    ) -> "EvaluationResultDto":
-        score_type = evaluation_result.score_type
-        score: float
-        if score_type == ScoreType.BOOLEAN:
-            score = 100 if evaluation_result.score else 0
-        elif score_type == ScoreType.ERROR:
-            score = 0
-        else:
-            score = evaluation_result.score
-
-        # Convert BaseModel details to dict so Pydantic doesn't lose subclass fields
-        if isinstance(evaluation_result.details, BaseModel):
-            details: str | dict[str, Any] | None = (
-                evaluation_result.details.model_dump()
-            )
-        else:
-            details = evaluation_result.details
-
-        return cls(
-            score=score,
-            details=details,
-            evaluation_time=evaluation_result.evaluation_time,
-        )
 
 
 class UiPathEvalRunResultDto(BaseModel):
@@ -138,81 +88,3 @@ class UiPathEvalOutput(BaseModel):
             eval_result.score for eval_result in self.evaluation_set_results
         ]
         return sum(eval_item_scores) / len(eval_item_scores)
-
-    def calculate_final_score(
-        self,
-        evaluator_weights: dict[str, float] | None = None,
-        default_weight: float = 1.0,
-    ) -> tuple[float, dict[str, float]]:
-        """Aggregate evaluation results with deduplication and weighted scoring.
-
-        This function performs the following steps:
-        1. Flattens the nested evaluation_set_results structure
-        2. Deduplicates results by datapoint_id (evaluation_name) and evaluator_name (averages duplicates)
-        3. Calculates average score per evaluator across all datapoints
-        4. Computes final weighted score across evaluators
-
-        Args:
-            evaluator_weights: Optional dict mapping evaluator names to weights
-            default_weight: Default weight for evaluators not in evaluator_weights (default: 1.0)
-
-        Returns:
-            Tuple of (final_score, agg_metrics_per_evaluator)
-            - final_score: Weighted average across evaluators
-            - agg_metrics_per_evaluator: Dict mapping evaluator names to their average scores
-        """
-        if not self.evaluation_set_results:
-            return 0.0, {}
-
-        if evaluator_weights is None:
-            evaluator_weights = {}
-
-        # Step 1: Flatten the nested structure and group by datapoint_id and evaluator_name for deduplication
-        # datapoint_id = evaluation_name, evaluator_name from UiPathEvalRunResultDto
-        grouped_by_datapoint_evaluator: defaultdict[
-            str, defaultdict[str, list[float]]
-        ] = defaultdict(lambda: defaultdict(list))
-
-        for eval_run_result in self.evaluation_set_results:
-            datapoint_id = eval_run_result.evaluation_name
-            for eval_run_result_dto in eval_run_result.evaluation_run_results:
-                evaluator_name = eval_run_result_dto.evaluator_name
-                score = eval_run_result_dto.result.score
-                grouped_by_datapoint_evaluator[datapoint_id][evaluator_name].append(
-                    score
-                )
-
-        # Step 2: Deduplicate by averaging same evaluator results for same datapoint
-        dedup_scores: list[tuple[str, str, float]] = []
-        for datapoint_id, evaluators_dict in grouped_by_datapoint_evaluator.items():
-            for evaluator_name, scores_list in evaluators_dict.items():
-                if scores_list:
-                    # Average the scores for this evaluator on this datapoint
-                    avg_score = sum(scores_list) / len(scores_list)
-                    dedup_scores.append((datapoint_id, evaluator_name, avg_score))
-
-        # Step 3: Group by evaluator and calculate average score per evaluator
-        grouped_by_evaluator: defaultdict[str, list[float]] = defaultdict(list)
-        for _datapoint_id, evaluator_name, score in dedup_scores:
-            grouped_by_evaluator[evaluator_name].append(score)
-
-        agg_metrics_per_evaluator = {}
-        for evaluator_name, scores_list in grouped_by_evaluator.items():
-            avg_score = sum(scores_list) / len(scores_list)
-            agg_metrics_per_evaluator[evaluator_name] = avg_score
-
-        # Step 4: Calculate final weighted score
-        if not agg_metrics_per_evaluator:
-            return 0.0, {}
-
-        total_weighted_score = 0.0
-        total_weight = 0.0
-
-        for evaluator_name, avg_score in agg_metrics_per_evaluator.items():
-            weight = evaluator_weights.get(evaluator_name, default_weight)
-            total_weighted_score += avg_score * weight
-            total_weight += weight
-
-        final_score = total_weighted_score / total_weight if total_weight > 0 else 0.0
-
-        return final_score, agg_metrics_per_evaluator

--- a/src/uipath/eval/runtime/runtime.py
+++ b/src/uipath/eval/runtime/runtime.py
@@ -59,7 +59,7 @@ from ..models.evaluation_set import (
     EvaluationItem,
     EvaluationSet,
 )
-from ..models.models import AgentExecution, EvalItemResult
+from ..models.models import AgentExecution, EvalItemResult, EvaluationResultDto
 from ._exporters import (
     ExecutionLogsExporter,
     ExecutionSpanExporter,
@@ -74,7 +74,6 @@ from ._spans import (
     set_evaluation_output_span_output,
 )
 from ._types import (
-    EvaluationResultDto,
     EvaluationRuntimeException,
     UiPathEvalOutput,
     UiPathEvalRunExecutionOutput,
@@ -94,6 +93,108 @@ from .events import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def compute_evaluator_scores(
+    evaluation_set_results: list[UiPathEvalRunResult],
+    evaluators: Iterable[GenericBaseEvaluator[Any, Any, Any]],
+    evaluator_weights: dict[str, float] | None = None,
+    default_weight: float = 1.0,
+) -> tuple[float, dict[str, float]]:
+    """Aggregate evaluation results with deduplication and weighted scoring.
+
+    Steps:
+    1. Flatten nested evaluation_set_results structure
+    2. Deduplicate results by (datapoint_id, evaluator_name), averaging duplicates
+    3. Reduce results per evaluator across all datapoints
+    4. Compute final weighted score across evaluators
+
+    Args:
+        evaluation_set_results: The per-datapoint evaluation results
+        evaluators: The evaluator instances. Each must have a `name` attribute
+            and a `reduce_scores` method.
+        evaluator_weights: Optional dict mapping evaluator names to weights
+        default_weight: Default weight for evaluators not in evaluator_weights (default: 1.0)
+
+    Returns:
+        Tuple of (final_score, agg_metrics_per_evaluator)
+        - final_score: Weighted average across evaluators
+        - agg_metrics_per_evaluator: Dict mapping evaluator names to their reduced scores
+    """
+    if not evaluation_set_results:
+        return 0.0, {}
+
+    if evaluator_weights is None:
+        evaluator_weights = {}
+
+    evaluator_reducers: dict[str, GenericBaseEvaluator[Any, Any, Any]] = {
+        e.name: e for e in evaluators
+    }
+
+    # Step 1: Flatten and group by (datapoint_id, evaluator_name) for deduplication
+    grouped_by_datapoint_evaluator: defaultdict[
+        str, defaultdict[str, list[EvaluationResultDto]]
+    ] = defaultdict(lambda: defaultdict(list))
+
+    for eval_run_result in evaluation_set_results:
+        datapoint_id = eval_run_result.evaluation_name
+        for eval_run_result_dto in eval_run_result.evaluation_run_results:
+            evaluator_name = eval_run_result_dto.evaluator_name
+            if evaluator_name not in evaluator_reducers:
+                known = sorted(evaluator_reducers.keys())
+                raise ValueError(
+                    f"Evaluator '{evaluator_name}' found in results for "
+                    f"datapoint '{datapoint_id}' but no matching evaluator "
+                    f"instance was provided. Known evaluators: {known}"
+                )
+            grouped_by_datapoint_evaluator[datapoint_id][evaluator_name].append(
+                eval_run_result_dto.result
+            )
+
+    # Step 2: Deduplicate by averaging same evaluator results for same datapoint
+    dedup_results: list[tuple[str, str, EvaluationResultDto]] = []
+    for datapoint_id, evaluators_dict in grouped_by_datapoint_evaluator.items():
+        for evaluator_name, results_list in evaluators_dict.items():
+            if results_list:
+                avg_score = sum(r.score for r in results_list) / len(results_list)
+                dedup_results.append(
+                    (
+                        datapoint_id,
+                        evaluator_name,
+                        EvaluationResultDto(
+                            score=avg_score,
+                            details=results_list[0].details,
+                        ),
+                    )
+                )
+
+    # Step 3: Group by evaluator and reduce using the evaluator's reducer
+    grouped_by_evaluator: defaultdict[str, list[EvaluationResultDto]] = defaultdict(
+        list
+    )
+    for _datapoint_id, evaluator_name, dp_result in dedup_results:
+        grouped_by_evaluator[evaluator_name].append(dp_result)
+
+    agg_metrics_per_evaluator = {}
+    for evaluator_name, results_list in grouped_by_evaluator.items():
+        reducer = evaluator_reducers[evaluator_name].reduce_scores
+        agg_metrics_per_evaluator[evaluator_name] = reducer(results_list)
+
+    # Step 4: Calculate final weighted score
+    if not agg_metrics_per_evaluator:
+        return 0.0, {}
+
+    total_weighted_score = 0.0
+    total_weight = 0.0
+
+    for evaluator_name, avg_score in agg_metrics_per_evaluator.items():
+        weight = evaluator_weights.get(evaluator_name, default_weight)
+        total_weighted_score += avg_score * weight
+        total_weight += weight
+
+    final_score = total_weighted_score / total_weight if total_weight > 0 else 0.0
+
+    return final_score, agg_metrics_per_evaluator
 
 
 class UiPathEvalRuntime:
@@ -253,38 +354,27 @@ class UiPathEvalRuntime:
                     ) = await self.initiate_evaluation()
                     workers = self.context.workers or 1
                     assert workers >= 1
-                    eval_run_result_list = await execute_parallel(
-                        evaluation_iterable, workers
-                    )
+                    eval_run_result_list: list[
+                        UiPathEvalRunResult
+                    ] = await execute_parallel(evaluation_iterable, workers)
+
                     results = UiPathEvalOutput(
                         evaluation_set_name=evaluation_set.name,
                         evaluation_set_results=eval_run_result_list,
                     )
 
-                    # Computing evaluator averages
-                    evaluator_averages: dict[str, float] = defaultdict(float)
-                    evaluator_count: dict[str, int] = defaultdict(int)
+                    # Check for failures
+                    any_failed = any(
+                        eval_run_result.agent_execution_output
+                        and eval_run_result.agent_execution_output.result.error
+                        for eval_run_result in results.evaluation_set_results
+                    )
 
-                    # Check if any eval runs failed
-                    any_failed = False
-                    for eval_run_result in results.evaluation_set_results:
-                        # Check if the agent execution had an error
-                        if (
-                            eval_run_result.agent_execution_output
-                            and eval_run_result.agent_execution_output.result.error
-                        ):
-                            any_failed = True
-
-                        for result_dto in eval_run_result.evaluation_run_results:
-                            evaluator_averages[result_dto.evaluator_name] += (
-                                result_dto.result.score
-                            )
-                            evaluator_count[result_dto.evaluator_name] += 1
-
-                    for eval_id in evaluator_averages:
-                        evaluator_averages[eval_id] = (
-                            evaluator_averages[eval_id] / evaluator_count[eval_id]
-                        )
+                    # Compute evaluator averages using each evaluator's reducer
+                    _, evaluator_averages = compute_evaluator_scores(
+                        results.evaluation_set_results,
+                        evaluators,
+                    )
 
                     # Configure span with output and metadata
                     await configure_eval_set_run_span(

--- a/tests/evaluators/test_evaluator_aggregation.py
+++ b/tests/evaluators/test_evaluator_aggregation.py
@@ -1,119 +1,132 @@
 """Test module for evaluation result aggregation logic.
 
-This module tests the deduplication and aggregation functionality
-in UiPathEvalOutput.calculate_final_score().
+This module tests the compute_evaluator_scores() standalone function,
+which handles deduplication, per-evaluator reduction, and weighted scoring.
 """
 
 import uuid
+from typing import Any, Callable
 
 import pytest
 
+from uipath.eval.evaluators import ExactMatchEvaluator
+from uipath.eval.models.models import EvaluationResultDto
 from uipath.eval.runtime._types import (
-    EvaluationResultDto,
-    UiPathEvalOutput,
     UiPathEvalRunResult,
     UiPathEvalRunResultDto,
 )
+from uipath.eval.runtime.runtime import compute_evaluator_scores
+
+
+def _make_evaluator(
+    name: str, reducer: Callable[[list[EvaluationResultDto]], float] | None = None
+) -> Any:
+    """Create a minimal mock evaluator with a name and optional custom reduce_scores."""
+    _reducer = reducer or (
+        lambda results: sum(r.score for r in results) / len(results) if results else 0.0
+    )
+
+    class MockEvaluator:
+        def reduce_scores(self, results: list[EvaluationResultDto]) -> float:
+            return _reducer(results)
+
+    obj = MockEvaluator()
+    obj.name = name  # type: ignore[attr-defined]
+    return obj
 
 
 class TestEvaluationResultAggregation:
-    """Test evaluation result aggregation with deduplication in UiPathEvalOutput."""
+    """Test evaluation result aggregation with deduplication."""
 
-    def test_calculate_final_score_empty(self) -> None:
-        """Test evaluation result aggregation with empty results."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[],
-        )
-
-        final_score, agg_metrics = eval_output.calculate_final_score()
+    def test_compute_evaluator_scores_empty(self) -> None:
+        """Test with empty results."""
+        final_score, agg_metrics = compute_evaluator_scores([], [])
 
         assert final_score == 0.0
         assert agg_metrics == {}
 
-    def test_calculate_final_score_single_evaluator(self) -> None:
-        """Test evaluation result aggregation with single evaluator across multiple datapoints."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        )
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test2",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        )
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test3",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.6),
-                        )
-                    ],
-                ),
-            ],
-        )
+    def test_compute_evaluator_scores_single_evaluator(self) -> None:
+        """Test with single evaluator across multiple datapoints."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    )
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    )
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test3",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.6),
+                    )
+                ],
+            ),
+        ]
 
-        final_score, agg_metrics = eval_output.calculate_final_score()
+        evaluators = [_make_evaluator("ExactMatchEvaluator")]
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
 
         expected_avg = (0.8 + 1.0 + 0.6) / 3  # 0.8
         assert final_score == pytest.approx(expected_avg)
         assert agg_metrics == {"ExactMatchEvaluator": pytest.approx(expected_avg)}
 
-    def test_calculate_final_score_multiple_evaluators(self) -> None:
-        """Test evaluation result aggregation with multiple evaluators."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ContainsEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.9),
-                        ),
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test2",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ContainsEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.7),
-                        ),
-                    ],
-                ),
-            ],
-        )
+    def test_compute_evaluator_scores_multiple_evaluators(self) -> None:
+        """Test with multiple evaluators."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ContainsEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.9),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ContainsEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.7),
+                    ),
+                ],
+            ),
+        ]
 
-        final_score, agg_metrics = eval_output.calculate_final_score()
+        evaluators = [
+            _make_evaluator("ExactMatchEvaluator"),
+            _make_evaluator("ContainsEvaluator"),
+        ]
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
 
         # ExactMatch avg: (0.8 + 1.0) / 2 = 0.9
         # Contains avg: (0.9 + 0.7) / 2 = 0.8
@@ -124,46 +137,44 @@ class TestEvaluationResultAggregation:
             "ContainsEvaluator": pytest.approx(0.8),
         }
 
-    def test_calculate_final_score_with_deduplication(self) -> None:
-        """Test evaluation result aggregation with duplicate evaluator results on same datapoint."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        # Multiple ExactMatch results for same datapoint (should be averaged)
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",  # Duplicate!
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",  # Another duplicate!
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.6),
-                        ),
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test2",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.5),
-                        ),
-                    ],
-                ),
-            ],
-        )
+    def test_compute_evaluator_scores_with_deduplication(self) -> None:
+        """Test with duplicate evaluator results on same datapoint."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    # Multiple ExactMatch results for same datapoint (should be averaged)
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",  # Duplicate!
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",  # Another duplicate!
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.6),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.5),
+                    ),
+                ],
+            ),
+        ]
 
-        final_score, agg_metrics = eval_output.calculate_final_score()
+        evaluators = [_make_evaluator("ExactMatchEvaluator")]
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
 
         # datapoint1 ExactMatch avg: (0.8 + 1.0 + 0.6) / 3 = 0.8
         # datapoint2 ExactMatch: 0.5
@@ -171,28 +182,25 @@ class TestEvaluationResultAggregation:
         assert final_score == pytest.approx(0.65)
         assert agg_metrics == {"ExactMatchEvaluator": pytest.approx(0.65)}
 
-    def test_calculate_final_score_with_weights(self) -> None:
-        """Test evaluation result aggregation with evaluator weights."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ContainsEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.6),
-                        ),
-                    ],
-                ),
-            ],
-        )
+    def test_compute_evaluator_scores_with_weights(self) -> None:
+        """Test with evaluator weights."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ContainsEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.6),
+                    ),
+                ],
+            ),
+        ]
 
         # Give ExactMatch twice the weight of Contains
         weights = {
@@ -200,7 +208,13 @@ class TestEvaluationResultAggregation:
             "ContainsEvaluator": 1.0,
         }
 
-        final_score, agg_metrics = eval_output.calculate_final_score(weights)
+        evaluators = [
+            _make_evaluator("ExactMatchEvaluator"),
+            _make_evaluator("ContainsEvaluator"),
+        ]
+        final_score, agg_metrics = compute_evaluator_scores(
+            results, evaluators, evaluator_weights=weights
+        )
 
         # Weighted average: (0.8 * 2.0 + 0.6 * 1.0) / (2.0 + 1.0) = 2.2 / 3 = 0.733...
         expected_weighted_avg = (0.8 * 2.0 + 0.6 * 1.0) / 3.0
@@ -210,66 +224,73 @@ class TestEvaluationResultAggregation:
             "ContainsEvaluator": pytest.approx(0.6),
         }
 
-    def test_calculate_final_score_missing_weights(self) -> None:
-        """Test evaluation result aggregation when some evaluators are missing from weights dict."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="UnknownEvaluator",  # Not in weights
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.6),
-                        ),
-                    ],
-                ),
-            ],
+    def test_compute_evaluator_scores_missing_weights(self) -> None:
+        """Test when some evaluators are missing from weights dict."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="UnknownEvaluator",  # Not in weights
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.6),
+                    ),
+                ],
+            ),
+        ]
+
+        weights = {"ExactMatchEvaluator": 2.0}  # Missing UnknownEvaluator weight
+
+        evaluators = [
+            _make_evaluator("ExactMatchEvaluator"),
+            _make_evaluator("UnknownEvaluator"),
+        ]
+        final_score, agg_metrics = compute_evaluator_scores(
+            results, evaluators, evaluator_weights=weights
         )
-
-        weights = {"ExactMatchEvaluator": 2.0}  # Missing UnknownEvaluator
-
-        final_score, agg_metrics = eval_output.calculate_final_score(weights)
 
         # UnknownEvaluator gets default weight of 1.0
         # Weighted average: (0.8 * 2.0 + 0.6 * 1.0) / (2.0 + 1.0) = 2.2 / 3
         expected_weighted_avg = (0.8 * 2.0 + 0.6 * 1.0) / 3.0
         assert final_score == pytest.approx(expected_weighted_avg)
 
-    def test_calculate_final_score_custom_default_weight(self) -> None:
-        """Test evaluation result aggregation with custom default weight."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="UnknownEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.6),
-                        ),
-                    ],
-                ),
-            ],
-        )
+    def test_compute_evaluator_scores_custom_default_weight(self) -> None:
+        """Test with custom default weight."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="UnknownEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.6),
+                    ),
+                ],
+            ),
+        ]
 
         weights = {"ExactMatchEvaluator": 2.0}
         default_weight = 0.5  # Custom default weight
 
-        final_score, agg_metrics = eval_output.calculate_final_score(
-            weights, default_weight
+        evaluators = [
+            _make_evaluator("ExactMatchEvaluator"),
+            _make_evaluator("UnknownEvaluator"),
+        ]
+        final_score, agg_metrics = compute_evaluator_scores(
+            results,
+            evaluators,
+            evaluator_weights=weights,
+            default_weight=default_weight,
         )
 
         # UnknownEvaluator gets default weight of 0.5
@@ -277,8 +298,8 @@ class TestEvaluationResultAggregation:
         expected_weighted_avg = (0.8 * 2.0 + 0.6 * 0.5) / 2.5
         assert final_score == pytest.approx(expected_weighted_avg)
 
-    def test_calculate_final_score_complex_scenario(self) -> None:
-        """Test evaluation result aggregation with complex scenario."""
+    def test_compute_evaluator_scores_complex_scenario(self) -> None:
+        """Test complex scenario with dedup, multiple evaluators, and multiple datapoints."""
         # Scenario:
         # datapoint1: ExactMatch[0.5, 1.0] (avg=0.75), Contains[1.0], ToolCallCount[1.0]
         # datapoint2: ExactMatch[0.0], Contains[1.0]
@@ -288,68 +309,70 @@ class TestEvaluationResultAggregation:
         # Contains: (1.0 + 1.0) / 2 = 1.0
         # ToolCallCount: (1.0 + 1.0) / 2 = 1.0
 
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatch",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.5),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatch",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="Contains",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ToolCallCount",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test2",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatch",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="Contains",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test3",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatch",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ToolCallCount",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                    ],
-                ),
-            ],
-        )
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatch",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.5),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatch",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="Contains",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ToolCallCount",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatch",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="Contains",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test3",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatch",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ToolCallCount",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                ],
+            ),
+        ]
 
-        final_score, agg_metrics = eval_output.calculate_final_score()
+        evaluators = [
+            _make_evaluator("ExactMatch"),
+            _make_evaluator("Contains"),
+            _make_evaluator("ToolCallCount"),
+        ]
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
 
         expected_exact_match = (0.75 + 0.0 + 1.0) / 3  # 0.583
         expected_contains = 1.0
@@ -365,73 +388,72 @@ class TestEvaluationResultAggregation:
             "ToolCallCount": pytest.approx(expected_tool_count),
         }
 
-    def test_calculate_final_score_single_datapoint_single_evaluator(self) -> None:
+    def test_compute_evaluator_scores_single_datapoint_single_evaluator(self) -> None:
         """Test simplest case: single datapoint, single evaluator."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.85),
-                        ),
-                    ],
-                ),
-            ],
-        )
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.85),
+                    ),
+                ],
+            ),
+        ]
 
-        final_score, agg_metrics = eval_output.calculate_final_score()
+        evaluators = [_make_evaluator("ExactMatchEvaluator")]
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
 
         assert final_score == pytest.approx(0.85)
         assert agg_metrics == {"ExactMatchEvaluator": pytest.approx(0.85)}
 
-    def test_calculate_final_score_different_evaluators_per_datapoint(self) -> None:
+    def test_compute_evaluator_scores_different_evaluators_per_datapoint(self) -> None:
         """Test when different datapoints have different evaluators."""
-        eval_output = UiPathEvalOutput(
-            evaluation_set_name="test_set",
-            evaluation_set_results=[
-                UiPathEvalRunResult(
-                    evaluation_name="test1",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.8),
-                        ),
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test2",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ContainsEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.9),
-                        ),
-                    ],
-                ),
-                UiPathEvalRunResult(
-                    evaluation_name="test3",
-                    evaluation_run_results=[
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ExactMatchEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=1.0),
-                        ),
-                        UiPathEvalRunResultDto(
-                            evaluator_name="ContainsEvaluator",
-                            evaluator_id=str(uuid.uuid4()),
-                            result=EvaluationResultDto(score=0.7),
-                        ),
-                    ],
-                ),
-            ],
-        )
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ContainsEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.9),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test3",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ExactMatchEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="ContainsEvaluator",
+                        evaluator_id=str(uuid.uuid4()),
+                        result=EvaluationResultDto(score=0.7),
+                    ),
+                ],
+            ),
+        ]
 
-        final_score, agg_metrics = eval_output.calculate_final_score()
+        evaluators = [
+            _make_evaluator("ExactMatchEvaluator"),
+            _make_evaluator("ContainsEvaluator"),
+        ]
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
 
         # ExactMatch: (0.8 + 1.0) / 2 = 0.9 (appears in test1 and test3)
         # Contains: (0.9 + 0.7) / 2 = 0.8 (appears in test2 and test3)
@@ -441,3 +463,207 @@ class TestEvaluationResultAggregation:
             "ExactMatchEvaluator": pytest.approx(0.9),
             "ContainsEvaluator": pytest.approx(0.8),
         }
+
+
+class TestBaseEvaluatorReduceScores:
+    """Test the default reduce_scores method on GenericBaseEvaluator."""
+
+    @pytest.fixture()
+    def evaluator(self) -> Any:
+        """Create a minimal ExactMatchEvaluator for testing reduce_scores."""
+        return ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": {}, "id": str(uuid.uuid4())}
+        )
+
+    def test_reduce_scores_default_average(self, evaluator: Any) -> None:
+        """Default reduce_scores computes simple average."""
+        results = [
+            EvaluationResultDto(score=0.8),
+            EvaluationResultDto(score=1.0),
+            EvaluationResultDto(score=0.6),
+        ]
+        assert evaluator.reduce_scores(results) == pytest.approx(0.8)
+
+    def test_reduce_scores_empty_list(self, evaluator: Any) -> None:
+        """Default reduce_scores returns 0.0 for empty list."""
+        assert evaluator.reduce_scores([]) == 0.0
+
+    def test_reduce_scores_single_score(self, evaluator: Any) -> None:
+        """Default reduce_scores returns the single score."""
+        assert evaluator.reduce_scores(
+            [EvaluationResultDto(score=0.75)]
+        ) == pytest.approx(0.75)
+
+    def test_reduce_scores_all_zeros(self, evaluator: Any) -> None:
+        """Default reduce_scores with all zeros."""
+        results = [
+            EvaluationResultDto(score=0.0),
+            EvaluationResultDto(score=0.0),
+            EvaluationResultDto(score=0.0),
+        ]
+        assert evaluator.reduce_scores(results) == 0.0
+
+    def test_reduce_scores_all_ones(self, evaluator: Any) -> None:
+        """Default reduce_scores with all ones."""
+        results = [
+            EvaluationResultDto(score=1.0),
+            EvaluationResultDto(score=1.0),
+            EvaluationResultDto(score=1.0),
+        ]
+        assert evaluator.reduce_scores(results) == 1.0
+
+
+class TestCustomReducerIntegration:
+    """Test that compute_evaluator_scores uses evaluator reduce_scores correctly."""
+
+    def test_uses_evaluator_reducer(self) -> None:
+        """Test that an evaluator's reduce_scores is used instead of default average."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="MyEvaluator",
+                        evaluator_id="my-eval",
+                        result=EvaluationResultDto(score=0.5),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="MyEvaluator",
+                        evaluator_id="my-eval",
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                ],
+            ),
+        ]
+
+        # Custom reducer: sum instead of average
+        evaluators = [
+            _make_evaluator(
+                "MyEvaluator", lambda results: sum(r.score for r in results)
+            )
+        ]
+
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
+
+        # sum([0.5, 1.0]) = 1.5, not average 0.75
+        assert agg_metrics == {"MyEvaluator": pytest.approx(1.5)}
+        assert final_score == pytest.approx(1.5)
+
+    def test_missing_evaluator_raises_error(self) -> None:
+        """Test that a missing evaluator raises a clear ValueError."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="UnknownEval",
+                        evaluator_id="unknown-type",
+                        result=EvaluationResultDto(score=0.4),
+                    ),
+                ],
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="UnknownEval"):
+            compute_evaluator_scores(results, [])
+
+    def test_details_passed_to_reducer(self) -> None:
+        """Test that EvaluationResultDto.details are passed through to reduce_scores."""
+        captured_details: list[dict[str, Any] | str | None] = []
+
+        def capturing_reducer(results: list[EvaluationResultDto]) -> float:
+            for r in results:
+                captured_details.append(r.details)
+            return sum(r.score for r in results) / len(results) if results else 0.0
+
+        details_a = {"predicted": "cat", "expected": "dog"}
+        details_b = {"predicted": "cat", "expected": "cat"}
+
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="MyEval",
+                        evaluator_id="my-eval",
+                        result=EvaluationResultDto(score=0.0, details=details_a),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="MyEval",
+                        evaluator_id="my-eval",
+                        result=EvaluationResultDto(score=1.0, details=details_b),
+                    ),
+                ],
+            ),
+        ]
+
+        evaluators = [_make_evaluator("MyEval", capturing_reducer)]
+        compute_evaluator_scores(results, evaluators)
+
+        assert len(captured_details) == 2
+        assert captured_details[0] == {"predicted": "cat", "expected": "dog"}
+        assert captured_details[1] == {"predicted": "cat", "expected": "cat"}
+
+    def test_mixed_custom_and_default_reducers(self) -> None:
+        """Test with one custom reducer and one falling back to default."""
+        results = [
+            UiPathEvalRunResult(
+                evaluation_name="test1",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="CustomEval",
+                        evaluator_id="custom-type",
+                        result=EvaluationResultDto(score=0.8),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="DefaultEval",
+                        evaluator_id="default-type",
+                        result=EvaluationResultDto(score=0.6),
+                    ),
+                ],
+            ),
+            UiPathEvalRunResult(
+                evaluation_name="test2",
+                evaluation_run_results=[
+                    UiPathEvalRunResultDto(
+                        evaluator_name="CustomEval",
+                        evaluator_id="custom-type",
+                        result=EvaluationResultDto(score=1.0),
+                    ),
+                    UiPathEvalRunResultDto(
+                        evaluator_name="DefaultEval",
+                        evaluator_id="default-type",
+                        result=EvaluationResultDto(score=0.4),
+                    ),
+                ],
+            ),
+        ]
+
+        # CustomEval uses min, DefaultEval uses default average
+        evaluators = [
+            _make_evaluator(
+                "CustomEval", lambda results: min(r.score for r in results)
+            ),
+            _make_evaluator("DefaultEval"),
+        ]
+
+        final_score, agg_metrics = compute_evaluator_scores(results, evaluators)
+
+        # CustomEval: min([0.8, 1.0]) = 0.8
+        # DefaultEval: avg([0.6, 0.4]) = 0.5
+        # Final: (0.8 + 0.5) / 2 = 0.65
+        assert agg_metrics == {
+            "CustomEval": pytest.approx(0.8),
+            "DefaultEval": pytest.approx(0.5),
+        }
+        assert final_score == pytest.approx(0.65)

--- a/tests/evaluators/test_evaluator_methods.py
+++ b/tests/evaluators/test_evaluator_methods.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan
-from pydantic import ValidationError
 from pytest_mock.plugin import MockerFixture
 
 from uipath.eval.evaluators.base_evaluator import BaseEvaluatorJustification
@@ -1223,8 +1222,8 @@ class TestEvaluatorErrorHandling:
             "default_evaluation_criteria": {},
         }
 
-        with pytest.raises(ValidationError):
-            # Missing required field 'model'
+        with pytest.raises(UiPathEvaluationError):
+            # Invalid default_evaluation_criteria (missing expectedOutput)
             LLMJudgeOutputEvaluator.model_validate(
                 {"evaluatorConfig": config, "id": str(uuid.uuid4())}
             )


### PR DESCRIPTION
Replace UiPathEvalOutput.calculate_final_score() instance method with a standalone compute_evaluator_scores() function that accepts evaluator instances and delegates aggregation to each evaluator's reduce_scores() static method. This enables evaluators to implement custom aggregation logic (e.g., precision, recall) instead of always using simple average.

- Add GenericBaseEvaluator.reduce_scores() with default average behavior
- Update runtime to use the new standalone aggregation function
- Fix evaluator config validation to also check evaluatorConfig key