### PR TITLE
feat: enable LiveTrackingSpanProcessor when UIPATH_LOG_TO_FILE is set

### DIFF
--- a/packages/uipath/src/uipath/_cli/cli_eval.py
+++ b/packages/uipath/src/uipath/_cli/cli_eval.py
@@ -393,7 +393,9 @@ def eval(
                         )
 
                         if (
-                            ctx.job_id or should_register_progress_reporter
+                            ctx.job_id
+                            or ctx.log_to_file
+                            or should_register_progress_reporter
                         ) and UiPathConfig.is_tracing_enabled:
                             # Live tracking for Orchestrator or Studio Web
                             # Uses UIPATH_TRACE_ID from environment for trace correlation


### PR DESCRIPTION
## Summary

When `UIPATH_LOG_TO_FILE=true` is set, also register the `LiveTrackingSpanProcessor` during eval. This ensures the local file-logging repro path matches deployed behavior where span upserts run in background threads alongside the main execution.

Without this, `UIPATH_LOG_TO_FILE` would enable file logging but not the background span threads — making it impossible to reproduce thread-related log interleaving issues locally.

## Changes

- `cli_eval.py`: Check `ctx.log_to_file` alongside `ctx.job_id` when deciding whether to register `LiveTrackingSpanProcessor`

## Test plan

- [x] `UIPATH_LOG_TO_FILE=true uv run uipath eval agent.json default.json` writes to `__uipath/execution.log` with span processor active
- [x] Without the env var, behavior is unchanged

**Companion PR:** UiPath/uipath-runtime-python#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)