### PR TITLE
feat(tracing): add coded agent info to traces

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.14"
+version = "0.1.15"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -267,6 +267,16 @@ class _SpanUtils:
             ]
             attributes_dict["links"] = links_list
 
+        # Add process context attributes from environment variables
+        for env_key, attr_key in (
+            ("PROJECT_KEY", "agentId"),
+            ("UIPATH_PROCESS_KEY", "agentName"),
+            ("UIPATH_PROCESS_VERSION", "agentVersion"),
+        ):
+            value = env.get(env_key)
+            if value:
+                attributes_dict[attr_key] = value
+
         span_type_value = attributes_dict.get("span_type", "OpenTelemetry")
         span_type = str(span_type_value)
 

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Description

- Add `codedAgentId`, `codedAgentName`, and `codedAgentVersion` as default span attributes, read from `UIPATH_PROCESS_UUID`, `UIPATH_PROCESS_KEY`, and `UIPATH_PROCESS_VERSION` environment variables respectively. This enables identifying coded agents from trace data alone.
- Add support for custom user-defined span attributes via `UIPATH_TRACE_ATTR__` prefixed environment variables, following the ASP.NET Core configuration convention. For example, setting `UIPATH_TRACE_ATTR__customerId=abc` will inject `customerId: "abc"` into all span attributes.

## How it works

Environment variables with the `UIPATH_TRACE_ATTR__` prefix are scanned during span conversion in `_SpanUtils.otel_span_to_uipath_span`. The prefix is stripped and the remainder becomes the attribute key. This requires zero code changes from SDK users — just set env vars.


## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.36.dev1015225768",

  # Any version from PR
  "uipath>=2.10.36.dev1015220000,<2.10.36.dev1015230000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-platform==0.1.15.dev1015225768",

  # Any version from PR
  "uipath-platform>=0.1.15.dev1015220000,<0.1.15.dev1015230000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```