### PR TITLE
fix: ignore hidden files on uipath push

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.35"
+version = "2.10.36"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_utils/_project_files.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_project_files.py
@@ -460,6 +460,9 @@ def files_to_include(
 
         dirs[:] = included_dirs
         for file in files:
+            if file.startswith("."):
+                continue
+
             file_extension = os.path.splitext(file)[1].lower()
             file_path = os.path.join(root, file)
             file_name = os.path.basename(file_path)

--- a/packages/uipath/tests/cli/test_files_to_include.py
+++ b/packages/uipath/tests/cli/test_files_to_include.py
@@ -1,0 +1,31 @@
+import os
+
+from uipath._cli._utils._project_files import files_to_include
+
+
+class TestFilesToIncludeHiddenFiles:
+    def test_hidden_files_are_excluded(self, tmp_path):
+        project_dir = str(tmp_path)
+        open(os.path.join(project_dir, "main.py"), "w").close()
+        open(os.path.join(project_dir, ".hidden_file.py"), "w").close()
+        open(os.path.join(project_dir, ".env"), "w").close()
+
+        included, _ = files_to_include(None, project_dir, include_uv_lock=False)
+        included_names = [f.file_name for f in included]
+
+        assert "main.py" in included_names
+        assert ".hidden_file.py" not in included_names
+        assert ".env" not in included_names
+
+    def test_hidden_files_in_subdirectory_are_excluded(self, tmp_path):
+        project_dir = str(tmp_path)
+        sub_dir = os.path.join(project_dir, "src")
+        os.makedirs(sub_dir)
+        open(os.path.join(sub_dir, "app.py"), "w").close()
+        open(os.path.join(sub_dir, ".secret.json"), "w").close()
+
+        included, _ = files_to_include(None, project_dir, include_uv_lock=False)
+        included_names = [f.file_name for f in included]
+
+        assert "app.py" in included_names
+        assert ".secret.json" not in included_names

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.35"
+version = "2.10.36"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- ignore hidden files on uipath push

## Why?

Fixes **Invalid File Name** revceived from SW **StructuralMigration** API

```
Pushing UiPath project to Studio Web...
❌ Failed to push UiPath project:
Request URL: https://staging.uipath.com/.../FileOperations/StructuralMigration
HTTP Method: POST
Status Code: 409
Response Content: {"code":"6000","message":"Invalid file name.","translatedMessage":"Invalid file name."}
```

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.36.dev1015265731",

  # Any version from PR
  "uipath>=2.10.36.dev1015260000,<2.10.36.dev1015270000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```