### PR TITLE
feat: add Platform and SwaggerMcp server types to McpServerType enum

### DIFF
--- a/packages/uipath-platform/src/uipath/platform/orchestrator/mcp.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/mcp.py
@@ -17,6 +17,8 @@ class McpServerType(IntEnum):
     SelfHosted = 3  # tunnel to (externally) self-hosted server
     Remote = 4  # HTTP connection to remote MCP server
     ProcessAssistant = 5  # Dynamic user process assistant
+    Platform = 6  # Platform-provided MCP service
+    SwaggerMcp = 7  # OpenAPI/Swagger-backed MCP server
 
 
 class McpServerStatus(IntEnum):


### PR DESCRIPTION
## Summary
- Add `Platform = 6` and `SwaggerMcp = 7` to `McpServerType` enum in `uipath-platform`
- The AgentHub backend supports these server types but the SDK doesn't recognize them, causing a Pydantic validation error when retrieving swagger-mcp servers:
  ```
  Input should be 0, 1, 2, 3, 4 or 5 [type=enum, input_value=7, input_type=int]
  ```

## Test plan
- [ ] Verify `McpServer.model_validate({"type": 7, ...})` no longer raises a validation error
- [ ] Verify existing server types (0-5) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Development Packages

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-platform==0.1.4.dev1014565519",

  # Any version from PR
  "uipath-platform>=0.1.4.dev1014560000,<0.1.4.dev1014570000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.26.dev1014565519",

  # Any version from PR
  "uipath>=2.10.26.dev1014560000,<2.10.26.dev1014570000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```