### PR TITLE
fix: enum values in input schema

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.8"
+version = "2.10.9"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/utils/text_tokens.py
+++ b/packages/uipath/src/uipath/agent/utils/text_tokens.py
@@ -133,4 +133,6 @@ def serialize_argument(
         return ""
     if isinstance(value, (list, dict, bool)):
         return json.dumps(value, ensure_ascii=False)
+    if hasattr(value, "value"):
+        return serialize_argument(value.value)
     return str(value)

--- a/packages/uipath/tests/agent/utils/test_text_tokens.py
+++ b/packages/uipath/tests/agent/utils/test_text_tokens.py
@@ -1,5 +1,7 @@
 """Tests for text_tokens.py utils."""
 
+from enum import Enum
+
 import pytest
 
 from uipath.agent.models.agent import TextToken, TextTokenType
@@ -250,6 +252,11 @@ class TestSafeGetNested:
 class TestSerializeValue:
     """Test value serialization."""
 
+    class RiskTolerance(str, Enum):
+        """Test enum mirroring dynamic string enums in input schemas."""
+
+        LOW = "low"
+
     def test_string(self):
         """Test serializing strings."""
         assert serialize_argument("hello") == "hello"
@@ -277,3 +284,7 @@ class TestSerializeValue:
         """Test serializing booleans (JSON-style lowercase)."""
         assert serialize_argument(True) == "true"
         assert serialize_argument(False) == "false"
+
+    def test_string_enum_uses_underlying_value(self):
+        """Test string enums serialize to their values for prompt interpolation."""
+        assert serialize_argument(self.RiskTolerance.LOW) == "low"

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2531,7 +2531,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.8"
+version = "2.10.9"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
##  Summary
  This PR fixes prompt interpolation for enum-backed input fields so the LLM receives the actual enum value instead of the enum member name. In the failing case, risk_tolerance=low was being rendered as DynamicEnum.KEY_0, which
  changed the prompt semantics and led to invalid model behavior.

##  Changes

  - Update prompt argument serialization to unwrap enum-like values before converting them to strings
  - Preserve existing JSON serialization behavior for lists, dicts, and booleans
  - Add a unit test covering string-enum interpolation

##  Why
  Agent prompts must reflect the validated input payload exactly. Passing enum member names instead of their values breaks downstream reasoning and can cause the model to branch incorrectly.