### PR TITLE
feat: generate .uiproj and studio_metadata files on init

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.0.27"
+version = "0.0.28"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_config.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_config.py
@@ -131,6 +131,12 @@ class ConfigurationManager:
         return Path(ENTRY_POINTS_FILE)
 
     @property
+    def uiproj_file_path(self) -> Path:
+        from uipath.platform.common.constants import UIPROJ_FILE
+
+        return Path(UIPROJ_FILE)
+
+    @property
     def studio_metadata_file_path(self) -> Path:
         from uipath.platform.common.constants import STUDIO_METADATA_FILE
 

--- a/packages/uipath-platform/src/uipath/platform/common/constants.py
+++ b/packages/uipath-platform/src/uipath/platform/common/constants.py
@@ -78,6 +78,7 @@ UIPATH_CONFIG_FILE = "uipath.json"
 UIPATH_BINDINGS_FILE = "bindings.json"
 ENTRY_POINTS_FILE = "entry-points.json"
 STUDIO_METADATA_FILE = "studio_metadata.json"
+UIPROJ_FILE = "project.uiproj"
 
 
 # Folder names

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.27"
+version = "0.0.28"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/docs/cli/index.md
+++ b/packages/uipath/docs/cli/index.md
@@ -40,9 +40,20 @@ Selected tenant: Tenant1
     :depth: 1
     :style: table
 
-Package requirements (bindings) are dependencies that are required by the automation package for successful execution.
+Initializes a UiPath project by generating all required configuration and metadata files. Run this command when setting up a new project and after modifying your agent's or function's input/output schema.
 
-For more information about package requirements, see  [the official documentation](https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/managing-package-requirements)
+### Generated Files
+
+| File | Description |
+|------|-------------|
+| `uipath.json` | Project configuration with entrypoint definitions |
+| `bindings.json` | Resource bindings (assets, processes, buckets, etc.) |
+| `entry-points.json` | Entry point definitions with input/output schemas |
+| `project.uiproj` | Project metadata for StudioWeb integration |
+| `.uipath/studio_metadata.json` | Studio metadata (schema and code version) |
+| `.env` | Environment variables file |
+| `AGENTS.md`, `CLAUDE.md` | Agent documentation and coding assistant instructions |
+| `.agent/CLI_REFERENCE.md`, `.agent/SDK_REFERENCE.md`, `.agent/REQUIRED_STRUCTURE.md` | Agent reference docs |
 
 /// warning
 
@@ -63,7 +74,13 @@ Running `uipath init` will process these function definitions and create the cor
 ```shell
 > uipath init
 ⠋ Initializing UiPath project ...
-✓  Created 'entry-points.json' file.
+✓  Created 'uipath.json' file.
+✓  Created 'bindings.json' file.
+✓  Created 'entry-points.json' file with 1 entrypoint(s).
+✓  Created 1 mermaid diagram file(s).
+✓  Updated 'project.uiproj' file.
+✓  Created '.uipath/studio_metadata.json' file.
+✓  Created: CLAUDE.md, CLI_REFERENCE.md, SDK_REFERENCE.md, AGENTS.md, REQUIRED_STRUCTURE.md.
 ```
 ---
 

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.10.18"
+version = "2.10.19"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.2, <0.6.0",
   "uipath-runtime>=0.9.1, <0.10.0",
-  "uipath-platform>=0.0.25, <0.1.0",
+  "uipath-platform>=0.0.28, <0.1.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/specs/README.md
+++ b/packages/uipath/specs/README.md
@@ -19,4 +19,9 @@ Entry point definitions with JSON Schema-based input/output contracts.
 
 - [Spec](entry-points.spec.md) | [Schema](entry-points.schema.json)
 
+### `project.uiproj` - Project Metadata
+Project-level metadata for StudioWeb integration. Auto-generated and auto-updated by `uipath init`.
+
+- [Spec](uiproj.spec.md) | [Schema](uiproj.schema.json)
+
 

--- a/packages/uipath/specs/uiproj.schema.json
+++ b/packages/uipath/specs/uiproj.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cloud.uipath.com/draft/2024-12/uiproj",
+  "title": "UiPath Project Configuration",
+  "description": "Project-level metadata for UiPath coded automation projects, used by StudioWeb",
+  "type": "object",
+  "required": ["ProjectType", "Name", "MainFile"],
+  "properties": {
+    "ProjectType": {
+      "type": "string",
+      "description": "The type of project, determined from uipath.json entrypoints",
+      "enum": ["Agent", "Function"]
+    },
+    "Name": {
+      "type": "string",
+      "description": "Project name, sourced from pyproject.toml [project].name"
+    },
+    "Description": {
+      "type": ["string", "null"],
+      "description": "Project description, sourced from pyproject.toml [project].description"
+    },
+    "MainFile": {
+      "type": ["string", "null"],
+      "description": "Main file path. Required by StudioWeb but not used for coded agents",
+      "default": null
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/uipath/specs/uiproj.spec.md
+++ b/packages/uipath/specs/uiproj.spec.md
@@ -1,0 +1,78 @@
+# UiPath Project Configuration Specification
+
+## Overview
+
+The `project.uiproj` file defines project-level metadata for UiPath coded projects. It is used by StudioWeb to identify the project type, name, and description. This file is auto-generated and auto-updated by `uipath init`.
+
+**File Name:** `project.uiproj`
+
+---
+
+## File Structure
+
+```json
+{
+  "ProjectType": "Agent",
+  "Name": "my-project",
+  "Description": "Project description",
+  "MainFile": null
+}
+```
+
+---
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `ProjectType` | `string` | Yes | The type of project: `"Agent"` or `"Function"` |
+| `Name` | `string` | Yes | Project name, taken from `pyproject.toml` `[project].name` |
+| `Description` | `string\|null` | No | Project description, taken from `pyproject.toml` `[project].description` |
+| `MainFile` | `string\|null` | Yes | Main file path. Required by StudioWeb but not used for coded agents; always `null` for coded projects |
+
+---
+
+## ProjectType
+
+The `ProjectType` is determined automatically from the entrypoints defined in `uipath.json`:
+
+- **`"Agent"`** — when all entrypoints are declared under the `"agents"` key
+- **`"Function"`** — when at least one entrypoint is declared under the `"functions"` key, or when no entrypoints exist
+
+If `uipath.json` contains both `"agents"` and `"functions"` (mixed types), a warning is emitted and the type defaults to the first entrypoint's type.
+
+If the project type changes between runs of `uipath init` (e.g., an existing `project.uiproj` has `"Agent"` but the current entrypoints are all functions), a warning is displayed.
+
+---
+
+## Lifecycle
+
+- **Created by:** `uipath init` (when `project.uiproj` does not exist)
+- **Updated by:** `uipath init` (when `project.uiproj` already exists)
+- **Consumed by:** StudioWeb for project integration
+
+---
+
+## Complete Examples
+
+### Agent Project
+
+```json
+{
+  "ProjectType": "Agent",
+  "Name": "invoice-processor",
+  "Description": "An agent that processes invoices using DU",
+  "MainFile": null
+}
+```
+
+### Function Project
+
+```json
+{
+  "ProjectType": "Function",
+  "Name": "calculator",
+  "Description": "A simple calculator function",
+  "MainFile": null
+}
+```

--- a/packages/uipath/src/uipath/_cli/_push/sw_file_handler.py
+++ b/packages/uipath/src/uipath/_cli/_push/sw_file_handler.py
@@ -443,6 +443,14 @@ class SwFileHandler:
             with open(local_metadata_file, "r") as f:
                 metadata = json.load(f)
 
+        # ensure push-related fields are always present for cloud workspace
+        # context: on initial init the CLI creates a minimal studio_metadata.json file
+        # which does not contain lastPushAuthor and lastPushDate
+        if "lastPushAuthor" not in metadata:
+            metadata["lastPushAuthor"] = author
+        if "lastPushDate" not in metadata:
+            metadata["lastPushDate"] = datetime.now(timezone.utc).isoformat()
+
         existing = remote_files.get(".uipath/studio_metadata.json")
         if existing:
             try:

--- a/packages/uipath/src/uipath/_cli/_utils/_common.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_common.py
@@ -15,6 +15,7 @@ from uipath.platform.common import (
 )
 
 from ..._utils.constants import ENV_UIPATH_ACCESS_TOKEN
+from ..models.runtime_schema import EntryPoint
 from ..spinner import Spinner
 from ._console import ConsoleLogger
 from ._studio_project import (
@@ -104,6 +105,36 @@ def clean_directory(directory: str) -> None:
 
         if os.path.isfile(file_path) and file_name.endswith(".py"):
             os.remove(file_path)
+
+
+def determine_project_type(entrypoints: list[EntryPoint]) -> str:
+    """Determine the project type from entrypoints.
+
+    Returns the type of the first entrypoint, or "function" if no entrypoints exist.
+    Logs a warning if there are multiple entrypoint types.
+
+    Args:
+        entrypoints: List of EntryPoint objects.
+
+    Returns:
+        The project type string (e.g. "agent" or "function").
+    """
+    if not entrypoints:
+        return "function"
+
+    unique_types = set(ep.type for ep in entrypoints)
+    chosen_type = entrypoints[0].type
+
+    if len(unique_types) > 1:
+        console = ConsoleLogger()
+        types_str = ", ".join(sorted(unique_types))
+        console.warning(
+            f"Mixed entrypoint types detected: [{types_str}]. "
+            f'Defaulting project type to "{chosen_type}". '
+            f"We recommend using a single type for all entrypoints."
+        )
+
+    return chosen_type
 
 
 async def ensure_coded_agent_project(studio_client: StudioClient):

--- a/packages/uipath/src/uipath/_cli/cli_init.py
+++ b/packages/uipath/src/uipath/_cli/cli_init.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import importlib.resources
 import json
 import logging
@@ -32,9 +33,12 @@ from uipath.runtime.schema import UiPathRuntimeGraph, UiPathRuntimeSchema
 from .._utils.constants import ENV_TELEMETRY_ENABLED
 from ..telemetry._constants import _PROJECT_KEY, _TELEMETRY_CONFIG_FILE
 from ._telemetry import track_command
+from ._utils._common import determine_project_type
 from ._utils._console import ConsoleLogger
+from ._utils._constants import AGENT_INITIAL_CODE_VERSION, SCHEMA_VERSION
+from ._utils._project_files import read_toml_project
 from .middlewares import Middlewares
-from .models.runtime_schema import Bindings
+from .models.runtime_schema import Bindings, EntryPoint
 from .models.uipath_json_schema import UiPathJsonConfig
 
 console = ConsoleLogger()
@@ -43,6 +47,11 @@ logger = logging.getLogger(__name__)
 CONFIG_PATH = "uipath.json"
 
 GRAPH_INDENT = "    "
+
+
+class Action(str, enum.Enum):
+    CREATED = "Created"
+    UPDATED = "Updated"
 
 
 def create_telemetry_config_file(target_directory: str) -> None:
@@ -76,7 +85,7 @@ def generate_env_file(target_directory):
         relative_path = os.path.relpath(env_path, target_directory)
         with open(env_path, "w"):
             pass
-        console.success(f"Created '{relative_path}' file.")
+        console.success(f"{Action.CREATED.value} '{relative_path}' file.")
 
 
 def generate_agent_md_file(
@@ -142,12 +151,12 @@ def generate_agent_md_files(target_directory: str, no_agents_md_override: bool) 
 
     if any_overridden:
         console.success(
-            f"Updated {click.style('AGENTS.md', fg='cyan')} files and Claude Code skills."
+            f"{Action.UPDATED.value} {click.style('AGENTS.md', fg='cyan')} files and Claude Code skills."
         )
         return
 
     console.success(
-        f"Created {click.style('AGENTS.md', fg='cyan')} files and Claude Code skills."
+        f"{Action.CREATED.value} {click.style('AGENTS.md', fg='cyan')} files and Claude Code skills."
     )
 
 
@@ -194,6 +203,78 @@ def write_entry_points_file(entry_points: list[UiPathRuntimeSchema]) -> Path:
         json.dump(json_object, entry_points_file, indent=4)
 
     return entry_points_file_path
+
+
+def write_uiproj_file(
+    entry_point_schemas: list[UiPathRuntimeSchema],
+    current_directory: str,
+) -> None:
+    """Write project.uiproj file, warning if the project type changed.
+
+    Args:
+        entry_point_schemas: The entrypoint schemas from runtime discovery.
+        current_directory: The project root directory.
+
+    """
+    entry_point_models = [
+        EntryPoint.model_validate(ep.model_dump(by_alias=True, exclude_unset=True))
+        for ep in entry_point_schemas
+    ]
+    project_type = determine_project_type(entry_point_models).capitalize()
+
+    toml_data = read_toml_project(os.path.join(current_directory, "pyproject.toml"))
+    project_name = toml_data["name"]
+    project_description = toml_data.get("description")
+
+    uiproj_file_path = Path(current_directory) / str(UiPathConfig.uiproj_file_path)
+    if uiproj_file_path.exists():
+        action = Action.UPDATED.value
+        with open(uiproj_file_path, "r") as f:
+            existing = json.load(f)
+        existing_type = existing.get("ProjectType")
+        if existing_type and existing_type != project_type:
+            console.warning(
+                f'Project type changed from "{existing_type}" to "{project_type}".'
+            )
+    else:
+        action = Action.CREATED.value
+
+    json_object = {
+        "ProjectType": project_type,
+        "Name": project_name,
+        "Description": project_description,
+        "MainFile": None,
+    }
+
+    with open(uiproj_file_path, "w") as f:
+        json.dump(json_object, f, indent=2)
+
+    console.success(f"{action} '{UiPathConfig.uiproj_file_path}' file.")
+
+
+def write_studio_metadata_file(directory: str) -> None:
+    """Write studio_metadata.json with initial codeVersion and schemaVersion.
+
+    Args:
+        directory: The project root directory.
+    """
+    local_metadata_file = os.path.join(
+        directory, str(UiPathConfig.studio_metadata_file_path)
+    )
+    if os.path.exists(local_metadata_file):
+        return
+
+    metadata = {
+        "schemaVersion": SCHEMA_VERSION,
+        "codeVersion": AGENT_INITIAL_CODE_VERSION,
+    }
+    os.makedirs(os.path.dirname(local_metadata_file), exist_ok=True)
+    with open(local_metadata_file, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    console.success(
+        f"{Action.CREATED.value} '{os.path.relpath(local_metadata_file, directory)}' file."
+    )
 
 
 def write_mermaid_files(entry_points: list[UiPathRuntimeSchema]) -> list[Path]:
@@ -342,7 +423,7 @@ def init(no_agents_md_override: bool) -> None:
                 if not config_path.exists():
                     config = UiPathJsonConfig.create_default()
                     config.save_to_file(config_path)
-                    console.success(f"Created '{config_path}' file.")
+                    console.success(f"{Action.CREATED.value} '{config_path}' file.")
                 else:
                     console.info(f"'{config_path}' already exists, skipping.")
 
@@ -352,7 +433,7 @@ def init(no_agents_md_override: bool) -> None:
                     bindings_path = write_bindings_file(
                         Bindings(version="2.0", resources=[])
                     )
-                    console.success(f"Created '{bindings_path}' file.")
+                    console.success(f"{Action.CREATED.value} '{bindings_path}' file.")
                 else:
                     console.info(f"'{bindings_path}' already exists, skipping.")
 
@@ -391,15 +472,18 @@ def init(no_agents_md_override: bool) -> None:
                 # Write entry-points.json with all schemas
                 entry_points_path = write_entry_points_file(entry_point_schemas)
                 console.success(
-                    f"Created '{entry_points_path}' file with {len(entry_point_schemas)} entrypoint(s)."
+                    f"{Action.CREATED.value} '{entry_points_path}' file with {len(entry_point_schemas)} entrypoint(s)."
                 )
 
                 # Write mermaid diagrams for each entrypoint
                 mermaid_paths = write_mermaid_files(entry_point_schemas)
                 if mermaid_paths and len(mermaid_paths) > 0:
                     console.success(
-                        f"Created {len(mermaid_paths)} mermaid diagram file(s)."
+                        f"{Action.CREATED.value} {len(mermaid_paths)} mermaid diagram file(s)."
                     )
+
+                write_uiproj_file(entry_point_schemas, current_directory)
+                write_studio_metadata_file(current_directory)
 
                 return entry_point_schemas
 

--- a/packages/uipath/src/uipath/_cli/cli_pack.py
+++ b/packages/uipath/src/uipath/_cli/cli_pack.py
@@ -3,18 +3,18 @@ import os
 import uuid
 import zipfile
 from string import Template
-from typing import Any
 
 import click
 from pydantic import TypeAdapter
 
-from uipath._cli.models.runtime_schema import Bindings
+from uipath._cli.models.runtime_schema import Bindings, EntryPoint, EntryPoints
 from uipath._cli.models.uipath_json_schema import RuntimeOptions, UiPathJsonConfig
 from uipath.eval.constants import EVALS_FOLDER, LEGACY_EVAL_FOLDER
 from uipath.platform.common import UiPathConfig
 
 from ..telemetry._constants import _PROJECT_KEY, _TELEMETRY_CONFIG_FILE
 from ._telemetry import track_command
+from ._utils._common import determine_project_type
 from ._utils._console import ConsoleLogger
 from ._utils._project_files import (
     ensure_config_file,
@@ -72,24 +72,23 @@ def validate_config_structure(config_data):
 
 
 def generate_operate_file(
-    entryPoints: list[dict[str, Any]], runtimeOptions: RuntimeOptions, dependencies=None
+    entrypoints: list[EntryPoint], runtimeOptions: RuntimeOptions, dependencies=None
 ):
-    if not entryPoints:
+    if not entrypoints:
         raise ValueError(
             "No entry points found in entry-points.json. Please run 'uipath init' to generate valid entry points."
         )
 
     project_id = get_project_id()
 
-    first_entry = entryPoints[0]
-    file_path = first_entry["filePath"]
-    type = first_entry["type"]
+    project_type = determine_project_type(entrypoints)
+    first_entry = entrypoints[0]
 
     operate_json_data = {
         "$schema": schema,
         "projectId": project_id,
-        "main": file_path,
-        "contentType": type,
+        "main": first_entry.file_path,
+        "contentType": project_type,
         "targetFramework": "Portable",
         "targetRuntime": "python",
         "runtimeOptions": {
@@ -105,11 +104,13 @@ def generate_operate_file(
     return operate_json_data
 
 
-def generate_entrypoints_file(entryPoints):
+def generate_entrypoints_file(entrypoints: list[EntryPoint]):
     entrypoint_json_data = {
         "$schema": schema,
         "$id": "entry-points.json",
-        "entryPoints": entryPoints,
+        "entryPoints": [
+            ep.model_dump(by_alias=True, exclude_none=True) for ep in entrypoints
+        ],
     }
 
     return entrypoint_json_data
@@ -184,15 +185,15 @@ def generate_psmdcp_content(projectName, version, description, authors):
     return [random_file_name, Template(content).substitute(variables)]
 
 
-def generate_package_descriptor_content(entryPoints):
+def generate_package_descriptor_content(entrypoints: list[EntryPoint]):
     files = {
         "operate.json": "content/operate.json",
         "entry-points.json": "content/entry-points.json",
         "bindings.json": "content/bindings_v2.json",
     }
 
-    for entry in entryPoints:
-        files[entry["filePath"]] = entry["filePath"]
+    for entry in entrypoints:
+        files[entry.file_path] = entry.file_path
 
     package_descriptor_content = {
         "$schema": "https://cloud.uipath.com/draft/2024-12/package-descriptor",
@@ -222,12 +223,13 @@ def pack_fn(
     entry_points_file_path = os.path.join(
         directory, str(UiPathConfig.entry_points_file_path)
     )
-    entry_points: list[dict[str, Any]] = []
     if not os.path.exists(entry_points_file_path):
         raise Exception("'entry-points.json' file not found. Please run 'uipath init'.")
-    else:
-        with open(entry_points_file_path, "r") as f:
-            entry_points = json.load(f).get("entryPoints", [])
+
+    with open(entry_points_file_path, "r") as f:
+        entry_points_data = EntryPoints.model_validate(json.load(f))
+
+    entrypoints = entry_points_data.entrypoints
 
     config_path = os.path.join(directory, "uipath.json")
     if not os.path.exists(config_path):
@@ -237,7 +239,7 @@ def pack_fn(
         config_data = TypeAdapter(UiPathJsonConfig).validate_python(json.load(f))
 
     operate_file = generate_operate_file(
-        entry_points, config_data.runtime_options, dependencies
+        entrypoints, config_data.runtime_options, dependencies
     )
 
     # try to read bindings from bindings.json
@@ -257,7 +259,7 @@ def pack_fn(
         f"/{project_name}.nuspec",
         f"/package/services/metadata/core-properties/{psmdcp_file_name}",
     )
-    package_descriptor_content = generate_package_descriptor_content(entry_points)
+    package_descriptor_content = generate_package_descriptor_content(entrypoints)
 
     # Create .uipath directory if it doesn't exist
     os.makedirs(".uipath", exist_ok=True)

--- a/packages/uipath/src/uipath/_cli/models/runtime_schema.py
+++ b/packages/uipath/src/uipath/_cli/models/runtime_schema.py
@@ -33,6 +33,25 @@ class Bindings(BaseModelWithDefaultConfig):
     resources: list[BindingResource] = Field(..., alias="resources")
 
 
+class EntryPoint(BaseModelWithDefaultConfig):
+    file_path: str = Field(..., alias="filePath")
+    unique_id: str = Field(..., alias="uniqueId")
+    type: str = Field(..., alias="type")
+    input: dict[str, Any] = Field(..., alias="input")
+    output: dict[str, Any] = Field(..., alias="output")
+    graph: dict[str, Any] | None = Field(default=None, alias="graph")
+    metadata: dict[str, Any] | None = Field(default=None, alias="metadata")
+
+
+class EntryPoints(BaseModelWithDefaultConfig):
+    schema_: str = Field(
+        default="https://cloud.uipath.com/draft/2024-12/entry-point",
+        alias="$schema",
+    )
+    id_: str = Field(default="entry-points.json", alias="$id")
+    entrypoints: list[EntryPoint] = Field(..., alias="entryPoints")
+
+
 class RuntimeInternalArguments(BaseModelWithDefaultConfig):
     resource_overwrites: dict[str, Any] = Field(..., alias="resourceOverwrites")
 

--- a/packages/uipath/tests/cli/models/test_entrypoints.py
+++ b/packages/uipath/tests/cli/models/test_entrypoints.py
@@ -1,0 +1,116 @@
+import json
+
+from uipath._cli.models.runtime_schema import EntryPoint, EntryPoints
+
+
+class TestEntryPointModel:
+    def test_entrypoint_from_dict(self) -> None:
+        data = {
+            "filePath": "agent",
+            "uniqueId": "f620a11e-90fa-4506-8859-d8f147fdc31d",
+            "type": "agent",
+            "input": {"type": "object", "properties": {}},
+            "output": {"type": "string"},
+        }
+        ep = EntryPoint.model_validate(data)
+        assert ep.file_path == "agent"
+        assert ep.type == "agent"
+        assert ep.graph is None
+        assert ep.metadata is None
+
+    def test_entrypoint_with_graph(self) -> None:
+        data = {
+            "filePath": "agent",
+            "uniqueId": "f620a11e-90fa-4506-8859-d8f147fdc31d",
+            "type": "agent",
+            "input": {"type": "object", "properties": {}},
+            "output": {"type": "string"},
+            "graph": {
+                "nodes": [{"id": "n1", "name": "main", "type": "function"}],
+                "edges": [],
+            },
+        }
+        ep = EntryPoint.model_validate(data)
+        assert ep.graph is not None
+        assert len(ep.graph["nodes"]) == 1
+
+    def test_entrypoint_roundtrip(self) -> None:
+        data = {
+            "filePath": "func",
+            "uniqueId": "00000000-0000-0000-0000-000000000000",
+            "type": "function",
+            "input": {"type": "object", "properties": {"x": {"type": "string"}}},
+            "output": {"type": "string"},
+        }
+        ep = EntryPoint.model_validate(data)
+        dumped = ep.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["filePath"] == "func"
+        assert dumped["type"] == "function"
+        assert "graph" not in dumped
+
+
+class TestEntryPointsModel:
+    def test_entrypoints_from_file_content(self) -> None:
+        content = {
+            "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+            "$id": "entry-points.json",
+            "entryPoints": [
+                {
+                    "filePath": "agent",
+                    "uniqueId": "f620a11e-90fa-4506-8859-d8f147fdc31d",
+                    "type": "agent",
+                    "input": {"type": "object", "properties": {}},
+                    "output": {"type": "string"},
+                },
+                {
+                    "filePath": "function",
+                    "uniqueId": "0c34d779-78b1-4902-8657-a0ebf65d66af",
+                    "type": "function",
+                    "input": {"type": "object", "properties": {}},
+                    "output": {"type": "string"},
+                },
+            ],
+        }
+        eps = EntryPoints.model_validate(content)
+        assert len(eps.entrypoints) == 2
+        assert eps.entrypoints[0].type == "agent"
+        assert eps.entrypoints[1].type == "function"
+
+    def test_entrypoints_roundtrip(self) -> None:
+        content = {
+            "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+            "$id": "entry-points.json",
+            "entryPoints": [
+                {
+                    "filePath": "main",
+                    "uniqueId": "00000000-0000-0000-0000-000000000000",
+                    "type": "function",
+                    "input": {"type": "object", "properties": {}},
+                    "output": {"type": "string"},
+                },
+            ],
+        }
+        eps = EntryPoints.model_validate(content)
+        dumped = eps.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["$schema"] == content["$schema"]
+        assert dumped["$id"] == content["$id"]
+        assert len(dumped["entryPoints"]) == 1
+
+    def test_entrypoints_json_serialization(self) -> None:
+        content = {
+            "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+            "$id": "entry-points.json",
+            "entryPoints": [
+                {
+                    "filePath": "test",
+                    "uniqueId": "00000000-0000-0000-0000-000000000000",
+                    "type": "agent",
+                    "input": {"type": "object", "properties": {}},
+                    "output": {"type": "string"},
+                },
+            ],
+        }
+        eps = EntryPoints.model_validate(content)
+        json_str = eps.model_dump_json(by_alias=True, exclude_none=True)
+        parsed = json.loads(json_str)
+        assert parsed["entryPoints"][0]["type"] == "agent"

--- a/packages/uipath/tests/cli/test_determine_project_type.py
+++ b/packages/uipath/tests/cli/test_determine_project_type.py
@@ -1,0 +1,49 @@
+from uipath._cli._utils._common import determine_project_type
+from uipath._cli.models.runtime_schema import EntryPoint
+
+
+def _make_entrypoint(type: str) -> EntryPoint:
+    return EntryPoint(
+        file_path="test",
+        unique_id="00000000-0000-0000-0000-000000000000",
+        type=type,
+        input={"type": "object", "properties": {}},
+        output={"type": "string"},
+    )
+
+
+class TestDetermineProjectType:
+    def test_empty_entrypoints_returns_function(self) -> None:
+        assert determine_project_type([]) == "function"
+
+    def test_single_agent_entrypoint(self) -> None:
+        assert determine_project_type([_make_entrypoint("agent")]) == "agent"
+
+    def test_single_function_entrypoint(self) -> None:
+        assert determine_project_type([_make_entrypoint("function")]) == "function"
+
+    def test_multiple_same_type(self) -> None:
+        entrypoints = [_make_entrypoint("agent"), _make_entrypoint("agent")]
+        assert determine_project_type(entrypoints) == "agent"
+
+    def test_mixed_types_returns_first(self) -> None:
+        entrypoints = [_make_entrypoint("agent"), _make_entrypoint("function")]
+        assert determine_project_type(entrypoints) == "agent"
+
+    def test_mixed_types_returns_first_function(self) -> None:
+        entrypoints = [_make_entrypoint("function"), _make_entrypoint("agent")]
+        assert determine_project_type(entrypoints) == "function"
+
+    def test_mixed_types_logs_warning(self, capsys) -> None:
+        entrypoints = [_make_entrypoint("agent"), _make_entrypoint("function")]
+        determine_project_type(entrypoints)
+        captured = capsys.readouterr()
+        assert "Mixed entrypoint types detected: [agent, function]" in captured.out
+        assert '"agent"' in captured.out
+        assert "We recommend using a single type for all entrypoints" in captured.out
+
+    def test_same_types_no_warning(self, capsys) -> None:
+        entrypoints = [_make_entrypoint("agent"), _make_entrypoint("agent")]
+        determine_project_type(entrypoints)
+        captured = capsys.readouterr()
+        assert "Mixed entrypoint types detected" not in captured.out

--- a/packages/uipath/tests/cli/test_init.py
+++ b/packages/uipath/tests/cli/test_init.py
@@ -10,9 +10,18 @@ from uipath._cli.middlewares import MiddlewareResult
 
 
 class TestInit:
+    def _generate_pyproject(self, project_name: str | None = None):
+        with open("pyproject.toml", "w") as f:
+            f.write(
+                f'[project]\nname = "{project_name if project_name else "test-project"}"\nversion = "0.1.0"\n'
+                'description = "Test"\nauthors = [{name = "Test"}]\n'
+                'requires-python = ">=3.11"\n'
+            )
+
     def test_init_env_file_creation(self, runner: CliRunner, temp_dir: str) -> None:
         """Test .env file creation scenarios."""
         with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._generate_pyproject()
             # Test creation of new .env
             result = runner.invoke(cli, ["init"], env={})
             assert result.exit_code == 0
@@ -35,6 +44,7 @@ class TestInit:
     ) -> None:
         """Test that init creates an empty uipath.json with functions structure."""
         with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._generate_pyproject()
             result = runner.invoke(cli, ["init"], env={})
             assert result.exit_code == 0
             assert os.path.exists("uipath.json")
@@ -60,7 +70,7 @@ class TestInit:
             uipath_config = {"functions": {"main": "main.py:main"}}
             with open("uipath.json", "w") as f:
                 json.dump(uipath_config, f)
-
+            self._generate_pyproject()
             result = runner.invoke(cli, ["init"], env={})
             assert result.exit_code == 0
 
@@ -88,7 +98,7 @@ class TestInit:
                     error_message="Middleware error",
                     should_include_stacktrace=False,
                 )
-
+                self._generate_pyproject()
                 result = runner.invoke(cli, ["init"], env={})
                 assert result.exit_code == 1
                 assert "Middleware error" in result.output
@@ -120,7 +130,7 @@ class TestInit:
             # Mock middleware to allow execution
             with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
                 mock_middleware.return_value = MiddlewareResult(should_continue=True)
-
+                self._generate_pyproject()
                 result = runner.invoke(cli, ["init"], env={})
 
                 # The command should fail due to invalid syntax
@@ -156,6 +166,7 @@ def main(input: Input) -> Output:
             uipath_config = {"functions": {"main": "test.py:main"}}
             with open("uipath.json", "w") as f:
                 json.dump(uipath_config, f)
+            self._generate_pyproject()
 
             result = runner.invoke(cli, ["init"], env={})
             assert result.exit_code == 0
@@ -269,6 +280,7 @@ def main(input: Input) -> Output:
             uipath_config = {"functions": {"main": "comprehensive_types.py:main"}}
             with open("uipath.json", "w") as f:
                 json.dump(uipath_config, f)
+            self._generate_pyproject()
 
             # Run init command
             result = runner.invoke(cli, ["init"], env={})
@@ -347,6 +359,7 @@ def main(input: Input) -> Output:
             uipath_config = {"functions": {"main": "main.py:main"}}
             with open("uipath.json", "w") as f:
                 json.dump(uipath_config, f)
+            self._generate_pyproject()
 
             result = runner.invoke(cli, ["init"], env={})
             assert result.exit_code == 0
@@ -457,6 +470,8 @@ def main(input: InputModel) -> InputModel: return input""")
             with open("uipath.json", "w") as f:
                 json.dump(uipath_config, f)
 
+            self._generate_pyproject()
+
             result = runner.invoke(cli, ["init"], env={})
 
             assert result.exit_code == 0
@@ -470,3 +485,177 @@ def main(input: InputModel) -> InputModel: return input""")
 
             verify_attachment_schema(input_schema, verify_other_field)
             verify_attachment_schema(output_schema, verify_other_field)
+
+    def test_init_creates_uiproj_with_function_type(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init creates project.uiproj with correct function type."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("main.py", "w") as f:
+                f.write("def main(input: str) -> str: return input")
+
+            uipath_config = {"functions": {"main": "main.py:main"}}
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+
+            self._generate_pyproject("my-project")
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+            assert os.path.exists("project.uiproj")
+            assert "Created 'project.uiproj' file" in result.output
+
+            with open("project.uiproj", "r") as f:
+                uiproj = json.load(f)
+                assert uiproj["ProjectType"] == "Function"
+                assert uiproj["Name"] == "my-project"
+                assert uiproj["Description"] == "Test"
+                assert uiproj["MainFile"] is None
+
+    def test_init_creates_uiproj_with_agent_type(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init creates project.uiproj with agent type."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("main.py", "w") as f:
+                f.write("def main(input: str) -> str: return input")
+
+            uipath_config = {"agents": {"main": "main.py:main"}}
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+
+            self._generate_pyproject("my-agent")
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+            assert os.path.exists("project.uiproj")
+
+            with open("project.uiproj", "r") as f:
+                uiproj = json.load(f)
+                assert uiproj["ProjectType"] == "Agent"
+                assert uiproj["Name"] == "my-agent"
+
+    def test_init_creates_uiproj_default_function_when_no_entrypoints(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init creates project.uiproj with Function type when no entrypoints."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._generate_pyproject()
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+            assert os.path.exists("project.uiproj")
+
+            with open("project.uiproj", "r") as f:
+                uiproj = json.load(f)
+                assert uiproj["ProjectType"] == "Function"
+
+    def test_init_updates_uiproj_and_warns_on_type_change(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init warns when project type changes in existing uiproj."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("main.py", "w") as f:
+                f.write("def main(input: str) -> str: return input")
+
+            # Create existing uiproj with Agent type
+            with open("project.uiproj", "w") as f:
+                json.dump(
+                    {
+                        "ProjectType": "Agent",
+                        "Name": "my-project",
+                        "Description": None,
+                        "MainFile": None,
+                    },
+                    f,
+                )
+
+            # Configure as function
+            uipath_config = {"functions": {"main": "main.py:main"}}
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+
+            self._generate_pyproject()
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+            assert 'Project type changed from "Agent" to "Function"' in result.output
+            assert "Updated 'project.uiproj' file" in result.output
+
+            with open("project.uiproj", "r") as f:
+                uiproj = json.load(f)
+                assert uiproj["ProjectType"] == "Function"
+
+    def test_init_mixed_entrypoints_warns(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init warns when there are mixed entrypoint types."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("agent.py", "w") as f:
+                f.write("def agent_main(input: str) -> str: return input")
+
+            with open("func.py", "w") as f:
+                f.write("def func_main(input: str) -> str: return input")
+
+            uipath_config = {
+                "agents": {"my_agent": "agent.py:agent_main"},
+                "functions": {"my_func": "func.py:func_main"},
+            }
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+
+            with open("pyproject.toml", "w") as f:
+                f.write(
+                    '[project]\nname = "mixed-project"\nversion = "0.1.0"\n'
+                    'description = "Mixed"\nauthors = [{name = "Test"}]\n'
+                    'requires-python = ">=3.11"\n'
+                )
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+            assert "Mixed entrypoint types detected: [" in result.output
+            assert (
+                "We recommend using a single type for all entrypoints" in result.output
+            )
+
+    def test_init_creates_studio_metadata_file(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init creates .uipath/studio_metadata.json with correct content."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._generate_pyproject()
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+
+            metadata_path = os.path.join(".uipath", "studio_metadata.json")
+            assert os.path.exists(metadata_path)
+            assert "studio_metadata.json" in result.output
+
+            with open(metadata_path, "r") as f:
+                metadata = json.load(f)
+                assert "schemaVersion" in metadata
+                assert "codeVersion" in metadata
+                assert metadata["schemaVersion"] == 1
+                assert metadata["codeVersion"] == "1.0.0"
+
+    def test_init_does_not_overwrite_existing_studio_metadata(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Test that init does not overwrite existing studio_metadata.json."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._generate_pyproject()
+
+            # Create existing metadata with different values
+            os.makedirs(".uipath", exist_ok=True)
+            existing_metadata = {"schemaVersion": 99, "codeVersion": "5.0.0"}
+            with open(os.path.join(".uipath", "studio_metadata.json"), "w") as f:
+                json.dump(existing_metadata, f)
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+
+            with open(os.path.join(".uipath", "studio_metadata.json"), "r") as f:
+                metadata = json.load(f)
+                assert metadata["schemaVersion"] == 99
+                assert metadata["codeVersion"] == "5.0.0"

--- a/packages/uipath/tests/cli/test_init_agents_md.py
+++ b/packages/uipath/tests/cli/test_init_agents_md.py
@@ -172,6 +172,14 @@ class TestGenerateAgentMdFiles:
 class TestInitWithAgentsMd:
     """Test the init command with default AGENTS.md creation."""
 
+    def _generate_pyproject(self):
+        with open("pyproject.toml", "w") as f:
+            f.write(
+                '[project]\nname = "test-project"\nversion = "0.1.0"\n'
+                'description = "Test"\nauthors = [{name = "Test"}]\n'
+                'requires-python = ">=3.11"\n'
+            )
+
     def test_init_creates_agent_files_by_default(
         self, runner: CliRunner, temp_dir: str
     ) -> None:
@@ -196,6 +204,7 @@ class TestInitWithAgentsMd:
                 mock_as_file.return_value.__enter__.return_value = temp_source
                 mock_as_file.return_value.__exit__.return_value = None
 
+                self._generate_pyproject()
                 result = runner.invoke(cli, ["init"])
 
                 assert result.exit_code == 0
@@ -238,6 +247,7 @@ class TestInitWithAgentsMd:
                 mock_as_file.return_value.__enter__.return_value = temp_source
                 mock_as_file.return_value.__exit__.return_value = None
 
+                self._generate_pyproject()
                 # Run init (AGENTS.md creation is now default)
                 result = runner.invoke(cli, ["init"])
 

--- a/packages/uipath/tests/cli/test_pack.py
+++ b/packages/uipath/tests/cli/test_pack.py
@@ -20,6 +20,28 @@ def create_bindings_file():
         json.dump(bindings_content, f, indent=4)
 
 
+def create_entry_points_file(entrypoint_type: str = "function"):
+    """Helper to create a default entry-points.json file for tests."""
+    entry_points_content = {
+        "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+        "$id": "entry-points.json",
+        "entryPoints": [
+            {
+                "filePath": "main",
+                "uniqueId": "00000000-0000-0000-0000-000000000000",
+                "type": entrypoint_type,
+                "input": {
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                },
+                "output": {"type": "string"},
+            }
+        ],
+    }
+    with open("entry-points.json", "w") as f:
+        json.dump(entry_points_content, f, indent=4)
+
+
 def create_uipath_json(
     functions: dict[str, str] | None = None, pack_options: dict | None = None
 ):
@@ -82,12 +104,7 @@ class TestPack:
             with open("main.py", "w") as f:
                 f.write("def main(input): return input")
             create_bindings_file()
-
-            # Mock middleware and run init
-            with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
-                mock_middleware.return_value = MiddlewareResult(should_continue=True)
-                init_result = runner.invoke(cli, ["init"], env={})
-                assert init_result.exit_code == 0
+            create_entry_points_file()
 
             result = runner.invoke(cli, ["pack", "./"], env={})
             assert result.exit_code == 1
@@ -112,12 +129,7 @@ class TestPack:
             with open("main.py", "w") as f:
                 f.write("def main(input): return input")
             create_bindings_file()
-
-            # Mock middleware and run init
-            with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
-                mock_middleware.return_value = MiddlewareResult(should_continue=True)
-                init_result = runner.invoke(cli, ["init"], env={})
-                assert init_result.exit_code == 0
+            create_entry_points_file()
 
             result = runner.invoke(cli, ["pack", "./"], env={})
             assert result.exit_code == 1
@@ -141,12 +153,7 @@ class TestPack:
             with open("main.py", "w") as f:
                 f.write("def main(input): return input")
             create_bindings_file()
-
-            # Mock middleware and run init
-            with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
-                mock_middleware.return_value = MiddlewareResult(should_continue=True)
-                init_result = runner.invoke(cli, ["init"], env={})
-                assert init_result.exit_code == 0
+            create_entry_points_file()
 
             result = runner.invoke(cli, ["pack", "./"], env={})
             assert result.exit_code == 1
@@ -170,12 +177,7 @@ class TestPack:
             with open("main.py", "w") as f:
                 f.write("def main(input): return input")
             create_bindings_file()
-
-            # Mock middleware and run init
-            with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
-                mock_middleware.return_value = MiddlewareResult(should_continue=True)
-                init_result = runner.invoke(cli, ["init"], env={})
-                assert init_result.exit_code == 0
+            create_entry_points_file()
 
             result = runner.invoke(cli, ["pack", "./"], env={})
             assert result.exit_code == 1
@@ -1079,30 +1081,31 @@ class TestPack:
 
     def test_generate_operate_file(self, runner: CliRunner, temp_dir: str) -> None:
         """Test generating operate.json from entry-points."""
+        from uipath._cli.models.runtime_schema import EntryPoint
+
         with runner.isolated_filesystem(temp_dir=temp_dir):
             create_bindings_file()
 
-            # Create entry-points structure (from entry-points.json)
-            entry_points = [
-                {
-                    "filePath": "agent1.py",
-                    "uniqueId": "agent1-id",
-                    "type": "agent",
-                    "input": {"type": "object", "properties": {}},
-                    "output": {"type": "object", "properties": {}},
-                }
+            entrypoints = [
+                EntryPoint(
+                    filePath="agent1.py",
+                    uniqueId="agent1-id",
+                    type="agent",
+                    input={"type": "object", "properties": {}},
+                    output={"type": "object", "properties": {}},
+                )
             ]
 
             operate_data = cli_pack.generate_operate_file(
-                entry_points, RuntimeOptions(is_conversational=False)
+                entrypoints, RuntimeOptions(is_conversational=False)
             )
 
             assert (
                 operate_data["$schema"]
                 == "https://cloud.uipath.com/draft/2024-12/entry-point"
             )
-            assert operate_data["main"] == entry_points[0]["filePath"]
-            assert operate_data["contentType"] == entry_points[0]["type"]
+            assert operate_data["main"] == "agent1.py"
+            assert operate_data["contentType"] == "agent"
             assert operate_data["targetFramework"] == "Portable"
             assert operate_data["targetRuntime"] == "python"
             assert operate_data["runtimeOptions"] == {
@@ -1120,66 +1123,72 @@ class TestPack:
 
     def test_generate_entrypoints_file(self, runner: CliRunner, temp_dir: str) -> None:
         """Test generating entry-points.json from entry-points structure."""
-        entry_points = [
-            {
-                "filePath": "agent1.py",
-                "uniqueId": "agent1-id",
-                "type": "agent",
-                "input": {"type": "object", "properties": {}},
-                "output": {"type": "object", "properties": {}},
-            },
-            {
-                "filePath": "agent2.py",
-                "uniqueId": "agent2-id",
-                "type": "agent",
-                "input": {"type": "object", "properties": {}},
-                "output": {"type": "object", "properties": {}},
-            },
+        from uipath._cli.models.runtime_schema import EntryPoint
+
+        entrypoints = [
+            EntryPoint(
+                filePath="agent1.py",
+                uniqueId="agent1-id",
+                type="agent",
+                input={"type": "object", "properties": {}},
+                output={"type": "object", "properties": {}},
+            ),
+            EntryPoint(
+                filePath="agent2.py",
+                uniqueId="agent2-id",
+                type="agent",
+                input={"type": "object", "properties": {}},
+                output={"type": "object", "properties": {}},
+            ),
         ]
 
-        entrypoints_data = cli_pack.generate_entrypoints_file(entry_points)
+        entrypoints_data = cli_pack.generate_entrypoints_file(entrypoints)
 
         assert (
             entrypoints_data["$schema"]
             == "https://cloud.uipath.com/draft/2024-12/entry-point"
         )
         assert entrypoints_data["$id"] == "entry-points.json"
-        assert entrypoints_data["entryPoints"] == entry_points
+        assert len(entrypoints_data["entryPoints"]) == 2
+        assert entrypoints_data["entryPoints"][0]["filePath"] == "agent1.py"
+        assert entrypoints_data["entryPoints"][1]["filePath"] == "agent2.py"
 
     def test_package_descriptor_content(self, runner: CliRunner, temp_dir: str) -> None:
         """Test generating package-descriptor.json content."""
-        entry_points = [
-            {
-                "filePath": "agent1.py",
-                "uniqueId": "agent1-id",
-                "type": "agent",
-                "input": {"type": "object", "properties": {}},
-                "output": {"type": "object", "properties": {}},
-            },
-            {
-                "filePath": "agent2.py",
-                "uniqueId": "agent2-id",
-                "type": "agent",
-                "input": {"type": "object", "properties": {}},
-                "output": {"type": "object", "properties": {}},
-            },
+        from uipath._cli.models.runtime_schema import EntryPoint
+
+        entrypoints = [
+            EntryPoint(
+                filePath="agent1.py",
+                uniqueId="agent1-id",
+                type="agent",
+                input={"type": "object", "properties": {}},
+                output={"type": "object", "properties": {}},
+            ),
+            EntryPoint(
+                filePath="agent2.py",
+                uniqueId="agent2-id",
+                type="agent",
+                input={"type": "object", "properties": {}},
+                output={"type": "object", "properties": {}},
+            ),
         ]
 
         expected_files = {
             "operate.json": "content/operate.json",
             "entry-points.json": "content/entry-points.json",
             "bindings.json": "content/bindings_v2.json",
+            "agent1.py": "agent1.py",
+            "agent2.py": "agent2.py",
         }
-        for entry in entry_points:
-            expected_files[entry["filePath"]] = entry["filePath"]
 
-        content = cli_pack.generate_package_descriptor_content(entry_points)
+        content = cli_pack.generate_package_descriptor_content(entrypoints)
 
         assert (
             content["$schema"]
             == "https://cloud.uipath.com/draft/2024-12/package-descriptor"
         )
-        assert len(content["files"]) == 3 + len(entry_points)
+        assert len(content["files"]) == 5
         assert content["files"] == expected_files
 
     def test_is_conversational_in_operate_json(
@@ -1248,3 +1257,38 @@ class TestPack:
                     operate_data["runtimeOptions"]["requiresUserInteraction"] is False
                 )
                 assert operate_data["runtimeOptions"]["isAttended"] is False
+
+    def test_pack_warns_mixed_entrypoint_types(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+    ) -> None:
+        """Test that pack warns when there are mixed entrypoint types."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("agent.py", "w") as f:
+                f.write("def agent_main(input: str) -> str: return input")
+            with open("func.py", "w") as f:
+                f.write("def func_main(input: str) -> str: return input")
+
+            uipath_config = {
+                "agents": {"my_agent": "agent.py:agent_main"},
+                "functions": {"my_func": "func.py:func_main"},
+            }
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+            with open("pyproject.toml", "w") as f:
+                f.write(project_details.to_toml())
+            create_bindings_file()
+
+            with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
+                mock_middleware.return_value = MiddlewareResult(should_continue=True)
+                init_result = runner.invoke(cli, ["init"], env={})
+                assert init_result.exit_code == 0
+
+            result = runner.invoke(cli, ["pack", "./"], env={})
+            assert result.exit_code == 0
+            assert "Mixed entrypoint types detected: [" in result.output
+            assert (
+                "We recommend using a single type for all entrypoints" in result.output
+            )

--- a/packages/uipath/tests/cli/test_push.py
+++ b/packages/uipath/tests/cli/test_push.py
@@ -494,8 +494,125 @@ class TestPush:
                 f"Unexpected codeVersion. Expected: {expected_code_version}, Got: {actual_code_version}"
             )
 
-    # Continue with remaining test methods - they all follow the same pattern
-    # I'll include abbreviated versions for brevity since the pattern is the same
+    def test_first_push_with_minimal_studio_metadata_from_init(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        mock_env_vars: dict[str, str],
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test first push when studio_metadata.json was created by init (minimal fields).
+
+        When `uipath init` creates studio_metadata.json it only includes
+        schemaVersion and codeVersion. The push command must backfill
+        lastPushAuthor and lastPushDate before uploading.
+        """
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        # Remote has no studio_metadata.json (first push)
+        mock_structure = {
+            "id": "root",
+            "name": "root",
+            "folders": [],
+            "files": [
+                {
+                    "id": "123",
+                    "name": "pyproject.toml",
+                    "isMain": False,
+                    "fileType": "1",
+                    "isEntryPoint": False,
+                    "ignoredFromPublish": False,
+                },
+            ],
+            "folderType": "0",
+        }
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        self._mock_lock_retrieval(httpx_mock, base_url, project_id, times=1)
+        self._mock_file_download(httpx_mock, "123")
+
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/StructuralMigration",
+            status_code=200,
+            json={"success": True},
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._create_required_files(exclude=["entry-points.json"])
+
+            with open("entry-points.json", "w") as f:
+                json.dump(
+                    {
+                        "entryPoints": [
+                            {
+                                "filePath": "main.py",
+                                "uniqueId": "main-id",
+                                "type": "agent",
+                                "input": {"type": "object", "properties": {}},
+                                "output": {"type": "object", "properties": {}},
+                            }
+                        ]
+                    },
+                    f,
+                )
+
+            with open("pyproject.toml", "w") as f:
+                f.write(project_details.to_toml())
+
+            with open("main.py", "w") as f:
+                f.write("print('Hello World')")
+
+            with open("uv.lock", "w") as f:
+                f.write('version = 1 \n requires-python = ">=3.11"')
+
+            # Create minimal studio_metadata.json as init would
+            os.mkdir(".uipath")
+            with open(os.path.join(".uipath", "studio_metadata.json"), "w") as f:
+                json.dump(
+                    {
+                        "schemaVersion": 1,
+                        "codeVersion": "1.0.0",
+                    },
+                    f,
+                )
+
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            result = runner.invoke(cli, ["push", "./", "--ignore-resources"])
+            assert result.exit_code == 0
+            assert "Uploading '.uipath/studio_metadata.json'" in result.output
+
+            structural_migration_request = httpx_mock.get_request(
+                method="POST",
+                url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/StructuralMigration",
+            )
+            assert structural_migration_request is not None
+            metadata_json_content = extract_metadata_json_from_added_resources(
+                structural_migration_request
+            )
+
+            # Must have backfilled the push-related fields
+            assert metadata_json_content["codeVersion"] == "1.0.0"
+            assert metadata_json_content["schemaVersion"] == 1
+            assert "lastPushAuthor" in metadata_json_content, (
+                "lastPushAuthor should be backfilled on first push"
+            )
+            assert "lastPushDate" in metadata_json_content, (
+                "lastPushDate should be backfilled on first push"
+            )
 
     def test_push_with_api_error(
         self,

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2540,7 +2540,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.18"
+version = "2.10.19"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2679,7 +2679,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.27"
+version = "0.0.28"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
  Generate `project.uiproj` on init

  ## Changes

  - add `EntryPoint` and `EntryPoints` models to `runtime_schema.py` for typed entrypoint handling
  - add `determine_project_type` -> returns the first entrypoint's type (defaults to "function" when empty), warns when mixed types are detected
  - add `write_uiproj_file`  -> generates project.uiproj in the project root on init with ProjectType, Name, Description, and MainFile fields. Warns when project type changes on subsequent inits
  - wire `determine_project_type` into pack to warn on mixed entrypoint types
  - add `UIPROJ_FILE` constant and `uiproj_file_path` config property in uipath-platform
  - generate `studio_metadata.json` file on init for SW local workspace detection


## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.19.dev1014505432",

  # Any version from PR
  "uipath>=2.10.19.dev1014500000,<2.10.19.dev1014510000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-platform==0.0.28.dev1014505432",

  # Any version from PR
  "uipath-platform>=0.0.28.dev1014500000,<0.0.28.dev1014510000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```