### PR TITLE
fix: add timeout to AppInsights flush to prevent blocking process exit

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.39"
+version = "2.10.40"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/telemetry/_track.py
+++ b/packages/uipath/src/uipath/telemetry/_track.py
@@ -325,15 +325,29 @@ class _AppInsightsEventClient:
             _logger.debug(f"Event tracking error for '{name}'", exc_info=True)
 
     @staticmethod
-    def flush() -> None:
-        """Flush any pending telemetry events."""
-        if _AppInsightsEventClient._client:
+    def flush(timeout: float = 5.0) -> None:
+        """Flush any pending telemetry events.
+
+        Blocks for up to ``timeout`` seconds waiting for the flush to complete.
+        On the happy path (network reachable) the flush finishes well within the
+        timeout and no data is lost.  When the ingestion endpoint is unreachable
+        (e.g. Automation Suite / CI with restricted egress) the synchronous sender
+        would otherwise retry indefinitely, preventing the process from exiting and
+        leaving eval runs stuck in Running state.  The flush runs in a daemon thread
+        so that if it does not finish within ``timeout`` seconds it is abandoned
+        rather than blocking the process indefinitely.
+        """
+        import threading
+
+        if not _AppInsightsEventClient._client:
+            return
+
+        def _do_flush() -> None:
             try:
-                _AppInsightsEventClient._client.flush()
-                # Check if items remain after flush (indicates send failure)
+                _AppInsightsEventClient._client.flush()  # type: ignore[union-attr]
                 try:
                     remaining = (
-                        _AppInsightsEventClient._client.channel.queue._queue.qsize()
+                        _AppInsightsEventClient._client.channel.queue._queue.qsize()  # type: ignore[union-attr]
                     )
                     if remaining > 0:
                         _logger.warning(
@@ -343,9 +357,16 @@ class _AppInsightsEventClient:
                 except Exception:
                     pass
             except Exception as e:
-                # Log but don't raise - telemetry should never break the main application
                 _logger.warning(f"Failed to flush telemetry events: {e}")
                 _logger.debug("Telemetry flush error", exc_info=True)
+
+        thread = threading.Thread(target=_do_flush, daemon=True)
+        thread.start()
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            _logger.warning(
+                "AppInsights flush: timed out after %.1fs, abandoning send", timeout
+            )
 
     @staticmethod
     def register_atexit_flush() -> None:

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.39"
+version = "2.10.40"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

- AppInsights `flush()` now runs in a `daemon=True` thread with a 5s timeout
- If the Azure endpoint is unreachable (e.g. Automation Suite / CI with restricted egress), the flush is abandoned after 5s instead of blocking indefinitely
- Bumps `uipath` version to `2.10.40`

## Problem

In Automation Suite environments, coded agent eval runs were getting stuck in **Running** state forever. The root cause:

1. The Python process completes the eval (PUT to update eval run succeeds)
2. `AppInsightsEventClient.flush()` is called (via `finally` block or `atexit` handler)
3. AS/CI environments block outbound access to `dc.applicationinsights.azure.com`
4. `urlopen()` times out → `_DiagnosticSender` re-queues the items → `SynchronousQueue.flush()` retries in a loop
5. Process **never exits** → Orchestrator never receives the exit signal → job stays "Running"

Alpha works fine because it has outbound internet access and the flush completes in <1s.

## Fix

```python
thread = threading.Thread(target=_do_flush, daemon=True)
thread.start()
thread.join(timeout=timeout)  # default 5s
if thread.is_alive():
    _logger.warning("AppInsights flush: timed out after %.1fs, abandoning send", timeout)
```

Using `daemon=True` ensures the thread is abandoned on process exit even if `join()` somehow doesn't return in time.

## Test plan

- [ ] Existing flush tests pass (`8 passed`)
- [ ] Verify eval runs complete in AS/CI environments (no longer stuck in Running)
- [ ] Verify alpha behaviour unchanged (flush completes within 5s, no timeout warning)