### PR TITLE
fix: create trigger sends empty strings instead of None

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.0"
+version = "0.1.1"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/resume_triggers/_protocol.py
+++ b/packages/uipath-platform/src/uipath/platform/resume_triggers/_protocol.py
@@ -595,8 +595,8 @@ class UiPathResumeTriggerCreator:
             action = await uipath.tasks.create_async(
                 title=value.title,
                 app_name=value.app_name if value.app_name else "",
-                app_folder_path=value.app_folder_path if value.app_folder_path else "",
-                app_folder_key=value.app_folder_key if value.app_folder_key else "",
+                app_folder_path=value.app_folder_path or None,
+                app_folder_key=value.app_folder_key or None,
                 app_key=value.app_key if value.app_key else "",
                 assignee=value.assignee if value.assignee else "",
                 recipient=value.recipient if value.recipient else "",

--- a/packages/uipath-platform/tests/services/test_hitl.py
+++ b/packages/uipath-platform/tests/services/test_hitl.py
@@ -1126,7 +1126,7 @@ class TestHitlProcessor:
                 title=create_action.title,
                 app_name=create_action.app_name,
                 app_folder_path=create_action.app_folder_path,
-                app_folder_key="",
+                app_folder_key=None,
                 app_key="",
                 assignee="",
                 recipient="",

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.10.21"
+version = "2.10.22"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.2, <0.6.0",
   "uipath-runtime>=0.9.1, <0.10.0",
-  "uipath-platform>=0.1.0, <0.2.0",
+  "uipath-platform>=0.1.1, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2540,7 +2540,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.21"
+version = "2.10.22"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2679,7 +2679,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Since folder headers method does not allow both folder path and folder key to be sent simultaneously, needed to update the code to send None instead of "".