### PR TITLE
Add missing return type annotations to evaluator methods

### DIFF
--- a/packages/uipath/src/uipath/eval/evaluators/legacy_context_precision_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_context_precision_evaluator.py
@@ -104,11 +104,11 @@ class LegacyContextPrecisionEvaluator(
     chunks_placeholder: str = "{{Chunks}}"
     llm: Optional[UiPathLlmChatService] = None
 
-    def model_post_init(self, __context: Any):
+    def model_post_init(self, __context: Any) -> None:
         """Initialize the evaluator after model creation."""
         super().model_post_init(__context)
 
-    def _initialize_llm(self):
+    def _initialize_llm(self) -> None:
         """Initialize the LLM used for evaluation."""
         uipath = UiPath()
         self.llm = UiPathLlmChatService(


### PR DESCRIPTION
## Summary
- Added missing `-> None` return type annotations to two methods in `legacy_context_precision_evaluator.py`:
  - `model_post_init()` 
  - `_initialize_llm()`
- Improves type safety and consistency with the rest of the codebase

## Test plan
- [ ] Run mypy/pyright to confirm no type errors introduced
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)