### PR TITLE
feat: add DataServiceApiUserAccess scope to CLI auth AGVSOL-1723 (AGVSOL-1645)

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.13"
+version = "2.10.14"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_auth/auth_config_cloud.json
+++ b/packages/uipath/src/uipath/_cli/_auth/auth_config_cloud.json
@@ -1,6 +1,6 @@
 {
   "client_id": "36dea5b8-e8bb-423d-8e7b-c808df8f1c00",
   "redirect_uri": "http://localhost:__PY_REPLACE_PORT__/oidc/login",
-  "scope": "offline_access ProcessMining OrchestratorApiUserAccess StudioWebBackend IdentityServerApi ConnectionService DataService DocumentUnderstanding Du.Digitization.Api Du.Classification.Api Du.Extraction.Api Du.Validation.Api EnterpriseContextService Directory JamJamApi LLMGateway LLMOps OMS RCS.FolderAuthorization TM.Projects TM.TestCases TM.Requirements TM.TestSets AutomationSolutions AT.TrackOperations Docs.GPT.Search",
+  "scope": "offline_access ProcessMining OrchestratorApiUserAccess StudioWebBackend IdentityServerApi ConnectionService DataService DataServiceApiUserAccess DocumentUnderstanding Du.Digitization.Api Du.Classification.Api Du.Extraction.Api Du.Validation.Api EnterpriseContextService Directory JamJamApi LLMGateway LLMOps OMS RCS.FolderAuthorization TM.Projects TM.TestCases TM.Requirements TM.TestSets AutomationSolutions AT.TrackOperations Docs.GPT.Search",
   "port": 8104
 }

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2540,7 +2540,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.13"
+version = "2.10.14"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
For the agentic vertical solutions we are creating automated scripts that can deploy our solutions. As part of the deployment, we need to import our schema into DataFabric. With the current set of Scopes available, its not possible to do this via an API call. 

When a user calls `import` from the UI, the scope `DataServiceApiUserAccess` is included in its JWT token.
Allow the Python SDK CLI client ID to get the scope `DataServiceApiUserAccess` so we can call `import` and automate schema creation during deployment.

✅ [UiPath/first-party-service-metadata#3574](https://github.com/UiPath/first-party-service-metadata/pull/3574) allows the Python SDK CLI client ID to get the `DataServiceApiUserAccess` scope.

This PR:
- Adds `DataServiceApiUserAccess` to the OAuth scope list in `auth_config_cloud.json`

## Dependencies
This PR requires the identity server change to land first:
- [UiPath/first-party-service-metadata#3574](https://github.com/UiPath/first-party-service-metadata/pull/3574) — adds CLI client `36dea5b8-...` to the `DataServiceApiUserAccess` scope's `ClientIdsAllowed` list

Without that change, the identity server will reject the scope request even if the CLI requests it.

## Test plan
- [x] Verify [first-party-service-metadata#3574](https://github.com/UiPath/first-party-service-metadata/pull/3574) is deployed
- [ ] Run `uipath auth --staging --force` and verify the new token includes `DataServiceApiUserAccess` in its scopes
- [ ] Verify `POST /datafabric_/api/Entity/import` succeeds with the new token (previously returned 403)
- [ ] Verify existing Data Fabric read operations (`GET /datafabric_/api/Entity`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)