### PR TITLE
fix: centralize httpx header merging in get_httpx_client_kwargs()

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.0.22"
+version = "0.0.23"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_base_service.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_base_service.py
@@ -71,13 +71,9 @@ class BaseService:
 
         self._url = UiPathUrl(self._config.base_url)
 
-        default_client_kwargs = get_httpx_client_kwargs()
-
-        client_kwargs = {
-            **default_client_kwargs,  # SSL, proxy, timeout, redirects
-            "base_url": self._url.base_url,
-            "headers": Headers(self.default_headers),
-        }
+        client_kwargs = get_httpx_client_kwargs(headers=self.default_headers)
+        client_kwargs["base_url"] = self._url.base_url
+        client_kwargs["headers"] = Headers(client_kwargs.get("headers", {}))
 
         self._client = Client(**client_kwargs)
         self._client_async = AsyncClient(**client_kwargs)

--- a/packages/uipath-platform/src/uipath/platform/common/_http_config.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_http_config.py
@@ -34,27 +34,34 @@ def create_ssl_context():
         )
 
 
-def get_httpx_client_kwargs() -> Dict[str, Any]:
-    """Get standardized httpx client configuration."""
+def get_httpx_client_kwargs(
+    headers: Dict[str, str] | None = None,
+) -> Dict[str, Any]:
+    """Get standardized httpx client configuration.
+
+    Args:
+        headers: Optional headers to merge with platform headers (e.g. licensing).
+            Caller headers take priority on key conflicts.
+    """
     client_kwargs: Dict[str, Any] = {"follow_redirects": True, "timeout": 30.0}
-    # Check environment variable to disable SSL verification
     disable_ssl_env = os.environ.get("UIPATH_DISABLE_SSL_VERIFY", "").lower()
     disable_ssl_from_env = disable_ssl_env in ("1", "true", "yes", "on")
 
     if disable_ssl_from_env:
         client_kwargs["verify"] = False
     else:
-        # Use system certificates with truststore fallback
         client_kwargs["verify"] = create_ssl_context()
-
-    # Auto-detect proxy from environment variables (httpx handles this automatically)
-    # HTTP_PROXY, HTTPS_PROXY, NO_PROXY are read by httpx by default
 
     from ._config import UiPathConfig
     from .constants import HEADER_LICENSING_CONTEXT
 
+    merged_headers: Dict[str, str] = {}
     licensing_context = UiPathConfig.licensing_context
     if licensing_context:
-        client_kwargs["headers"] = {HEADER_LICENSING_CONTEXT: licensing_context}
+        merged_headers[HEADER_LICENSING_CONTEXT] = licensing_context
+    if headers:
+        merged_headers.update(headers)
+    if merged_headers:
+        client_kwargs["headers"] = merged_headers
 
     return client_kwargs

--- a/packages/uipath-platform/tests/services/test_http_config.py
+++ b/packages/uipath-platform/tests/services/test_http_config.py
@@ -1,0 +1,100 @@
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from uipath.platform.common._config import ConfigurationManager
+from uipath.platform.common._http_config import get_httpx_client_kwargs
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure licensing-related env vars are clean for every test."""
+    monkeypatch.delenv("UIPATH_DISABLE_SSL_VERIFY", raising=False)
+
+
+class TestGetHttpxClientKwargsHeaders:
+    """Tests for header merging in get_httpx_client_kwargs()."""
+
+    def test_no_licensing_no_caller_headers(self) -> None:
+        """No headers key when neither licensing nor caller headers are provided."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value=None,
+        ):
+            result = get_httpx_client_kwargs()
+        assert "headers" not in result
+
+    def test_licensing_context_only(self) -> None:
+        """Licensing header included when licensing_context is set."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value="test-license-ctx",
+        ):
+            result = get_httpx_client_kwargs()
+        assert result["headers"] == {"x-uipath-licensing-context": "test-license-ctx"}
+
+    def test_caller_headers_only(self) -> None:
+        """Caller headers included when no licensing_context is set."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value=None,
+        ):
+            result = get_httpx_client_kwargs(headers={"Authorization": "Bearer tok"})
+        assert result["headers"] == {"Authorization": "Bearer tok"}
+
+    def test_licensing_and_caller_headers_merged(self) -> None:
+        """Both licensing and caller headers present in result."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value="lic-ctx",
+        ):
+            result = get_httpx_client_kwargs(headers={"Authorization": "Bearer tok"})
+        assert result["headers"] == {
+            "x-uipath-licensing-context": "lic-ctx",
+            "Authorization": "Bearer tok",
+        }
+
+    def test_caller_headers_win_on_conflict(self) -> None:
+        """Caller headers override licensing headers on same key."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value="lic-ctx",
+        ):
+            result = get_httpx_client_kwargs(
+                headers={"x-uipath-licensing-context": "caller-override"}
+            )
+        assert result["headers"] == {"x-uipath-licensing-context": "caller-override"}
+
+    def test_result_always_contains_base_config(self) -> None:
+        """SSL, timeout, and redirect config always present regardless of headers."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value="lic",
+        ):
+            result = get_httpx_client_kwargs(headers={"Authorization": "Bearer x"})
+        assert result["follow_redirects"] is True
+        assert result["timeout"] == 30.0
+        assert "verify" in result
+
+    def test_no_headers_key_when_empty(self) -> None:
+        """Empty caller headers dict with no licensing does not add headers key."""
+        with patch.object(
+            ConfigurationManager,
+            "licensing_context",
+            new_callable=PropertyMock,
+            return_value=None,
+        ):
+            result = get_httpx_client_kwargs(headers={})
+        assert "headers" not in result

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.12"
+version = "2.10.13"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/tracing/_otel_exporters.py
+++ b/packages/uipath/src/uipath/tracing/_otel_exporters.py
@@ -136,9 +136,9 @@ class LlmOpsHttpExporter(SpanExporter):
                 "UIPATH_ORGANIZATION_ID", ""
             )
 
-        client_kwargs = get_httpx_client_kwargs()
+        client_kwargs = get_httpx_client_kwargs(headers=self.headers)
 
-        self.http_client = httpx.Client(**client_kwargs, headers=self.headers)
+        self.http_client = httpx.Client(**client_kwargs)
         self.trace_id = trace_id
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2540,7 +2540,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.12"
+version = "2.10.13"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2679,7 +2679,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Add headers parameter to get_httpx_client_kwargs() so callers pass their headers through the central function instead of as a separate kwarg to httpx.Client(). This prevents KeyError crashes when licensing_context is set and the function already injects a headers key into client_kwargs.

Bump uipath-platform to 0.0.23, uipath to 2.10.13.