### PR TITLE
feat: filter app schemas by folder key

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.0.23"
+version = "0.0.24"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from uipath.core.tracing import traced
 
@@ -395,12 +395,12 @@ class TasksService(FolderContext, BaseService):
         Raises:
             Exception: If neither app_name nor app_key is provided for app-specific actions
         """
-        app_folder_path = app_folder_path if app_folder_path else self._folder_path
-
         (key, action_schema) = (
             (app_key, None)
             if app_key
-            else await self._get_app_key_and_schema_async(app_name, app_folder_path)
+            else await self._get_app_key_and_schema_async(
+                app_name, app_folder_path, app_folder_key
+            )
         )
         spec = _create_spec(
             title=title,
@@ -481,12 +481,10 @@ class TasksService(FolderContext, BaseService):
         Raises:
             Exception: If neither app_name nor app_key is provided for app-specific actions
         """
-        app_folder_path = app_folder_path if app_folder_path else self._folder_path
-
         (key, action_schema) = (
             (app_key, None)
             if app_key
-            else self._get_app_key_and_schema(app_name, app_folder_path)
+            else self._get_app_key_and_schema(app_name, app_folder_path, app_folder_key)
         )
         spec = _create_spec(
             title=title,
@@ -588,8 +586,11 @@ class TasksService(FolderContext, BaseService):
         return Task.model_validate(response.json())
 
     async def _get_app_key_and_schema_async(
-        self, app_name: Optional[str], app_folder_path: Optional[str]
-    ) -> Tuple[str, Optional[TaskSchema]]:
+        self,
+        app_name: str | None,
+        app_folder_path: str | None,
+        app_folder_key: str | None,
+    ) -> tuple[str, TaskSchema | None]:
         if not app_name:
             raise Exception("appName or appKey is required")
         spec = _retrieve_app_key_spec(app_name=app_name)
@@ -603,7 +604,7 @@ class TasksService(FolderContext, BaseService):
         )
         try:
             deployed_app = self._extract_deployed_app(
-                response.json()["deployed"], app_folder_path
+                response.json()["deployed"], app_name, app_folder_path, app_folder_key
             )
             action_schema = deployed_app["actionSchema"]
             deployed_app_key = deployed_app["systemName"]
@@ -624,8 +625,11 @@ class TasksService(FolderContext, BaseService):
             raise Exception("Failed to deserialize action schema") from KeyError
 
     def _get_app_key_and_schema(
-        self, app_name: Optional[str], app_folder_path: Optional[str]
-    ) -> Tuple[str, Optional[TaskSchema]]:
+        self,
+        app_name: str | None,
+        app_folder_path: str | None,
+        app_folder_key: str | None,
+    ) -> tuple[str, TaskSchema | None]:
         if not app_name:
             raise Exception("appName or appKey is required")
 
@@ -641,7 +645,7 @@ class TasksService(FolderContext, BaseService):
 
         try:
             deployed_app = self._extract_deployed_app(
-                response.json()["deployed"], app_folder_path
+                response.json()["deployed"], app_name, app_folder_path, app_folder_key
             )
             action_schema = deployed_app["actionSchema"]
             deployed_app_key = deployed_app["systemName"]
@@ -661,27 +665,45 @@ class TasksService(FolderContext, BaseService):
         except KeyError:
             raise Exception("Failed to deserialize action schema") from KeyError
 
-    # should be removed after folder filtering support is added on apps API
     def _extract_deployed_app(
-        self, deployed_apps: List[Dict[str, Any]], app_folder_path: Optional[str]
-    ) -> Dict[str, Any]:
-        if len(deployed_apps) > 1 and not app_folder_path:
-            raise Exception("Multiple app schemas found")
-        try:
-            if app_folder_path:
+        self,
+        deployed_apps: list[dict[str, Any]],
+        app_name: str,
+        app_folder_path: str | None,
+        app_folder_key: str | None,
+    ) -> dict[str, Any]:
+        # try extracting the requested app schema. folder path has priority over folder key
+        filtered_apps_by_name = [
+            app for app in deployed_apps if app["deploymentTitle"] == app_name
+        ]
+        if len(filtered_apps_by_name) < 1:
+            raise Exception(f"App '{app_name}' was not found in the current tenant")
+
+        # priority: app_folder_path -> app_folder_key -> self._folder_path -> self._folder_key
+        candidates = [
+            (app_folder_path, "fullyQualifiedName", "fully qualified name"),
+            (app_folder_key, "key", "identifier"),
+            (self._folder_path, "fullyQualifiedName", "fully qualified name"),
+            (self._folder_key, "key", "identifier"),
+        ]
+
+        for value, field, label in candidates:
+            if not value:
+                continue
+            try:
                 return next(
                     app
-                    for app in deployed_apps
-                    if app["deploymentFolder"]["fullyQualifiedName"] == app_folder_path
+                    for app in filtered_apps_by_name
+                    if app["deploymentFolder"][field] == value
                 )
-            else:
-                return next(
-                    app
-                    for app in deployed_apps
-                    if app["deploymentFolder"]["key"] == self._folder_key
-                )
-        except StopIteration:
-            raise KeyError from StopIteration
+            except StopIteration:
+                raise Exception(
+                    f"App '{app_name}' was not found in folder with {label} '{value}'"
+                ) from StopIteration
+
+        raise Exception(
+            f"App '{app_name}' was found but no folder key or folder path was provided to select a deployment"
+        )
 
     @property
     def custom_headers(self) -> Dict[str, str]:

--- a/packages/uipath-platform/tests/services/test_actions_service.py
+++ b/packages/uipath-platform/tests/services/test_actions_service.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -142,6 +144,7 @@ class TestTasksService:
                 "deployed": [
                     {
                         "systemName": "test-app",
+                        "deploymentTitle": "test-app",
                         "actionSchema": {
                             "key": "test-key",
                             "inputs": [],
@@ -149,7 +152,10 @@ class TestTasksService:
                             "inOuts": [],
                             "outcomes": [],
                         },
-                        "deploymentFolder": {"fullyQualifiedName": "test-folder-path"},
+                        "deploymentFolder": {
+                            "fullyQualifiedName": "test-folder-path",
+                            "key": "test-folder-key",
+                        },
                     }
                 ]
             },
@@ -177,3 +183,408 @@ class TestTasksService:
         assert isinstance(action, Task)
         assert action.id == 1
         assert action.title == "Test Action"
+
+
+def _make_deployed_app(
+    name: str,
+    folder_path: str,
+    folder_key: str,
+    system_name: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "systemName": system_name or name,
+        "deploymentTitle": name,
+        "actionSchema": {
+            "key": f"{name}-schema-key",
+            "inputs": [],
+            "outputs": [],
+            "inOuts": [],
+            "outcomes": [],
+        },
+        "deploymentFolder": {
+            "fullyQualifiedName": folder_path,
+            "key": folder_key,
+        },
+    }
+
+
+class TestCreateFiltersByFolder:
+    """Tests for folder filtering when creating tasks via app_name lookup."""
+
+    def _make_tasks_service(
+        self,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        folder_key: str | None = None,
+        folder_path: str | None = None,
+    ) -> TasksService:
+        if folder_key:
+            monkeypatch.setenv("UIPATH_FOLDER_KEY", folder_key)
+        if folder_path:
+            monkeypatch.setenv("UIPATH_FOLDER_PATH", folder_path)
+        return TasksService(config=config, execution_context=execution_context)
+
+    def _mock_app_schemas_response(
+        self,
+        httpx_mock: HTTPXMock,
+        base_url: str,
+        org: str,
+        app_name: str,
+        deployed_apps: list[dict[str, Any]],
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}/apps_/default/api/v1/default/deployed-action-apps-schemas?search={app_name}&filterByDeploymentTitle=true",
+            status_code=200,
+            json={"deployed": deployed_apps},
+        )
+
+    def _mock_create_task_response(
+        self,
+        httpx_mock: HTTPXMock,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/tasks/AppTasks/CreateAppTask",
+            status_code=200,
+            json={"id": 1, "title": "Test Action"},
+        )
+
+    def test_create_filters_by_app_folder_key(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [
+                _make_deployed_app(
+                    "my-app", "folder-a", "key-a", system_name="my-app-a"
+                ),
+                _make_deployed_app(
+                    "my-app", "folder-b", "key-b", system_name="my-app-b"
+                ),
+            ],
+        )
+        self._mock_create_task_response(httpx_mock, base_url, org, tenant)
+
+        task = tasks_service.create(
+            title="Test",
+            app_name="my-app",
+            app_folder_key="key-b",
+            app_folder_path=None,
+        )
+
+        assert isinstance(task, Task)
+        create_request = [
+            r for r in httpx_mock.get_requests() if "CreateAppTask" in str(r.url)
+        ][0]
+        # systemName from the key-b deployment is used as appId in the request
+        assert b"my-app-b" in create_request.content
+
+    @pytest.mark.anyio
+    async def test_create_async_filters_by_app_folder_key(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [
+                _make_deployed_app(
+                    "my-app", "folder-a", "key-a", system_name="my-app-a"
+                ),
+                _make_deployed_app(
+                    "my-app", "folder-b", "key-b", system_name="my-app-b"
+                ),
+            ],
+        )
+        self._mock_create_task_response(httpx_mock, base_url, org, tenant)
+
+        task = await tasks_service.create_async(
+            title="Test",
+            app_name="my-app",
+            app_folder_key="key-b",
+            app_folder_path=None,
+        )
+
+        assert isinstance(task, Task)
+        create_request = [
+            r for r in httpx_mock.get_requests() if "CreateAppTask" in str(r.url)
+        ][0]
+        # systemName from the key-b deployment is used as appId in the request
+        assert b"my-app-b" in create_request.content
+
+    def test_create_filters_by_app_folder_path(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [
+                _make_deployed_app("my-app", "folder-a", "key-a"),
+                _make_deployed_app("my-app", "folder-b", "key-b"),
+            ],
+        )
+        self._mock_create_task_response(httpx_mock, base_url, org, tenant)
+
+        task = tasks_service.create(
+            title="Test",
+            app_name="my-app",
+            app_folder_path="folder-a",
+        )
+
+        assert isinstance(task, Task)
+
+    def test_create_folder_path_takes_priority_over_folder_key(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [
+                _make_deployed_app("my-app", "folder-a", "key-a"),
+                _make_deployed_app("my-app", "folder-b", "key-b"),
+            ],
+        )
+        self._mock_create_task_response(httpx_mock, base_url, org, tenant)
+
+        task = tasks_service.create(
+            title="Test",
+            app_name="my-app",
+            app_folder_path="folder-a",
+            app_folder_key="key-b",
+        )
+
+        assert isinstance(task, Task)
+
+    def test_create_falls_back_to_env_folder_path(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(
+            config, execution_context, monkeypatch, folder_path="env-folder-path"
+        )
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [
+                _make_deployed_app("my-app", "folder-a", "key-a"),
+                _make_deployed_app(
+                    "my-app", "env-folder-path", "key-b", system_name="my-app-b"
+                ),
+            ],
+        )
+        self._mock_create_task_response(httpx_mock, base_url, org, tenant)
+
+        task = tasks_service.create(
+            title="Test",
+            app_name="my-app",
+        )
+
+        assert isinstance(task, Task)
+        create_request = [
+            r for r in httpx_mock.get_requests() if "CreateAppTask" in str(r.url)
+        ][0]
+        assert b"my-app-b" in create_request.content
+
+    def test_create_falls_back_to_env_folder_key(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(
+            config, execution_context, monkeypatch, folder_key="env-key"
+        )
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [
+                _make_deployed_app("my-app", "folder-a", "key-a"),
+                _make_deployed_app("my-app", "folder-b", "env-key"),
+            ],
+        )
+        self._mock_create_task_response(httpx_mock, base_url, org, tenant)
+
+        task = tasks_service.create(
+            title="Test",
+            app_name="my-app",
+        )
+
+        assert isinstance(task, Task)
+
+    def test_create_raises_when_app_not_found_in_tenant(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(
+            config, execution_context, monkeypatch, folder_path="folder-a"
+        )
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [_make_deployed_app("other-app", "folder-a", "key-a")],
+        )
+
+        with pytest.raises(
+            Exception, match="'my-app' was not found in the current tenant"
+        ):
+            tasks_service.create(title="Test", app_name="my-app")
+
+    def test_create_raises_when_app_not_found_in_folder_path(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [_make_deployed_app("my-app", "folder-a", "key-a")],
+        )
+
+        with pytest.raises(
+            Exception,
+            match="'my-app' was not found in folder with fully qualified name 'folder-b'",
+        ):
+            tasks_service.create(
+                title="Test", app_name="my-app", app_folder_path="folder-b"
+            )
+
+    def test_create_raises_when_app_not_found_in_folder_key(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [_make_deployed_app("my-app", "folder-a", "key-a")],
+        )
+
+        with pytest.raises(
+            Exception,
+            match="'my-app' was not found in folder with identifier 'wrong-key'",
+        ):
+            tasks_service.create(
+                title="Test",
+                app_name="my-app",
+                app_folder_key="wrong-key",
+                app_folder_path=None,
+            )
+
+    def test_create_raises_when_no_folder_key_or_path_provided(
+        self,
+        httpx_mock: HTTPXMock,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+        tasks_service = self._make_tasks_service(config, execution_context, monkeypatch)
+        self._mock_app_schemas_response(
+            httpx_mock,
+            base_url,
+            org,
+            "my-app",
+            [_make_deployed_app("my-app", "folder-a", "key-a")],
+        )
+
+        with pytest.raises(
+            Exception, match="no folder key or folder path was provided"
+        ):
+            tasks_service.create(
+                title="Test",
+                app_name="my-app",
+                app_folder_path=None,
+            )

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/tests/resource_overrides/test_resource_overrides.py
+++ b/packages/uipath/tests/resource_overrides/test_resource_overrides.py
@@ -130,6 +130,7 @@ class TestResourceOverrides:
                 "deployed": [
                     {
                         "systemName": "app-key-123",
+                        "deploymentTitle": "Overwritten App Name",
                         "deploymentFolder": {
                             "fullyQualifiedName": "Overwritten/App/Folder"
                         },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2679,7 +2679,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- filter deployed apps by exact deploymentTitle (avoids common prefixes)
- try selecting the app by folder path (if provided), fallback to folder key
- changed selection priority (explicit args should have priority over env vars:
`app_folder_path -> app_folder_key -> self._folder_path-> self._folder_key`