### PR TITLE
fix: try publishing only new package versions on cd

### DIFF
--- a/.github/scripts/detect_publishable_packages.py
+++ b/.github/scripts/detect_publishable_packages.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Detect which packages need publishing to PyPI.
+
+Compares local package versions against what's already on PyPI.
+Only outputs packages whose local version doesn't exist on PyPI yet.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def get_all_packages() -> list[dict[str, str]]:
+    """Get all packages with their names and versions from pyproject.toml."""
+    packages_dir = Path("packages")
+    packages = []
+
+    for item in sorted(packages_dir.iterdir()):
+        pyproject = item / "pyproject.toml"
+        if item.is_dir() and pyproject.exists():
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            project = data.get("project", {})
+            name = project.get("name")
+            version = project.get("version")
+            if name and version:
+                packages.append(
+                    {"directory": item.name, "name": name, "version": version}
+                )
+
+    return packages
+
+
+def version_exists_on_pypi(package_name: str, version: str) -> bool:
+    """Check if a specific version of a package exists on PyPI."""
+    url = f"https://pypi.org/pypi/{package_name}/{version}/json"
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=10):
+            return True
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return False
+        print(
+            f"  Warning: PyPI returned HTTP {e.code} for {package_name}=={version}",
+            file=sys.stderr,
+        )
+        return False
+    except Exception as e:
+        print(
+            f"  Warning: Could not check PyPI for {package_name}=={version}: {e}",
+            file=sys.stderr,
+        )
+        # If we can't reach PyPI, skip publishing to be safe
+        return True
+
+
+def main():
+    """Main entry point."""
+    all_packages = get_all_packages()
+    publishable = []
+
+    print(f"Checking {len(all_packages)} package(s) against PyPI...")
+
+    for pkg in all_packages:
+        name, version, directory = pkg["name"], pkg["version"], pkg["directory"]
+        exists = version_exists_on_pypi(name, version)
+        if exists:
+            print(f"  {name}=={version} — already on PyPI, skipping")
+        else:
+            print(f"  {name}=={version} — new version, will publish")
+            publishable.append(directory)
+
+    # Output as JSON for GitHub Actions
+    packages_json = json.dumps(publishable)
+    print(f"\nPublishable packages JSON: {packages_json}")
+
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"packages={packages_json}\n")
+            f.write(f"count={len(publishable)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_detect_publishable_packages.py
+++ b/.github/scripts/test_detect_publishable_packages.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Tests for detect_publishable_packages.py."""
+
+import json
+import os
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from detect_publishable_packages import (
+    get_all_packages,
+    main,
+    version_exists_on_pypi,
+)
+
+
+@pytest.fixture()
+def packages_dir(tmp_path: Path):
+    """Create a fake packages directory with pyproject.toml files."""
+    pkg_a = tmp_path / "packages" / "pkg-a"
+    pkg_a.mkdir(parents=True)
+    (pkg_a / "pyproject.toml").write_text(
+        '[project]\nname = "pkg-a"\nversion = "1.0.0"\n'
+    )
+
+    pkg_b = tmp_path / "packages" / "pkg-b"
+    pkg_b.mkdir(parents=True)
+    (pkg_b / "pyproject.toml").write_text(
+        '[project]\nname = "pkg-b"\nversion = "2.0.0"\n'
+    )
+
+    # Directory without pyproject.toml — should be ignored
+    no_toml = tmp_path / "packages" / "no-toml"
+    no_toml.mkdir(parents=True)
+
+    # Directory with pyproject.toml missing version — should be ignored
+    no_version = tmp_path / "packages" / "no-version"
+    no_version.mkdir(parents=True)
+    (no_version / "pyproject.toml").write_text("[project]\n")
+
+    return tmp_path
+
+
+class TestGetAllPackages:
+    def test_detects_packages(self, packages_dir: Path):
+        with mock.patch(
+            "detect_publishable_packages.Path",
+            side_effect=lambda p: packages_dir / p if p == "packages" else Path(p),
+        ):
+            packages = get_all_packages()
+
+        assert len(packages) == 2
+        names = {p["name"] for p in packages}
+        assert names == {"pkg-a", "pkg-b"}
+
+    def test_returns_correct_fields(self, packages_dir: Path):
+        with mock.patch(
+            "detect_publishable_packages.Path",
+            side_effect=lambda p: packages_dir / p if p == "packages" else Path(p),
+        ):
+            packages = get_all_packages()
+
+        pkg_a = next(p for p in packages if p["name"] == "pkg-a")
+        assert pkg_a["directory"] == "pkg-a"
+        assert pkg_a["version"] == "1.0.0"
+
+
+class TestVersionExistsOnPypi:
+    def test_returns_true_when_version_exists(self):
+        mock_response = mock.MagicMock()
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch("urllib.request.urlopen", return_value=mock_response):
+            assert version_exists_on_pypi("some-package", "1.0.0") is True
+
+    def test_returns_false_when_404(self):
+        error = urllib.error.HTTPError(
+            url="", code=404, msg="Not Found", hdrs=None, fp=None  # type: ignore[arg-type]
+        )
+        with mock.patch("urllib.request.urlopen", side_effect=error):
+            assert version_exists_on_pypi("some-package", "9.9.9") is False
+
+    def test_returns_false_on_other_http_error(self):
+        error = urllib.error.HTTPError(
+            url="", code=500, msg="Server Error", hdrs=None, fp=None  # type: ignore[arg-type]
+        )
+        with mock.patch("urllib.request.urlopen", side_effect=error):
+            assert version_exists_on_pypi("some-package", "1.0.0") is False
+
+    def test_returns_true_on_network_error(self):
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=ConnectionError("no network")
+        ):
+            assert version_exists_on_pypi("some-package", "1.0.0") is True
+
+
+class TestMain:
+    def test_publishes_new_versions_only(self, packages_dir: Path):
+        def mock_pypi(name: str, version: str) -> bool:
+            # pkg-a 1.0.0 exists, pkg-b 2.0.0 does not
+            return name == "pkg-a" and version == "1.0.0"
+
+        with (
+            mock.patch(
+                "detect_publishable_packages.Path",
+                side_effect=lambda p: packages_dir / p if p == "packages" else Path(p),
+            ),
+            mock.patch(
+                "detect_publishable_packages.version_exists_on_pypi",
+                side_effect=mock_pypi,
+            ),
+        ):
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+                output_file = f.name
+
+            try:
+                os.environ["GITHUB_OUTPUT"] = output_file
+                main()
+
+                with open(output_file) as f:
+                    content = f.read()
+
+                assert "packages=" in content
+                assert "count=" in content
+
+                # Parse the output
+                lines = content.strip().split("\n")
+                packages_line = next(l for l in lines if l.startswith("packages="))
+                count_line = next(l for l in lines if l.startswith("count="))
+
+                packages = json.loads(packages_line.split("=", 1)[1])
+                count = int(count_line.split("=", 1)[1])
+
+                assert packages == ["pkg-b"]
+                assert count == 1
+            finally:
+                os.unlink(output_file)
+                os.environ.pop("GITHUB_OUTPUT", None)
+
+    def test_nothing_to_publish(self, packages_dir: Path):
+        with (
+            mock.patch(
+                "detect_publishable_packages.Path",
+                side_effect=lambda p: packages_dir / p if p == "packages" else Path(p),
+            ),
+            mock.patch(
+                "detect_publishable_packages.version_exists_on_pypi",
+                return_value=True,
+            ),
+        ):
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+                output_file = f.name
+
+            try:
+                os.environ["GITHUB_OUTPUT"] = output_file
+                main()
+
+                with open(output_file) as f:
+                    content = f.read()
+
+                packages_line = next(
+                    l for l in content.strip().split("\n") if l.startswith("packages=")
+                )
+                count_line = next(
+                    l for l in content.strip().split("\n") if l.startswith("count=")
+                )
+
+                assert json.loads(packages_line.split("=", 1)[1]) == []
+                assert int(count_line.split("=", 1)[1]) == 0
+            finally:
+                os.unlink(output_file)
+                os.environ.pop("GITHUB_OUTPUT", None)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  detect-changed-packages:
+  detect-publishable-packages:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
@@ -23,26 +23,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Detect changed packages
+      - name: Detect publishable packages
         id: detect
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.event.after }}
-        run: python .github/scripts/detect_changed_packages.py
+        run: python .github/scripts/detect_publishable_packages.py
 
   build:
     name: Build ${{ matrix.package }}
-    needs: detect-changed-packages
-    if: needs.detect-changed-packages.outputs.count > 0 && github.repository == 'UiPath/uipath-python'
+    needs: detect-publishable-packages
+    if: needs.detect-publishable-packages.outputs.count > 0 && github.repository == 'UiPath/uipath-python'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -50,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJson(needs.detect-changed-packages.outputs.packages) }}
+        package: ${{ fromJson(needs.detect-publishable-packages.outputs.packages) }}
     permissions:
       contents: read
       actions: write
@@ -99,13 +93,13 @@ jobs:
 
   pypi-publish:
     name: Upload ${{ matrix.package }} to PyPI
-    needs: [detect-changed-packages, build]
+    needs: [detect-publishable-packages, build]
     runs-on: ubuntu-latest
     environment: pypi
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJson(needs.detect-changed-packages.outputs.packages) }}
+        package: ${{ fromJson(needs.detect-publishable-packages.outputs.packages) }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test-cd-scripts.yml
+++ b/.github/workflows/test-cd-scripts.yml
@@ -1,0 +1,32 @@
+name: Test CD Scripts
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/scripts/detect_publishable_packages.py'
+      - '.github/scripts/test_detect_publishable_packages.py'
+      - '.github/workflows/cd.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test-cd-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        working-directory: .github/scripts
+        run: python -m pytest test_detect_publishable_packages.py -v


### PR DESCRIPTION
## Fix CD publish pipeline to only publish new versions

  - replace `detect_changed_packages.py` (which includes dependency propagation) with new `detect_publishable_packages.py` that checks each package version against `PyPI`
  - only packages whose version doesn't already exist on PyPI are built and published
  - add unit tests for the new script
  - add dedicated CI workflow that runs tests on CD script/workflow changes