### PR TITLE
fix(documents): add resource_override to create_validate_extraction_action

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.9"
+version = "0.1.10"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/documents/_documents_service.py
+++ b/packages/uipath-platform/src/uipath/platform/documents/_documents_service.py
@@ -2299,6 +2299,11 @@ class DocumentsService(FolderContext, BaseService):
             operation_id=operation_id,
         )
 
+    @resource_override(
+        resource_type="bucket",
+        resource_identifier="storage_bucket_name",
+        folder_identifier="action_folder",
+    )
     @traced(name="documents_create_validate_extraction_action", run_type="uipath")
     def create_validate_extraction_action(
         self,
@@ -2360,6 +2365,11 @@ class DocumentsService(FolderContext, BaseService):
             operation_id=operation_id,
         )
 
+    @resource_override(
+        resource_type="bucket",
+        resource_identifier="storage_bucket_name",
+        folder_identifier="action_folder",
+    )
     @traced(name="documents_create_validate_extraction_action_async", run_type="uipath")
     async def create_validate_extraction_action_async(
         self,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
create_validate_extraction_action_async  ([code](https://github.com/UiPath/uipath-python/blob/c9fdba4de7c43eeea9a15291eb15d67cac4ab832/packages/uipath-platform/src/uipath/platform/documents/_documents_service.py#L2364)) is not using resource_override to correctly bind buckets, which causes a bucket not found error

more context: https://uipath-product.slack.com/archives/C07TZ9J253M/p1774526789509849?thread_ts=1770664453.758519&cid=C07TZ9J253M