### PR TITLE
fix: case-insensitive deserialization of variant field in context resource settings

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.10.28"
+version = "2.10.29"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.2, <0.6.0",
   "uipath-runtime>=0.9.1, <0.10.0",
-  "uipath-platform>=0.1.8, <0.2.0",
+  "uipath-platform>=0.1.4, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -325,7 +325,7 @@ class AgentContextQuerySetting(BaseCfg):
 
     value: str | None = Field(default=None)
     description: str | None = Field(default=None)
-    variant: str | None = Field(default=None)
+    variant: AgentToolArgumentPropertiesVariant | None = Field(default=None)
 
 
 class AgentContextValueSetting(BaseCfg):
@@ -373,7 +373,9 @@ class AgentContextSettings(BaseCfg):
     retrieval_mode: AgentContextRetrievalMode = Field(alias="retrievalMode")
     threshold: float = Field(default=0)
     query: AgentContextQuerySetting = Field(
-        default_factory=lambda: AgentContextQuerySetting(variant="dynamic")
+        default_factory=lambda: AgentContextQuerySetting(
+            variant=AgentToolArgumentPropertiesVariant.DYNAMIC
+        )
     )
     folder_path_prefix: Optional[AgentContextQuerySetting] = Field(
         None, alias="folderPathPrefix"

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -1647,6 +1647,63 @@ class TestAgentBuilderConfig:
             == AgentContextRetrievalMode.UNKNOWN
         )
 
+    def test_context_settings_variant_case_insensitive(self):
+        """Test that context query setting variant handles different casings."""
+
+        json_data = {
+            "id": "test-variant-case",
+            "name": "Agent with mixed-case variants",
+            "version": "1.0.0",
+            "settings": {
+                "model": "gpt-4o-2024-11-20",
+                "maxTokens": 16384,
+                "temperature": 0,
+                "engine": "basic-v1",
+            },
+            "inputSchema": {"type": "object", "properties": {}},
+            "outputSchema": {"type": "object", "properties": {}},
+            "resources": [
+                {
+                    "$resourceType": "context",
+                    "folderPath": "TestFolder",
+                    "indexName": "Test Index",
+                    "settings": {
+                        "threshold": 0.5,
+                        "resultCount": 5,
+                        "retrievalMode": "semantic",
+                        "query": {
+                            "value": "{{searchQuery}}",
+                            "variant": "Argument",
+                        },
+                        "folderPathPrefix": {
+                            "variant": "Static",
+                            "value": "/docs",
+                        },
+                    },
+                    "name": "Test Context",
+                    "description": "Context with mixed-case variants",
+                }
+            ],
+            "messages": [{"role": "system", "content": "Test system message"}],
+        }
+
+        config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
+            json_data
+        )
+
+        context_resource = config.resources[0]
+        assert isinstance(context_resource, AgentContextResourceConfig)
+        assert context_resource.settings is not None
+        assert (
+            context_resource.settings.query.variant
+            == AgentToolArgumentPropertiesVariant.ARGUMENT
+        )
+        assert context_resource.settings.folder_path_prefix is not None
+        assert (
+            context_resource.settings.folder_path_prefix.variant
+            == AgentToolArgumentPropertiesVariant.STATIC
+        )
+
     def test_agent_with_unknown_resource_type(self):
         """Test that AgentDefinition handles unknown resource types gracefully"""
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.28"
+version = "2.10.29"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
 Different packagers produce resource setting JSON with different casing for the variant field — e.g., "argument" vs "Argument", "static" vs "Static". The AgentContextQuerySetting.variant field is currently typed as str | None, which stores the raw string as-is. Downstream code compares it against AgentToolArgumentPropertiesVariant enum values (lowercase), causing mismatches when the JSON uses capitalized variants.

The AgentToolArgumentPropertiesVariant enum already extends CaseInsensitiveEnum which handles case-insensitive matching via _missing_().
