### PR TITLE
feat: add ArgumentEmail and ArgumentGroupName escalation recipient types

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.48"
+version = "2.10.49"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -135,6 +135,8 @@ class AgentEscalationRecipientType(str, CaseInsensitiveEnum):
     ASSET_USER_EMAIL = "AssetUserEmail"
     GROUP_NAME = "GroupName"
     ASSET_GROUP_NAME = "AssetGroupName"
+    ARGUMENT_EMAIL = "ArgumentEmail"
+    ARGUMENT_GROUP_NAME = "ArgumentGroupName"
 
 
 class AgentContextRetrievalMode(str, CaseInsensitiveEnum):
@@ -481,6 +483,8 @@ _RECIPIENT_TYPE_NORMALIZED_MAP: Mapping[int | str, AgentEscalationRecipientType]
     5: AgentEscalationRecipientType.GROUP_NAME,
     "staticgroupname": AgentEscalationRecipientType.GROUP_NAME,
     6: AgentEscalationRecipientType.ASSET_GROUP_NAME,
+    7: AgentEscalationRecipientType.ARGUMENT_EMAIL,
+    8: AgentEscalationRecipientType.ARGUMENT_GROUP_NAME,
 }
 
 
@@ -536,8 +540,37 @@ class AssetRecipient(BaseEscalationRecipient):
     folder_path: str = Field(..., alias="folderPath")
 
 
+class ArgumentEmailRecipient(BaseEscalationRecipient):
+    """Argument email recipient resolved from a named input argument.
+
+    The argument_path supports dot-notation for nested input fields (e.g. "user.email").
+    """
+
+    type: Literal[AgentEscalationRecipientType.ARGUMENT_EMAIL,] = Field(
+        ..., alias="type"
+    )
+    argument_path: str = Field(..., alias="argumentName")
+
+
+class ArgumentGroupNameRecipient(BaseEscalationRecipient):
+    """Argument group name recipient resolved from a named input argument.
+
+    The argument_path supports dot-notation for nested input fields (e.g. "team.groupName").
+    """
+
+    type: Literal[AgentEscalationRecipientType.ARGUMENT_GROUP_NAME,] = Field(
+        ..., alias="type"
+    )
+    argument_path: str = Field(..., alias="argumentName")
+
+
 AgentEscalationRecipient = Annotated[
-    Union[StandardRecipient, AssetRecipient],
+    Union[
+        StandardRecipient,
+        AssetRecipient,
+        ArgumentEmailRecipient,
+        ArgumentGroupNameRecipient,
+    ],
     Field(discriminator="type"),
     BeforeValidator(_normalize_recipient_type),
 ]

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from uipath.agent.models.agent import (
     AgentA2aResourceConfig,
@@ -43,6 +43,8 @@ from uipath.agent.models.agent import (
     AgentUnknownToolResourceConfig,
     AgentWordOperator,
     AgentWordRule,
+    ArgumentEmailRecipient,
+    ArgumentGroupNameRecipient,
     AssetRecipient,
     BatchTransformFileExtension,
     BatchTransformWebSearchGrounding,
@@ -3789,3 +3791,49 @@ class TestDataFabricContextConfig:
         ]
         assert len(a2a_resources) == 1
         assert isinstance(a2a_resources[0], AgentA2aResourceConfig)
+
+
+class TestArgumentRecipientDeserialization:
+    def test_argument_email_recipient_by_type_int(self):
+        payload = {"type": 7, "argumentName": "assigneeEmail"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, ArgumentEmailRecipient)
+        assert recipient.argument_path == "assigneeEmail"
+        assert recipient.type == AgentEscalationRecipientType.ARGUMENT_EMAIL
+
+    def test_argument_group_name_recipient_by_type_int(self):
+        payload = {"type": 8, "argumentName": "assigneeGroup"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, ArgumentGroupNameRecipient)
+        assert recipient.argument_path == "assigneeGroup"
+        assert recipient.type == AgentEscalationRecipientType.ARGUMENT_GROUP_NAME
+
+    def test_argument_email_recipient_by_type_string(self):
+        payload = {"type": "ArgumentEmail", "argumentName": "emailArg"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, ArgumentEmailRecipient)
+        assert recipient.argument_path == "emailArg"
+
+    def test_argument_group_name_recipient_by_type_string(self):
+        payload = {"type": "ArgumentGroupName", "argumentName": "groupArg"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, ArgumentGroupNameRecipient)
+        assert recipient.argument_path == "groupArg"
+
+    def test_argument_email_recipient_missing_argument_name_raises(self):
+        payload = {"type": 7}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_argument_group_name_recipient_missing_argument_name_raises(self):
+        payload = {"type": 8}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.48"
+version = "2.10.49"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

Adds two new recipient types to the escalation data model to support argument-driven assignees — where the assignee is resolved from a named input argument at runtime rather than being fixed at design time.

| Type value | Name | Wire field (`argumentName`) | Resolves to |
|---|---|---|---|
| `7` | `ArgumentEmail` | `argument_path: str` | Email recipient |
| `8` | `ArgumentGroupName` | `argument_path: str` | Group-name recipient |

Both extend `BaseEscalationRecipient` and are included in the `AgentEscalationRecipient` discriminated union.

**Note on field naming**: the Python field is `argument_path` (supports dot-notation for nested fields e.g. `user.email`). The JSON alias on the wire remains `argumentName` — wire format is unchanged.

## Changed files

| File | Change |
|---|---|
| `src/uipath/agent/models/agent.py` | `ARGUMENT_EMAIL = "ArgumentEmail"`, `ARGUMENT_GROUP_NAME = "ArgumentGroupName"` enum values; normalization map entries (int `7`, `8`); `ArgumentEmailRecipient` and `ArgumentGroupNameRecipient` classes; discriminated union updated |

## Failure modes & what was tested

### What can fail
These model classes have no runtime logic — they are pure data containers. The only failure modes are deserialization:
1. **Unknown type value**: a recipient with `type` not in the normalization map raises a Pydantic validation error. This is existing behavior, unchanged.
2. **Missing `argumentName` field**: `argument_path` is required with no default — a recipient missing the field raises a Pydantic validation error at parse time, before any tool runs.

Both are fail-fast at agent startup, not at task creation time.

### What was tested
- Deserialized `{ "type": 7, "argumentName": "assigneeEmail" }` → `ArgumentEmailRecipient(argument_path="assigneeEmail")` ✓
- Deserialized `{ "type": 8, "argumentName": "assigneeGroup" }` → `ArgumentGroupNameRecipient(argument_path="assigneeGroup")` ✓
- Deserialized via integer type `7`/`8` (normalization map path) ✓
- Deserialized via string `"ArgumentEmail"`/`"ArgumentGroupName"` (enum path) ✓
- Existing recipient types 1–6 unaffected ✓
- Full end-to-end HC run: agent with `ArgumentEmail` recipient created Action Center task with correct assignee ✓

## Related

- Agents repo PR: UiPath/Agents#4835
- Consumed by: UiPath/uipath-langchain-python PR #735 (runtime resolution)
- Design doc: https://uipath.atlassian.net/wiki/spaces/BPA/pages/90469990611/Dynamic+Assignee

## Test plan

- [ ] Deserialize `{ "type": 7, "argumentName": "assigneeEmail" }` → `ArgumentEmailRecipient(argument_path="assigneeEmail")`
- [ ] Same for type `8` → `ArgumentGroupNameRecipient`
- [ ] Deserialize via integer type and string type for both
- [ ] Verify existing recipient types 1–6 unaffected

Tested locally using [HackedCoded](https://uipath.atlassian.net/wiki/spaces/~7120201d2c956b7d1c4065a7ba3947a7b34ebd/pages/90017595396/Hacked-Coded+Project+Setup+Guide)

<img width="1118" height="495" alt="image" src="https://github.com/user-attachments/assets/e40a0fff-5844-43de-9176-15e8a1b23494" />