### PR TITLE
fix: do not retry span ingestion for non-retryable codes

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.5"
+version = "2.10.6"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/tracing/_otel_exporters.py
+++ b/packages/uipath/src/uipath/tracing/_otel_exporters.py
@@ -13,6 +13,7 @@ from opentelemetry.sdk.trace.export import (
 
 from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.platform.common import _SpanUtils
+from uipath.platform.common.retry import NON_RETRYABLE_STATUS_CODES
 
 logger = logging.getLogger(__name__)
 
@@ -399,10 +400,13 @@ class LlmOpsHttpExporter(SpanExporter):
                 response = self.http_client.post(url, json=payload)
                 if response.status_code == 200:
                     return SpanExportResult.SUCCESS
-                else:
-                    logger.warning(
-                        f"Attempt {attempt + 1} failed with status code {response.status_code}: {response.text}"
-                    )
+
+                logger.warning(
+                    f"Attempt {attempt + 1} failed with status code {response.status_code}: {response.text}"
+                )
+
+                if response.status_code in NON_RETRYABLE_STATUS_CODES:
+                    return SpanExportResult.FAILURE
             except Exception as e:
                 logger.error(f"Attempt {attempt + 1} failed with exception: {e}")
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.5"
+version = "2.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2638,21 +2638,21 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.5"
+version = "0.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/01/4eac9fb79b0396ef10b099af7afc8c71d8081ab33538543bb7d7df579412/uipath_core-0.5.5.tar.gz", hash = "sha256:31fbba640b8b3e128e9cb4c1fd8c9cc492230cb9998397895f40f2b755590f96", size = 112378, upload-time = "2026-03-04T15:47:19.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/8a/d129d33a81865f99d9134391a52f8691f557d95a18a38df4d88917b3e235/uipath_core-0.5.6.tar.gz", hash = "sha256:bebaf2e62111e844739e4f4e4dc47c48bac93b7e6fce6754502a9f4979c41888", size = 112659, upload-time = "2026-03-04T18:04:42.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/fa/1ce0c97947b47b50d3438edbec174f6d7e64596ff58f38fb4c1aa9663a55/uipath_core-0.5.5-py3-none-any.whl", hash = "sha256:6660b7c9c4ab15433d4df325a31a12d47418206b79e0d05640e73c3e74895f7a", size = 42026, upload-time = "2026-03-04T15:47:18.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/77ab712518aa2a8485a558a0de245ac425e07fd8b74cfa8951550f0aea63/uipath_core-0.5.6-py3-none-any.whl", hash = "sha256:4a741fc760605165b0541b3abb6ade728bfa386e000ace00054bc43995720e5b", size = 42047, upload-time = "2026-03-04T18:04:41.606Z" },
 ]
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.11"
+version = "0.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2661,9 +2661,9 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/b4/82ca80eb2ad17fa3ffcd140d59e5527efe884323fdf09f7adfccada73759/uipath_platform-0.0.11.tar.gz", hash = "sha256:5f4d20ab4407ae4e3846df5c3b938b7d32382362e160db459bc2038c21d8f798", size = 261785, upload-time = "2026-03-04T15:47:16.387Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/2a/71e9417353f16962cc6f888395519d8a59d8ed3f9dd4e0543d1ca01700f1/uipath_platform-0.0.12.tar.gz", hash = "sha256:358c127c7677dde48a8126cbc39ee9315c1f6268a603561b081563d585f2cfde", size = 261814, upload-time = "2026-03-05T07:42:15.728Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/a1/f263ea9117d7aedb8d667055f8ffa6520db7762a29d18e5e56828cf6711b/uipath_platform-0.0.11-py3-none-any.whl", hash = "sha256:5d403341dd83b6eb432f4988861031c63cee95781a505c0b59a71bf75003efa0", size = 158043, upload-time = "2026-03-04T15:47:14.709Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a3/bf8014d19cd3739fbb8738a3f2151b13c8d92f2afedc16fd01e3e2ed65a3/uipath_platform-0.0.12-py3-none-any.whl", hash = "sha256:8ebe3f1e1b73ca2ed47c1708a075272f9d663c83e6495f461f489c22cb5b1830", size = 158070, upload-time = "2026-03-05T07:42:13.746Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The span exporter retried up to 4 times on any non-200 status code, including 413 Payload Too Large. Each retry re-serialized the same oversized JSON payload, wasting memory and CPU. On serverless machines this contributed to OOM when trace payloads contained large base64 file content from multimodal LLM calls.

Add a set of non-retryable status codes (400, 401, 403, 404, 413, 422) that cause immediate failure without retry, since these are permanent errors where the payload or credentials won't change.