### PR TITLE
fix: remove $select from deeprag GET request

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.0.16"
+version = "0.0.17"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -1911,7 +1911,6 @@ class ContextGroundingService(FolderContext, BaseService):
             endpoint=Endpoint(f"/ecs_/v2/deeprag/{id}"),
             params={
                 "$expand": "content",
-                "$select": "id,content,name,createdDate,lastDeepRagStatus,failureReason",
             },
         )
 

--- a/packages/uipath-platform/tests/services/test_context_grounding_service.py
+++ b/packages/uipath-platform/tests/services/test_context_grounding_service.py
@@ -1326,7 +1326,7 @@ class TestContextGroundingService:
     ) -> None:
         citation = Citation(ordinal=1, page_number=1, source="abc", reference="abc")
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?$expand=content&$select=id,content,name,createdDate,lastDeepRagStatus,failureReason",
+            url=f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?$expand=content",
             status_code=200,
             json={
                 "id": "test-task-id",
@@ -1358,7 +1358,7 @@ class TestContextGroundingService:
         assert sent_requests[0].method == "GET"
         assert (
             sent_requests[0].url
-            == f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?%24expand=content&%24select=id%2Ccontent%2Cname%2CcreatedDate%2ClastDeepRagStatus%2CfailureReason"
+            == f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?%24expand=content"
         )
 
         assert HEADER_USER_AGENT in sent_requests[0].headers
@@ -1380,7 +1380,7 @@ class TestContextGroundingService:
         citation = Citation(ordinal=1, page_number=1, source="abc", reference="abc")
 
         httpx_mock.add_response(
-            url=f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?$expand=content&$select=id,content,name,createdDate,lastDeepRagStatus,failureReason",
+            url=f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?$expand=content",
             status_code=200,
             json={
                 "id": "test-task-id",
@@ -1412,7 +1412,7 @@ class TestContextGroundingService:
         assert sent_requests[0].method == "GET"
         assert (
             sent_requests[0].url
-            == f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?%24expand=content&%24select=id%2Ccontent%2Cname%2CcreatedDate%2ClastDeepRagStatus%2CfailureReason"
+            == f"{base_url}{org}{tenant}/ecs_/v2/deeprag/test-task-id?%24expand=content"
         )
 
         assert HEADER_USER_AGENT in sent_requests[0].headers

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1061,7 +1061,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.16"
+version = "0.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
context: https://uipath-product.slack.com/archives/C060F2VLC20/p1772825919389239

the failureReason is not yet deployed in stg / prd. we need to remove the select param - the deeprag is flag except for content.