### PR TITLE
feat: add Property binding resource support to SDK

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -109,7 +109,11 @@ jobs:
 
           Write-Output "Package $PROJECT_NAME version set to $DEV_VERSION"
 
+          $startMarker = "<!-- DEV_PACKAGE_START:$PROJECT_NAME -->"
+          $endMarker = "<!-- DEV_PACKAGE_END:$PROJECT_NAME -->"
+
           $dependencyMessage = @"
+          $startMarker
           ### $PROJECT_NAME
 
           ``````toml
@@ -130,7 +134,13 @@ jobs:
 
           [tool.uv.sources]
           $PROJECT_NAME = { index = "testpypi" }
+
+          [tool.uv]
+          override-dependencies = [
+              "$PROJECT_NAME>=$MIN_VERSION,<$MAX_VERSION",
+          ]
           ``````
+          $endMarker
           "@
 
           # Get the owner and repo from the GitHub repository
@@ -148,35 +158,27 @@ jobs:
           $pr = Invoke-RestMethod -Uri $prUri -Method Get -Headers $headers
           $currentBody = $pr.body
 
-          # Define regex patterns for matching package sections
           $devPackagesHeader = "## Development Packages"
-          $packageHeaderPattern = "### $PROJECT_NAME\s*\n"
+          $markerPattern = "(?s)$([regex]::Escape($startMarker)).*?$([regex]::Escape($endMarker))"
 
-          # Find if the package section exists using multiline regex
-          $packageSectionRegex = "(?ms)### $PROJECT_NAME\s*\n``````toml.*?``````"
-
-          if ($currentBody -match $devPackagesHeader) {
-            # Development Packages section exists
-            if ($currentBody -match $packageSectionRegex) {
-              # Replace existing package section
-              Write-Output "Updating existing $PROJECT_NAME section"
-              $newBody = $currentBody -replace $packageSectionRegex, $dependencyMessage.Trim()
+          function Get-UpdatedBody($body, $message) {
+            if ($body -match $markerPattern) {
+              return $body -replace $markerPattern, $message.Trim()
+            } elseif ($body -match $devPackagesHeader) {
+              $insertPoint = $body.IndexOf($devPackagesHeader) + $devPackagesHeader.Length
+              return $body.Insert($insertPoint, "`n`n$($message.Trim())")
             } else {
-              # Append new package section after the Development Packages header
-              Write-Output "Adding new $PROJECT_NAME section"
-              $insertPoint = $currentBody.IndexOf($devPackagesHeader) + $devPackagesHeader.Length
-              $newBody = $currentBody.Insert($insertPoint, "`n`n$dependencyMessage")
+              $section = "$devPackagesHeader`n`n$($message.Trim())"
+              if ($body) {
+                $result = "$body`n`n$section"
+              } else {
+                $result = $section
+              }
+              return $result
             }
-          } else {
-            # Create the Development Packages section
-            Write-Output "Creating Development Packages section with $PROJECT_NAME"
-            $packageSection = @"
-          ## Development Packages
-
-          $dependencyMessage
-          "@
-            $newBody = if ($currentBody) { "$currentBody`n`n$packageSection" } else { $packageSection }
           }
+
+          $newBody = Get-UpdatedBody $currentBody $dependencyMessage
 
           # Update the PR description with retry logic
           $maxRetries = 3
@@ -200,17 +202,7 @@ jobs:
                 # Re-fetch PR body in case another job updated it
                 $pr = Invoke-RestMethod -Uri $prUri -Method Get -Headers $headers
                 $currentBody = $pr.body
-
-                # Recompute newBody with fresh data
-                if ($currentBody -match $packageSectionRegex) {
-                  $newBody = $currentBody -replace $packageSectionRegex, $dependencyMessage.Trim()
-                } elseif ($currentBody -match $devPackagesHeader) {
-                  $insertPoint = $currentBody.IndexOf($devPackagesHeader) + $devPackagesHeader.Length
-                  $newBody = $currentBody.Insert($insertPoint, "`n`n$dependencyMessage")
-                } else {
-                  $packageSection = "$devPackagesHeader`n`n$dependencyMessage"
-                  $newBody = if ($currentBody) { "$currentBody`n`n$packageSection" } else { $packageSection }
-                }
+                $newBody = Get-UpdatedBody $currentBody $dependencyMessage
               } else {
                 Write-Output "Failed to update PR description after $maxRetries attempts"
                 throw

--- a/packages/uipath-platform/src/uipath/platform/_uipath.py
+++ b/packages/uipath-platform/src/uipath/platform/_uipath.py
@@ -11,6 +11,7 @@ from .agenthub._remote_a2a_service import RemoteA2aService
 from .chat import ConversationsService, UiPathLlmChatService, UiPathOpenAIService
 from .common import (
     ApiClient,
+    BindingsService,
     ExternalApplicationService,
     UiPathApiConfig,
     UiPathExecutionContext,
@@ -75,6 +76,10 @@ class UiPath:
                 elif error["loc"][0] == "secret":
                     raise SecretMissingError() from e
         self._execution_context = UiPathExecutionContext()
+
+    @cached_property
+    def bindings(self) -> BindingsService:
+        return BindingsService()
 
     @property
     def api_client(self) -> ApiClient:

--- a/packages/uipath-platform/src/uipath/platform/common/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/common/__init__.py
@@ -13,6 +13,7 @@ from ._bindings import (
     ResourceOverwritesContext,
     resource_override,
 )
+from ._bindings_service import BindingsService
 from ._config import UiPathApiConfig, UiPathConfig
 from ._endpoints_manager import EndpointManager
 from ._execution_context import UiPathExecutionContext
@@ -99,6 +100,7 @@ __all__ = [
     "validate_pagination_params",
     "EndpointManager",
     "jsonschema_to_pydantic",
+    "BindingsService",
     "ConnectionResourceOverwrite",
     "GenericResourceOverwrite",
     "ResourceOverwrite",

--- a/packages/uipath-platform/src/uipath/platform/common/_bindings.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_bindings.py
@@ -42,11 +42,22 @@ class ResourceOverwrite(BaseModel, ABC):
         """The folder location identifier for this resource."""
         pass
 
+    @property
+    @abstractmethod
+    def properties(self) -> dict[str, Any]:
+        """A dictionary of properties provided by this overwrite."""
+        pass
+
 
 class GenericResourceOverwrite(ResourceOverwrite):
-    resource_type: Literal["process", "index", "app", "asset", "bucket", "mcpServer"]
-    name: str = Field(alias="name")
-    folder_path: str = Field(alias="folderPath")
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    resource_type: Literal["process", "index", "app", "asset", "bucket", "mcpserver", "property", "mcpServer"]
+    name: str = Field(default="", alias="name")
+    folder_path: str = Field(default="", alias="folderPath")
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        return self.model_extra or {}
 
     @property
     def resource_identifier(self) -> str:
@@ -70,6 +81,10 @@ class ConnectionResourceOverwrite(ResourceOverwrite):
         populate_by_name=True,
         extra="ignore",
     )
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, exclude={"resource_type"})
 
     @property
     def resource_identifier(self) -> str:
@@ -109,7 +124,7 @@ class ResourceOverwriteParser:
         Returns:
             The appropriate ResourceOverwrite subclass instance
         """
-        resource_type = key.split(".")[0]
+        resource_type = key.split(".")[0].lower()
         value_with_type = {"resource_type": resource_type, **value}
         return cls._adapter.validate_python(value_with_type)
 
@@ -138,6 +153,9 @@ class ResourceOverwritesContext:
                 len(existing),
             )
         overwrites = await self.get_overwrites_callable()
+
+        logger.debug("ResourceOverwritesContext loading overwrites: %s", overwrites)
+
         self._token = _resource_overwrites.set(overwrites)
         self.overwrites_count = len(overwrites)
         if overwrites:

--- a/packages/uipath-platform/src/uipath/platform/common/_bindings_service.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_bindings_service.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from functools import cached_property
+from pathlib import Path
+from typing import Any, overload
+
+from ._bindings import ResourceOverwrite, _resource_overwrites
+from ._config import UiPathConfig
+
+logger = logging.getLogger(__name__)
+
+
+class BindingsService:
+    """Service for reading bindings configurations from bindings.json.
+
+    Provides access to properties configured at design time and resolved at runtime.
+    """
+
+    def __init__(self, bindings_file_path: Path | None = None) -> None:
+        self._bindings_file_path = bindings_file_path or UiPathConfig.bindings_file_path
+
+    @cached_property
+    def _load_bindings(self) -> list[dict[str, Any]]:
+        try:
+            with open(self._bindings_file_path, "r") as f:
+                data = json.load(f)
+            return data.get("resources", [])
+        except FileNotFoundError:
+            logger.debug("Bindings file not found: %s", self._bindings_file_path)
+            return []
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(
+                "Failed to load bindings file %s: %s", self._bindings_file_path, e
+            )
+            return []
+
+    def _find_resource(self, key: str) -> dict[str, Any] | None:
+        """Find a binding resource by exact or suffix key match."""
+        resources = self._load_bindings
+        for resource in resources:
+            resource_key = resource.get("key", "")
+            if (
+                resource_key == key
+                or resource_key.endswith(f".{key}")
+                or resource_key.endswith(key)
+            ):
+                return resource
+        return None
+
+    def _get_overwrite(self, key: str) -> ResourceOverwrite | None:
+        """Check context var for a runtime overwrite for the given key.
+
+        Supports exact key match and suffix match so that
+        a short label like ``"SharePoint Invoices folder"`` resolves against a
+        fully-qualified stored key like
+        ``"property.sharepoint-connection.SharePoint Invoices folder"``.
+        """
+        context_overwrites = _resource_overwrites.get()
+        if context_overwrites is None:
+            return None
+        for stored_key, overwrite in context_overwrites.items():
+            # Remove the `<resource_type>.` prefix correctly
+            parts = stored_key.split(".", 1)
+            bare_key = parts[1] if len(parts) > 1 else stored_key
+
+            if bare_key == key or bare_key.endswith(f".{key}") or stored_key == key:
+                return overwrite
+        return None
+
+    @overload
+    def get_property(self, key: str) -> dict[str, str]: ...
+
+    @overload
+    def get_property(self, key: str, sub_property: str) -> str: ...
+
+    def get_property(
+        self, key: str, sub_property: str | None = None
+    ) -> str | dict[str, str]:
+        """Get the value(s) of a binding resource.
+
+        Args:
+            key: The binding key, e.g. ``"sharepoint-connection.SharePoint Invoices folder"`` or ``"asset.my-asset"``.
+            Accepts the full key or a suffix that uniquely identifies the binding.
+            sub_property: The name of a specific sub-property to retrieve (e.g. ``"ID"`` or ``"folderPath"``).
+            If omitted, returns all sub-properties as a ``{name: value}`` dict.        Returns:
+            The ``defaultValue`` of the requested sub-property when ``sub_property`` is
+            given, or a dict of all sub-property names mapped to their ``defaultValue``
+            when ``sub_property`` is omitted.
+
+        Raises:
+            KeyError: When the binding key is not found, or when ``sub_property`` is given
+                but does not exist on the binding.
+        """
+        # Check for runtime overwrite first
+        overwrite = self._get_overwrite(key)
+        if overwrite is not None:
+            if sub_property is not None:
+                if sub_property not in overwrite.properties:
+                    raise KeyError(
+                        f"Sub-property '{sub_property}' not found in binding '{key}'. "
+                        f"Available: {list(overwrite.properties.keys())}"
+                    )
+                return overwrite.properties[sub_property]
+            return dict(overwrite.properties)
+
+        # Fall back to bindings.json
+        resource = self._find_resource(key)
+        if resource is None:
+            raise KeyError(
+                f"Binding '{key}' not found in {self._bindings_file_path}."
+            )
+
+        value: dict = resource.get("value", {})
+        all_values = {
+            name: props.get("defaultValue", "") if isinstance(props, dict) else str(props)
+            for name, props in value.items()
+        }
+
+        if sub_property is not None:
+            if sub_property not in all_values:
+                raise KeyError(
+                    f"Sub-property '{sub_property}' not found in binding '{key}'. "
+                    f"Available: {list(all_values.keys())}"
+                )
+            return all_values[sub_property]
+
+        return all_values

--- a/packages/uipath/specs/bindings.spec.md
+++ b/packages/uipath/specs/bindings.spec.md
@@ -43,6 +43,7 @@ The configuration supports multiple resource types:
 4. **index** - Search indexes
 5. **apps** - Action center apps
 6. **connection** - External connections
+7. **Property** - Connector-defined resource properties (e.g. SharePoint folder IDs selected at design time)
 
 
 ---
@@ -53,7 +54,7 @@ Each resource in the `resources` array has the following structure:
 
 ```json
 {
-  "resource": "asset|process|bucket|index|connection",
+  "resource": "asset|process|bucket|index|connection|Property",
   "key": "unique_key",
   "value": { ... },
   "metadata": { ... }
@@ -64,7 +65,7 @@ Each resource in the `resources` array has the following structure:
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `resource` | `string` | Yes | Resource type (one of the five types) |
+| `resource` | `string` | Yes | Resource type (one of the seven types) |
 | `key` | `string` | Yes | Unique identifier for this resource |
 | `value` | `object` | Yes | Resource-specific configuration |
 | `metadata` | `object` | No | Additional metadata for the binding |
@@ -303,6 +304,101 @@ Connections define external system integrations.
 
 ---
 
+### 7. Property
+
+Property bindings represent connector-defined resources that a user browses and selects at design time (e.g. a SharePoint folder, an OneDrive file). They are child resources of a parent Connection binding and contain **arbitrary sub-properties** with resolved values.
+
+**Key Format:** `<parent-connection-uuid>.<label>`
+
+**Example:**
+
+```json
+{
+  "resource": "Property",
+  "key": "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder",
+  "value": {
+    "FullName": {
+      "defaultValue": "Invoices",
+      "isExpression": false,
+      "displayName": "File or folder",
+      "description": "Select a file or folder",
+      "propertyName": "BrowserItemFriendlyName"
+    },
+    "ID": {
+      "defaultValue": "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M",
+      "isExpression": false,
+      "displayName": "File or folder",
+      "description": "The file or folder of interest",
+      "propertyName": "BrowserItemId"
+    },
+    "ParentDriveID": {
+      "defaultValue": "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt",
+      "isExpression": false,
+      "displayName": "Drive",
+      "description": "The drive (OneDrive/SharePoint) of file or folder",
+      "propertyName": "BrowserDriveId"
+    }
+  },
+  "metadata": {
+    "ActivityName": "SharePoint Invoices folder",
+    "BindingsVersion": "2.1",
+    "ObjectName": "CuratedFile",
+    "DisplayLabel": "FullName",
+    "ParentResourceKey": "Connection.775694d9-4c5b-430f-bf47-6079b0ce8623"
+  }
+}
+```
+
+**Property-Specific Metadata:**
+- `ParentResourceKey`: The key of the parent Connection resource (`"Connection.<uuid>"`)
+- `ObjectName`: The connector-defined object type (e.g. `"CuratedFile"`)
+- `DisplayLabel`: The sub-property used as the primary display value
+
+---
+
+## Using Bindings at Runtime
+
+The `BindingsService` allows users to dynamically query resources configured at design time (and overwritten at runtime) directly from `bindings.json`. You can access any binding resource type (Properties, assets, queues, etc.) by passing its key.
+
+**Querying Connector `Property` Bindings:**
+```python
+from uipath import UiPath
+sdk = UiPath()
+
+# Get a single sub-property value
+folder_id = sdk.bindings.get_property(
+    "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder", 
+    "ID"
+) # → "017NI543..."
+
+# You can also use just a suffix of the key:
+folder_id = sdk.bindings.get_property("SharePoint Invoices folder", "ID")
+
+# Get all sub-properties as a dict
+props = sdk.bindings.get_property("SharePoint Invoices folder")
+# → {"FullName": "Invoices", "ID": "017NI543...", "ParentDriveID": "b!fFiPz..."}
+```
+
+**Querying Standard Bindings (Assets, Buckets, etc.):**
+```python
+from uipath import UiPath
+sdk = UiPath()
+
+# For a specific sub-property
+asset_folder_path = sdk.bindings.get_property("DatabaseConnectionString.Production", "folderPath")
+# → "Production"
+
+# Get all sub-properties
+asset_props = sdk.bindings.get_property("DatabaseConnectionString.Production")
+# → {'name': 'DatabaseConnectionString', 'folderPath': 'Production'}
+```
+
+---
+
+## Value Object Structure
+
+---
+
 ## Value Object Structure
 
 ### For Assets, Processes, Buckets, Apps and Indexes
@@ -334,13 +430,31 @@ Connections define external system integrations.
 }
 ```
 
-### Property Definition Fields
+### For Property bindings
+
+The keys and number of sub-properties are connector-defined and vary by connector activity. Each sub-property follows this structure:
+
+```json
+{
+  "<SubPropertyName>": {
+    "defaultValue": "resolved_value",
+    "isExpression": false,
+    "displayName": "Human-readable label",
+    "description": "Optional longer description",
+    "propertyName": "ConnectorInternalPropertyName"
+  }
+}
+```
+
+### Sub-property Definition Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `defaultValue` | `string` | Yes | The default value for this property |
+| `defaultValue` | `string` | Yes | The resolved value for this sub-property |
 | `isExpression` | `boolean` | Yes | Whether the value is a dynamic expression (usually `false`) |
 | `displayName` | `string` | Yes | Human-readable name shown in UI |
+| `description` | `string` | No | Optional longer description of the sub-property |
+| `propertyName` | `string` | No | Internal connector property name |
 
 ---
 
@@ -352,11 +466,13 @@ Metadata provides additional context about the resource binding.
 
 | Field | Type | Description | Applicable To |
 |-------|------|-------------|---------------|
-| `ActivityName` | `string` | Activity used to access the resource | asset, process, bucket, index |
+| `ActivityName` | `string` | Activity used to access the resource | asset, process, bucket, index, Property |
 | `BindingsVersion` | `string` | Version of the bindings schema | All resources |
-| `DisplayLabel` | `string` | Label format for display | asset, process, bucket, index |
+| `DisplayLabel` | `string` | Label format for display | asset, process, bucket, index, Property |
 | `Connector` | `string` | Type of connector | connection |
 | `UseConnectionService` | `string` | Whether to use connection service | connection |
+| `ObjectName` | `string` | Connector-defined object type | Property |
+| `ParentResourceKey` | `string` | Key of the parent Connection resource (`"Connection.<uuid>"`) | Property |
 
 ---
 
@@ -486,6 +602,40 @@ Metadata provides additional context about the resource binding.
                 "BindingsVersion": "2.2",
                 "Connector": "Salesforce",
                 "UseConnectionService": "True"
+            }
+        },
+        {
+            "resource": "Property",
+            "key": "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder",
+            "value": {
+                "FullName": {
+                    "defaultValue": "Invoices",
+                    "isExpression": false,
+                    "displayName": "File or folder",
+                    "description": "Select a file or folder",
+                    "propertyName": "BrowserItemFriendlyName"
+                },
+                "ID": {
+                    "defaultValue": "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M",
+                    "isExpression": false,
+                    "displayName": "File or folder",
+                    "description": "The file or folder of interest",
+                    "propertyName": "BrowserItemId"
+                },
+                "ParentDriveID": {
+                    "defaultValue": "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt",
+                    "isExpression": false,
+                    "displayName": "Drive",
+                    "description": "The drive (OneDrive/SharePoint) of file or folder",
+                    "propertyName": "BrowserDriveId"
+                }
+            },
+            "metadata": {
+                "ActivityName": "SharePoint Invoices folder",
+                "BindingsVersion": "2.1",
+                "ObjectName": "CuratedFile",
+                "DisplayLabel": "FullName",
+                "ParentResourceKey": "Connection.775694d9-4c5b-430f-bf47-6079b0ce8623"
             }
         }
     ]

--- a/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
@@ -584,7 +584,10 @@ class StudioClient:
         data = response.json()
         overwrites = {}
 
+        logger.info("Received resource overwrites response from Studio API: %s", data)
+        
         for key, value in data.items():
+            logger.debug("Parsing overwrite for key '%s' with value: %s", key, value)
             overwrites[key] = ResourceOverwriteParser.parse(key, value)
 
         logger.info(

--- a/packages/uipath/src/uipath/_cli/models/runtime_schema.py
+++ b/packages/uipath/src/uipath/_cli/models/runtime_schema.py
@@ -18,6 +18,8 @@ class BindingResourceValue(BaseModelWithDefaultConfig):
     default_value: str = Field(..., alias="defaultValue")
     is_expression: bool = Field(..., alias="isExpression")
     display_name: str = Field(..., alias="displayName")
+    description: str | None = Field(default=None, alias="description")
+    property_name: str | None = Field(default=None, alias="propertyName")
 
 
 # TODO: create stronger binding resource definition with discriminator based on resource enum.

--- a/packages/uipath/tests/sdk/test_property_bindings.py
+++ b/packages/uipath/tests/sdk/test_property_bindings.py
@@ -1,0 +1,306 @@
+# type: ignore
+import json
+
+import pytest
+
+from uipath.platform.common import GenericResourceOverwrite, ResourceOverwriteParser
+from uipath.platform.common._bindings import _resource_overwrites
+from uipath.platform.common._bindings_service import BindingsService
+
+SAMPLE_BINDINGS = {
+    "version": "2.1",
+    "resources": [
+        {
+            "resource": "Property",
+            "key": "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder",
+            "value": {
+                "FullName": {
+                    "defaultValue": "Invoices",
+                    "isExpression": False,
+                    "displayName": "File or folder",
+                    "description": "Select a file or folder",
+                    "propertyName": "BrowserItemFriendlyName",
+                },
+                "ID": {
+                    "defaultValue": "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M",
+                    "isExpression": False,
+                    "displayName": "File or folder",
+                    "description": "The file or folder of interest",
+                    "propertyName": "BrowserItemId",
+                },
+                "ParentDriveID": {
+                    "defaultValue": "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt",
+                    "isExpression": False,
+                    "displayName": "Drive",
+                    "description": "The drive (OneDrive/SharePoint) of file or folder",
+                    "propertyName": "BrowserDriveId",
+                },
+            },
+            "metadata": {
+                "ActivityName": "SharePoint Invoices folder",
+                "BindingsVersion": "2.1",
+                "ObjectName": "CuratedFile",
+                "DisplayLabel": "FullName",
+                "ParentResourceKey": "Connection.775694d9-4c5b-430f-bf47-6079b0ce8623",
+            },
+        }
+    ],
+}
+
+
+@pytest.fixture
+def bindings_file(tmp_path):
+    path = tmp_path / "bindings.json"
+    path.write_text(json.dumps(SAMPLE_BINDINGS))
+    return path
+
+
+@pytest.fixture
+def service(bindings_file):
+    return BindingsService(bindings_file_path=bindings_file)
+
+
+class TestBindingsServiceGetProperty:
+    def test_get_single_sub_property(self, service):
+        result = service.get_property(
+            "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder", "ID"
+        )
+        assert result == "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M"
+
+    def test_get_all_sub_properties(self, service):
+        result = service.get_property(
+            "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder"
+        )
+        assert result == {
+            "FullName": "Invoices",
+            "ID": "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M",
+            "ParentDriveID": "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt",
+        }
+
+    def test_suffix_key_match(self, service):
+        """Key ending with the user-supplied string should resolve correctly."""
+        result = service.get_property("SharePoint Invoices folder", "FullName")
+        assert result == "Invoices"
+
+    def test_suffix_key_all_properties(self, service):
+        result = service.get_property("SharePoint Invoices folder")
+        assert "ID" in result
+        assert "FullName" in result
+        assert "ParentDriveID" in result
+
+    def test_key_not_found_raises(self, service):
+        with pytest.raises(KeyError, match="nonexistent"):
+            service.get_property("nonexistent.key", "ID")
+
+    def test_sub_property_not_found_raises(self, service):
+        with pytest.raises(KeyError, match="NoSuchField"):
+            service.get_property("SharePoint Invoices folder", "NoSuchField")
+
+    def test_missing_bindings_file_raises(self, tmp_path):
+        service = BindingsService(bindings_file_path=tmp_path / "missing.json")
+        with pytest.raises(KeyError):
+            service.get_property("some.key", "ID")
+
+
+class TestBindingsServiceWithRuntimeOverwrite:
+    def test_overwrite_single_sub_property(self, service):
+        overwrite = GenericResourceOverwrite(
+            resource_type="property",
+            ID="OVERWRITTEN_ID",
+            ParentDriveID="OVERWRITTEN_DRIVE",
+        )
+        key = "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder"
+        token = _resource_overwrites.set({f"property.{key}": overwrite})
+        try:
+            result = service.get_property(key, "ID")
+            assert result == "OVERWRITTEN_ID"
+        finally:
+            _resource_overwrites.reset(token)
+
+    def test_overwrite_all_sub_properties(self, service):
+        overwrite = GenericResourceOverwrite(
+            resource_type="property",
+            ID="OVERWRITTEN_ID",
+            ParentDriveID="OVERWRITTEN_DRIVE",
+        )
+        key = "SharePoint Invoices folder"
+        token = _resource_overwrites.set({f"property.{key}": overwrite})
+        try:
+            result = service.get_property(key)
+            assert result == {
+                "ID": "OVERWRITTEN_ID",
+                "ParentDriveID": "OVERWRITTEN_DRIVE",
+            }
+        finally:
+            _resource_overwrites.reset(token)
+
+    def test_overwrite_missing_sub_property_raises(self, service):
+        overwrite = GenericResourceOverwrite(
+            resource_type="property",
+            ID="OVERWRITTEN_ID",
+        )
+        key = "SharePoint Invoices folder"
+        token = _resource_overwrites.set({f"property.{key}": overwrite})
+        try:
+            with pytest.raises(KeyError, match="NoSuchField"):
+                service.get_property(key, "NoSuchField")
+        finally:
+            _resource_overwrites.reset(token)
+
+    def test_suffix_match_against_fully_qualified_contextvar_key(self, service):
+        """Short label resolves against a fully-qualified key stored by the Studio path."""
+        overwrite = GenericResourceOverwrite(
+            resource_type="property",
+            ID="STUDIO_ID",
+            ParentDriveID="STUDIO_DRIVE",
+        )
+        # Studio stores keys as "property.<full-key>" — e.g. after ResourceOverwriteParser
+        full_key = "775694d9-4c5b-430f-bf47-6079b0ce8623.SharePoint Invoices folder"
+        token = _resource_overwrites.set({f"property.{full_key}": overwrite})
+        try:
+            # Caller uses only the label suffix, not the full UUID-prefixed key
+            result = service.get_property("SharePoint Invoices folder", "ID")
+            assert result == "STUDIO_ID"
+        finally:
+            _resource_overwrites.reset(token)
+
+    def test_no_overwrite_falls_back_to_file(self, service):
+        result = service.get_property("SharePoint Invoices folder", "ParentDriveID")
+        assert (
+            result
+            == "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt"
+        )
+
+
+class TestPropertyResourceOverwrite:
+    def test_construction(self):
+        overwrite = GenericResourceOverwrite(
+            resource_type="property",
+            ID="abc",
+            DriveID="xyz",
+        )
+        assert overwrite.resource_type == "property"
+        assert overwrite.properties == {"ID": "abc", "DriveID": "xyz"}
+        assert overwrite.resource_identifier == ""
+        assert overwrite.folder_identifier == ""
+
+    def test_parse_property_overwrite(self):
+        overwrite = ResourceOverwriteParser.parse(
+            key="property.some-connection.My Folder",
+            value={"ID": "parsed_id", "DriveID": "parsed_drive"},
+        )
+        assert isinstance(overwrite, GenericResourceOverwrite)
+        assert overwrite.resource_type == "property"
+        assert overwrite.properties["ID"] == "parsed_id"
+        assert overwrite.properties["DriveID"] == "parsed_drive"
+
+
+RUNTIME_CONFIG = {
+    "runtime": {
+        "internalArguments": {
+            "resourceOverwrites": {
+                # Real runtime format: capital-P key prefix, extra fields on
+                # connections, and flat sub-property values (no "values" wrapper).
+                "connection.coupa-connection": {
+                    "connectionId": "61de4895-f6e8-4252-90b7-8e7add4bfea8",
+                    "elementInstanceId": "397548",
+                    "folderKey": "19559fcf-166b-49ef-bbb8-bd672d679c76",
+                    "ConnectionId": "61de4895-f6e8-4252-90b7-8e7add4bfea8",
+                },
+                "connection.sharepoint-connection": {
+                    "connectionId": "359b25d6-79a2-43de-88fb-d7eb4230988a",
+                    "elementInstanceId": "398411",
+                    "folderKey": "19559fcf-166b-49ef-bbb8-bd672d679c76",
+                    "ConnectionId": "359b25d6-79a2-43de-88fb-d7eb4230988a",
+                },
+                "Property.sharepoint-connection.SharePoint Invoices folder": {
+                    "FullName": "Invoices",
+                    "ID": "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M",
+                    "ParentDriveID": "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt",
+                },
+            }
+        }
+    }
+}
+
+
+def _parse_runtime_overwrites(config: dict) -> dict:
+    """Mirror what _common.py does when loading a runtime config file."""
+    raw = (
+        config.get("runtime", {})
+        .get("internalArguments", {})
+        .get("resourceOverwrites", {})
+    )
+    return {
+        key: ResourceOverwriteParser.parse(key, value) for key, value in raw.items()
+    }
+
+
+class TestRuntimeConfigOverwrites:
+    """End-to-end tests using the synthetic runtime config payload."""
+
+    def test_parse_produces_three_overwrites(self):
+        overwrites = _parse_runtime_overwrites(RUNTIME_CONFIG)
+        assert len(overwrites) == 3
+
+    def test_connection_overwrites_parsed(self):
+        from uipath.platform.common import ConnectionResourceOverwrite
+
+        overwrites = _parse_runtime_overwrites(RUNTIME_CONFIG)
+        coupa = overwrites["connection.coupa-connection"]
+        assert isinstance(coupa, ConnectionResourceOverwrite)
+        assert coupa.connection_id == "61de4895-f6e8-4252-90b7-8e7add4bfea8"
+        assert coupa.folder_key == "19559fcf-166b-49ef-bbb8-bd672d679c76"
+
+        sp = overwrites["connection.sharepoint-connection"]
+        assert isinstance(sp, ConnectionResourceOverwrite)
+        assert sp.connection_id == "359b25d6-79a2-43de-88fb-d7eb4230988a"
+
+    def test_property_overwrite_parsed(self):
+        overwrites = _parse_runtime_overwrites(RUNTIME_CONFIG)
+        # Key is stored with the original casing but normalised to lowercase resource_type
+        prop = overwrites["Property.sharepoint-connection.SharePoint Invoices folder"]
+        assert isinstance(prop, GenericResourceOverwrite)
+        assert prop.resource_type == "property"
+        assert prop.properties["ID"] == "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M"
+        assert prop.properties["FullName"] == "Invoices"
+
+    def test_get_property_full_key(self, bindings_file):
+        overwrites = _parse_runtime_overwrites(RUNTIME_CONFIG)
+        token = _resource_overwrites.set(overwrites)
+        try:
+            svc = BindingsService(bindings_file_path=bindings_file)
+            result = svc.get_property(
+                "sharepoint-connection.SharePoint Invoices folder", "ID"
+            )
+            assert result == "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M"
+        finally:
+            _resource_overwrites.reset(token)
+
+    def test_get_property_suffix_key(self, bindings_file):
+        """Short label should resolve against the fully-qualified stored key."""
+        overwrites = _parse_runtime_overwrites(RUNTIME_CONFIG)
+        token = _resource_overwrites.set(overwrites)
+        try:
+            svc = BindingsService(bindings_file_path=bindings_file)
+            result = svc.get_property("SharePoint Invoices folder", "ParentDriveID")
+            assert (
+                result
+                == "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt"
+            )
+        finally:
+            _resource_overwrites.reset(token)
+
+    def test_get_property_all_values(self, bindings_file):
+        overwrites = _parse_runtime_overwrites(RUNTIME_CONFIG)
+        token = _resource_overwrites.set(overwrites)
+        try:
+            svc = BindingsService(bindings_file_path=bindings_file)
+            result = svc.get_property("SharePoint Invoices folder")
+            assert result == {
+                "FullName": "Invoices",
+                "ID": "017NI543GXSYR5TZEZOBHJQNL6I2H4VA3M",
+                "ParentDriveID": "b!fFiPzsQBgk2xGTJUTRo5jryva9eCrqNPowK3pN2kXWKF90cVuHqnS4RUsG9j1cRt",
+            }
+        finally:
+            _resource_overwrites.reset(token)


### PR DESCRIPTION
## Summary

- Adds \`sdk.bindings.get_property(key, sub_property?)\` — a generic API for reading connector-defined Property binding values from \`bindings.json\` at runtime
- Extends \`BindingResourceValue\` with optional \`description\` and \`propertyName\` fields present in Property bindings
- Merges Property support into \`GenericResourceOverwrite\` (adds \`"property"\` to its \`resource_type\` Literal and an optional \`values\` field) rather than a separate class
- Documents \`Property\` as the 7th resource type in \`bindings.spec.md\`
- Replaces the need for user-maintained helpers like the \`get_binding_property()\` function seen in vertical solutions

## Changes

- \`runtime_schema.py\` — \`BindingResourceValue\` gains optional \`description\` / \`propertyName\` fields
- \`_bindings.py\` — \`"property"\` added to \`GenericResourceOverwrite\`; \`ResourceOverwriteParser.parse\` normalises the \`Property\` key prefix to lowercase and accepts the real runtime flat-dict format
- \`_bindings_service.py\` (new) — \`BindingsService.get_property()\` reads bindings.json, supports exact and suffix key matching, and honours runtime overwrites via the existing \`_resource_overwrites\` ContextVar
- \`_uipath.py\` — exposes \`sdk.bindings\` as a \`cached_property\`
- \`bindings.spec.md\` — full documentation for the Property resource type including key format, value structure, metadata fields, and SDK usage examples
- \`test_property_bindings.py\` (new) — unit tests covering happy paths, suffix matching, runtime overwrites (Studio-loaded and real runtime payload formats), and error cases

## Breaking Changes

None. All changes are additive:

- `ResourceOverwriteParser.parse` is strictly more permissive — inputs that previously raised a `ValidationError` (capital-P key prefix, flat value dict) now succeed. All previously valid inputs produce the same result.
- Making `name` and `folder_path` optional on `GenericResourceOverwrite` is backwards compatible — existing callers that supply them are unaffected.
- `PropertyResourceOverwrite` was introduced and removed in this same PR, so no external code depends on it.

## Test plan

- [x] All existing tests pass (1265 in the main package, full suite green)
- [x] Unit tests for \`BindingsService\`: exact key, suffix key, missing key/sub-property, missing file
- [x] Runtime overwrite path: Studio-loaded overwrites (fully-qualified key), suffix matching against contextvar, real runtime payload (capital-P key, flat dict)
- [x] \`ResourceOverwriteParser\` round-trip with all resource types including the new property format

## Development Packages

<!-- DEV_PACKAGE_START:uipath -->
### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.35.dev1014865699",

  # Any version from PR
  "uipath>=2.10.35.dev1014860000,<2.10.35.dev1014870000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath>=2.10.35.dev1014860000,<2.10.35.dev1014870000",
]
```
<!-- DEV_PACKAGE_END:uipath -->

<!-- DEV_PACKAGE_START:uipath-platform -->
### uipath-platform

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-platform==0.1.13.dev1014865699",

  # Any version from PR
  "uipath-platform>=0.1.13.dev1014860000,<0.1.13.dev1014870000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }

[tool.uv]
override-dependencies = [
    "uipath-platform>=0.1.13.dev1014860000,<0.1.13.dev1014870000",
]
```
<!-- DEV_PACKAGE_END:uipath-platform -->