### PR TITLE
fix: support entity resource overwrites

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.16"
+version = "0.1.17"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_bindings.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_bindings.py
@@ -45,7 +45,7 @@ class ResourceOverwrite(BaseModel, ABC):
 
 class GenericResourceOverwrite(ResourceOverwrite):
     resource_type: Literal[
-        "process", "index", "app", "asset", "bucket", "mcpServer", "queue"
+        "process", "index", "app", "asset", "bucket", "mcpServer", "queue", "entity"
     ]
     name: str = Field(alias="name")
     folder_path: str = Field(alias="folderPath")

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.39"
+version = "2.10.40"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_resources/CLI_REFERENCE.md
+++ b/packages/uipath/src/uipath/_resources/CLI_REFERENCE.md
@@ -128,6 +128,7 @@ uv run uipath run --resume
 | `--trace-file` | value | `Sentinel.UNSET` | File path where traces will be written in JSONL format |
 | `--max-llm-concurrency` | value | `20` | Maximum concurrent LLM requests (default: 20) |
 | `--resume` | flag | false | Resume execution from a previous suspended state |
+| `--verbose` | flag | false | Include agent execution output (trace, result) in the output file |
 
 **Usage Examples:**
 
@@ -613,6 +614,335 @@ Options:
 - `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
 - `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
 - `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+---
+
+### `uipath context-grounding`
+
+Manage UiPath Context Grounding indexes.
+
+    Context Grounding indexes store and search contextual information
+    used to enhance AI-enabled automation processes.
+
+    
+    Two index types:
+        Regular   - Persistent, backed by bucket or connection, created via 'create'
+        Ephemeral - Temporary, no Orchestrator folder, created from local files via 'create-ephemeral'
+
+    
+    Examples:
+        uipath context-grounding list --folder-path "Shared"
+    
+
+**Subcommands:**
+
+#### `uipath context-grounding batch-transform`
+
+Manage Batch Transform tasks.
+
+    Batch Transform processes and transforms CSV files from context
+    grounding indexes.
+
+    
+    Examples:
+        uipath context-grounding batch-transform start --help
+    
+
+**`uipath context-grounding batch-transform download`**
+
+Download a Batch Transform result file.
+
+    
+    Examples:
+        uipath context-grounding batch-transform download --task-id abc-123 --output-file result.csv
+    
+
+Options:
+- `--task-id`: ID of the Batch Transform task (default: `Sentinel.UNSET`)
+- `--output-file`: Local destination path for the result file (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding batch-transform retrieve`**
+
+Retrieve a Batch Transform task status.
+
+    
+    Examples:
+        uipath context-grounding batch-transform retrieve --task-id abc-123-def-456
+    
+
+Options:
+- `--task-id`: ID of the Batch Transform task (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding batch-transform start`**
+
+Start a Batch Transform task on an index.
+
+    The index must contain CSV files. Only one file is processed per task.
+
+    
+    Two ways to specify the index:
+        Regular index:   --index-name + --folder-path
+        Ephemeral index: --index-id
+
+    
+    --columns-file is a JSON array defining output columns:
+        [
+          {"name": "entity", "description": "Extracted entity name"},
+          {"name": "category", "description": "Entity category"}
+        ]
+
+    
+    Examples:
+        uipath context-grounding batch-transform start --index-name my-index --task-name my-task --prompt "Extract" --columns-file cols.json
+        uipath context-grounding batch-transform start --index-id abc-123 --task-name my-task --prompt "Extract" --columns-file cols.json
+    
+
+Options:
+- `--index-name`: Name of the context grounding index (default: `Sentinel.UNSET`)
+- `--index-id`: ID of the context grounding index (ephemeral indexes only) (default: `Sentinel.UNSET`)
+- `--task-name`: Name for the Batch Transform task (default: `Sentinel.UNSET`)
+- `--prompt`: Task prompt describing what to process (default: `Sentinel.UNSET`)
+- `--columns-file`: JSON file defining output columns (see format above) (default: `Sentinel.UNSET`)
+- `--target-file`: Specific file name to target in the index (default: `Sentinel.UNSET`)
+- `--prefix`: Storage bucket folder path prefix for filtering files (default: `Sentinel.UNSET`)
+- `--web-search`: Enable web search grounding
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding create`**
+
+Create a new context grounding index (persistent).
+
+    The created index lives in an Orchestrator folder. Ingestion must be
+    triggered separately after creation.
+
+    
+    Two ways to specify the data source:
+        --bucket-source   Bucket name for bucket-backed indexes
+        --source-file     JSON file for connections (use 'source-schema' to see formats)
+
+    
+    Examples:
+        uipath context-grounding create --index-name my-index --bucket-source my-bucket
+        uipath context-grounding create --index-name my-index --source-file config.json
+    
+
+Options:
+- `--index-name`: Name of the index to create (default: `Sentinel.UNSET`)
+- `--source-file`: JSON file with connection source configuration (Google Drive, OneDrive, Dropbox, Confluence) (default: `Sentinel.UNSET`)
+- `--bucket-source`: Bucket name for bucket-backed indexes (default: `Sentinel.UNSET`)
+- `--description`: Description of the index (default: ``)
+- `--extraction-strategy`: Extraction strategy (default: LLMV4) (default: `LLMV4`)
+- `--file-type`: File type filter (e.g., 'pdf', 'txt') (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding create-ephemeral`**
+
+Create an ephemeral index from local files (temporary).
+
+    Uploads files as attachments and creates a temporary index. Reference it
+    in other commands with --index-id (no folder, no name). Ingestion starts
+    automatically. Poll with 'retrieve --index-id <id>' until
+    lastIngestionStatus is Successful before starting a task.
+
+    
+    Supported file types:
+        DeepRAG:  PDF, TXT
+        BatchRAG: CSV
+
+    
+    Examples:
+        uipath context-grounding create-ephemeral --usage DeepRAG --files doc1.pdf --files doc2.pdf
+        uipath context-grounding create-ephemeral --usage BatchRAG --files data.csv
+    
+
+Options:
+- `--usage`: Task type for the ephemeral index (default: `Sentinel.UNSET`)
+- `--files`: Local file paths to upload as attachments (repeatable) (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+#### `uipath context-grounding deep-rag`
+
+Manage Deep RAG tasks.
+
+    Deep RAG performs multi-document research and synthesis on context
+    grounding indexes.
+
+    
+    Examples:
+        uipath context-grounding deep-rag start --help
+    
+
+**`uipath context-grounding deep-rag retrieve`**
+
+Retrieve a Deep RAG task result (status, summary, citations).
+
+    
+    Examples:
+        uipath context-grounding deep-rag retrieve --task-id abc-123-def-456
+    
+
+Options:
+- `--task-id`: ID of the Deep RAG task (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding deep-rag start`**
+
+Start a Deep RAG task on an index.
+
+    
+    Two ways to specify the index:
+        Regular index:   --index-name + --folder-path
+        Ephemeral index: --index-id
+
+    
+    Examples:
+        uipath context-grounding deep-rag start --index-name my-index --folder-path Shared --task-name my-task --prompt "Summarize"
+        uipath context-grounding deep-rag start --index-id abc-123 --task-name my-task --prompt "Summarize"
+    
+
+Options:
+- `--index-name`: Name of the context grounding index (default: `Sentinel.UNSET`)
+- `--index-id`: ID of the context grounding index (ephemeral indexes only) (default: `Sentinel.UNSET`)
+- `--task-name`: Name for the Deep RAG task (default: `Sentinel.UNSET`)
+- `--prompt`: Task prompt describing what to research (default: `Sentinel.UNSET`)
+- `--glob-pattern`: Glob pattern to filter files in the index (default: **) (default: `**`)
+- `--citation-mode`: Citation mode (default: Skip) (default: `Skip`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding delete`**
+
+Delete a context grounding index.
+
+    
+    Examples:
+        uipath context-grounding delete --index-name my-index --confirm
+        uipath context-grounding delete --index-name my-index --dry-run
+    
+
+Options:
+- `--index-name`: Name of the index to delete (default: `Sentinel.UNSET`)
+- `--confirm`: Skip confirmation prompt
+- `--dry-run`: Show what would be deleted without deleting
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding ingest`**
+
+Trigger ingestion on a context grounding index.
+
+    Ingestion runs asynchronously. Use 'retrieve' to poll lastIngestionStatus
+    until it reaches Successful or Failed.
+
+    
+    Examples:
+        uipath context-grounding ingest --index-name my-index --folder-path "Shared"
+    
+
+Options:
+- `--index-name`: Name of the index to ingest (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding list`**
+
+List all context grounding indexes.
+
+    
+    Examples:
+        uipath context-grounding list --folder-path "Shared"
+    
+
+Options:
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding retrieve`**
+
+Retrieve a context grounding index.
+
+    
+    Two ways to specify the index:
+        Regular index:   --index-name + --folder-path
+        Ephemeral index: --index-id
+
+    
+    Examples:
+        uipath context-grounding retrieve --index-name my-index --folder-path "Shared"
+        uipath context-grounding retrieve --index-id abc-123-def-456 --format json
+    
+
+Options:
+- `--index-name`: Name of the index to retrieve (default: `Sentinel.UNSET`)
+- `--index-id`: ID of the index to retrieve (ephemeral indexes only) (default: `Sentinel.UNSET`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding search`**
+
+Search a context grounding index (regular indexes only).
+
+    
+    Examples:
+        uipath context-grounding search --index-name my-index --query "What is the revenue?"
+        uipath context-grounding search --index-name my-index --query "results" --limit 5
+    
+
+Options:
+- `--index-name`: Name of the index to search (default: `Sentinel.UNSET`)
+- `--query`: Search query in natural language (default: `Sentinel.UNSET`)
+- `--limit`: Maximum number of results (default: 10) (default: `10`)
+- `--threshold`: Minimum similarity threshold (default: 0.0) (default: `0.0`)
+- `--search-mode`: Search mode (default: Auto) (default: `Auto`)
+- `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
+- `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
+- `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)
+- `--output`, `-o`: Output file (overrides global) (default: `Sentinel.UNSET`)
+
+**`uipath context-grounding source-schema`**
+
+Show JSON source file formats for connection-backed indexes.
+
+    Use this to see the required fields for --source-file when creating
+    an index backed by Google Drive, OneDrive, Dropbox, or Confluence.
+
+    
+    Examples:
+        uipath context-grounding source-schema --type google_drive
+    
+
+Options:
+- `--type`: Show schema for a specific source type (omit to show all) (default: `Sentinel.UNSET`)
 
 ---
 

--- a/packages/uipath/src/uipath/_resources/SDK_REFERENCE.md
+++ b/packages/uipath/src/uipath/_resources/SDK_REFERENCE.md
@@ -113,6 +113,37 @@ sdk.attachments.upload_async(name: str, content: str | bytes | None=None, source
 
 ```
 
+### Automation Tracker
+
+Automation Tracker service
+
+```python
+# End tracking an operation within a transaction.
+sdk.automation_tracker.end_operation(transaction_id: str, operation_id: str, name: str, fingerprint: str, parent_operation: Optional[str]=None, status: <enum 'OperationStatus="OperationStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# End tracking an operation within a transaction (async).
+sdk.automation_tracker.end_operation_async(transaction_id: str, operation_id: str, name: str, fingerprint: str, parent_operation: Optional[str]=None, status: <enum 'OperationStatus="OperationStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# End tracking a business transaction.
+sdk.automation_tracker.end_transaction(transaction_id: str, name: str, reference: str, fingerprint: str, status: <enum 'TransactionStatus="TransactionStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# End tracking a business transaction (async).
+sdk.automation_tracker.end_transaction_async(transaction_id: str, name: str, reference: str, fingerprint: str, status: <enum 'TransactionStatus="TransactionStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# Start tracking an operation within a transaction.
+sdk.automation_tracker.start_operation(transaction_id: str, operation_id: str, name: str, fingerprint: str, parent_operation: Optional[str]=None, status: <enum 'OperationStatus="OperationStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# Start tracking an operation within a transaction (async).
+sdk.automation_tracker.start_operation_async(transaction_id: str, operation_id: str, name: str, fingerprint: str, parent_operation: Optional[str]=None, status: <enum 'OperationStatus="OperationStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# Start tracking a business transaction.
+sdk.automation_tracker.start_transaction(transaction_id: str, name: str, reference: str, fingerprint: str, status: <enum 'TransactionStatus="TransactionStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+# Start tracking a business transaction (async).
+sdk.automation_tracker.start_transaction_async(transaction_id: str, name: str, reference: str, fingerprint: str, status: <enum 'TransactionStatus="TransactionStatus.UNKNOWN", result: Optional[str]=None, attributes: Optional[Dict[str, str]]=None, timestamp: Optional[datetime.datetime]=None) -> None
+
+```
+
 ### Buckets
 
 Buckets service
@@ -240,11 +271,23 @@ sdk.context_grounding.add_to_index(name: str, blob_file_path: str, content_type:
 # Asynchronously add content to the index.
 sdk.context_grounding.add_to_index_async(name: str, blob_file_path: str, content_type: Optional[str]=None, content: Union[str, bytes, NoneType]=None, source_path: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None, ingest_data: bool=True) -> None
 
-# Create a new context grounding index.
-sdk.context_grounding.create_index(name: str, source: Union[uipath.platform.context_grounding.context_grounding_payloads.BucketSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.GoogleDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.DropboxSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.OneDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.ConfluenceSourceConfig], description: Optional[str]=None, advanced_ingestion: Optional[bool]=True, preprocessing_request: Optional[str]="#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest", folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
+# Create a new ephemeral context grounding index.
+sdk.context_grounding.create_ephemeral_index(usage: <enum 'EphemeralIndexUsage, attachments: List[str]) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
+
+# Create a new ephemeral context grounding index.
+sdk.context_grounding.create_ephemeral_index_async(usage: <enum 'EphemeralIndexUsage, attachments: List[str]) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
 
 # Create a new context grounding index.
-sdk.context_grounding.create_index_async(name: str, source: Union[uipath.platform.context_grounding.context_grounding_payloads.BucketSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.GoogleDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.DropboxSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.OneDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.ConfluenceSourceConfig], description: Optional[str]=None, advanced_ingestion: Optional[bool]=True, preprocessing_request: Optional[str]="#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest", folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
+sdk.context_grounding.create_index(name: str, source: Union[uipath.platform.context_grounding.context_grounding_payloads.BucketSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.GoogleDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.DropboxSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.OneDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.ConfluenceSourceConfig], description: Optional[str]=None, extraction_strategy: Optional[str]=None, embeddings_enabled: Optional[bool]=None, is_encrypted: Optional[bool]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
+
+# Create a new context grounding index.
+sdk.context_grounding.create_index_async(name: str, source: Union[uipath.platform.context_grounding.context_grounding_payloads.BucketSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.GoogleDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.DropboxSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.OneDriveSourceConfig, uipath.platform.context_grounding.context_grounding_payloads.ConfluenceSourceConfig], description: Optional[str]=None, extraction_strategy: Optional[str]=None, embeddings_enabled: Optional[bool]=None, is_encrypted: Optional[bool]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
+
+# Delete a context grounding index by its name.
+sdk.context_grounding.delete_by_name(name: str, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
+
+# Asynchronously delete a context grounding index by its name.
+sdk.context_grounding.delete_by_name_async(name: str, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
 
 # Delete a context grounding index.
 sdk.context_grounding.delete_index(index: uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
@@ -258,14 +301,38 @@ sdk.context_grounding.download_batch_transform_result(id: str, destination_path:
 # Asynchronously downloads the Batch Transform result file to the specified path.
 sdk.context_grounding.download_batch_transform_result_async(id: str, destination_path: str, validate_status: bool=True, index_name: str | None=None) -> None
 
+# Trigger ingestion on a context grounding index by its name.
+sdk.context_grounding.ingest_by_name(name: str, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
+
+# Asynchronously trigger ingestion on a context grounding index by its name.
+sdk.context_grounding.ingest_by_name_async(name: str, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
+
 # Ingest data into the context grounding index.
 sdk.context_grounding.ingest_data(index: uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
 
 # Asynchronously ingest data into the context grounding index.
 sdk.context_grounding.ingest_data_async(index: uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> None
 
+# List all context grounding indexes in a folder.
+sdk.context_grounding.list(folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex]
+
+# Asynchronously list all context grounding indexes in a folder.
+sdk.context_grounding.list_async(folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex]
+
+# List all context grounding indexes in a folder.
+sdk.context_grounding.list_indexes(folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex]
+
+# Asynchronously list all context grounding indexes in a folder.
+sdk.context_grounding.list_indexes_async(folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex]
+
 # Retrieve context grounding index information by its name.
 sdk.context_grounding.retrieve(name: str, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
+
+# Retrieve all context grounding indexes across all folders.
+sdk.context_grounding.retrieve_across_folders(name: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex]
+
+# Asynchronously retrieve all context grounding indexes across all folders.
+sdk.context_grounding.retrieve_across_folders_async(name: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex]
 
 # Asynchronously retrieve context grounding index information by its name.
 sdk.context_grounding.retrieve_async(name: str, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding_index.ContextGroundingIndex
@@ -289,22 +356,40 @@ sdk.context_grounding.retrieve_deep_rag(id: str, index_name: str | None=None) ->
 sdk.context_grounding.retrieve_deep_rag_async(id: str, index_name: str | None=None) -> uipath.platform.context_grounding.context_grounding.DeepRagResponse
 
 # Search for contextual information within a specific index.
-sdk.context_grounding.search(name: str, query: str, number_of_results: int=10, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding.ContextGroundingQueryResponse]
+sdk.context_grounding.search(name: str, query: str, number_of_results: int=10, threshold: Optional[float]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding.ContextGroundingQueryResponse]
 
 # Search asynchronously for contextual information within a specific index.
-sdk.context_grounding.search_async(name: str, query: str, number_of_results: int=10, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding.ContextGroundingQueryResponse]
+sdk.context_grounding.search_async(name: str, query: str, number_of_results: int=10, threshold: Optional[float]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> typing.List[uipath.platform.context_grounding.context_grounding.ContextGroundingQueryResponse]
 
 # Starts a Batch Transform, task on the targeted index.
-sdk.context_grounding.start_batch_transform(name: str, index_name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], output_columns: list[uipath.platform.context_grounding.context_grounding.BatchTransformOutputColumn], storage_bucket_folder_path_prefix: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, enable_web_search_grounding: bool=False, folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.BatchTransformCreationResponse
+sdk.context_grounding.start_batch_transform(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], output_columns: List[uipath.platform.context_grounding.context_grounding.BatchTransformOutputColumn], storage_bucket_folder_path_prefix: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, target_file_name: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, enable_web_search_grounding: bool=False, index_name: str | None=None, index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None, folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.BatchTransformCreationResponse
 
 # Asynchronously starts a Batch Transform, task on the targeted index.
-sdk.context_grounding.start_batch_transform_async(name: str, index_name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], output_columns: list[uipath.platform.context_grounding.context_grounding.BatchTransformOutputColumn], storage_bucket_folder_path_prefix: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, enable_web_search_grounding: bool=False, folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.BatchTransformCreationResponse
+sdk.context_grounding.start_batch_transform_async(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], output_columns: List[uipath.platform.context_grounding.context_grounding.BatchTransformOutputColumn], storage_bucket_folder_path_prefix: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, target_file_name: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, enable_web_search_grounding: bool=False, index_name: str | None=None, index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None, folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.BatchTransformCreationResponse
+
+# Asynchronously starts a Batch Transform, task on the targeted index.
+sdk.context_grounding.start_batch_transform_ephemeral(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], output_columns: List[uipath.platform.context_grounding.context_grounding.BatchTransformOutputColumn], storage_bucket_folder_path_prefix: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, enable_web_search_grounding: bool=False, index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None) -> uipath.platform.context_grounding.context_grounding.BatchTransformCreationResponse
+
+# Asynchronously starts a Batch Transform, task on the targeted index.
+sdk.context_grounding.start_batch_transform_ephemeral_async(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], output_columns: List[uipath.platform.context_grounding.context_grounding.BatchTransformOutputColumn], storage_bucket_folder_path_prefix: Annotated[str | None, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]=None, enable_web_search_grounding: bool=False, index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None) -> uipath.platform.context_grounding.context_grounding.BatchTransformCreationResponse
 
 # Starts a Deep RAG task on the targeted index.
-sdk.context_grounding.start_deep_rag(name: str, index_name: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])], prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
+sdk.context_grounding.start_deep_rag(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", index_name: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None, index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None, folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
 
 # Asynchronously starts a Deep RAG task on the targeted index.
-sdk.context_grounding.start_deep_rag_async(name: str, index_name: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])], prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
+sdk.context_grounding.start_deep_rag_async(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", index_name: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None, index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None, folder_key: str | None=None, folder_path: str | None=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
+
+# Asynchronously starts a Deep RAG task on the targeted index.
+sdk.context_grounding.start_deep_rag_ephemeral(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
+
+# Asynchronously starts a Deep RAG task on the targeted index.
+sdk.context_grounding.start_deep_rag_ephemeral_async(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
+
+# Perform a unified search on a context grounding index.
+sdk.context_grounding.unified_search(name: str, query: str, search_mode: <enum 'SearchMode="SearchMode.AUTO", number_of_results: int=10, threshold: float=0.0, scope: Optional[uipath.platform.context_grounding.context_grounding.UnifiedSearchScope]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding.UnifiedQueryResult
+
+# Asynchronously perform a unified search on a context grounding index.
+sdk.context_grounding.unified_search_async(name: str, query: str, search_mode: <enum 'SearchMode="SearchMode.AUTO", number_of_results: int=10, threshold: float=0.0, scope: Optional[uipath.platform.context_grounding.context_grounding.UnifiedSearchScope]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding.UnifiedQueryResult
 
 ```
 
@@ -324,28 +409,28 @@ Documents service
 
 ```python
 # Classify a document using a DU Modern project.
-sdk.documents.classify(project_type: <enum 'ProjectType, tag: Optional[str]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None) -> typing.List[uipath.platform.documents.documents.ClassificationResult]
+sdk.documents.classify(project_type: <enum 'ProjectType, tag: Optional[str]=None, version: Optional[int]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None) -> typing.List[uipath.platform.documents.documents.ClassificationResult]
 
 # Asynchronously version of the [`classify`][uipath.platform.documents._documents_service.DocumentsService.classify] method.
-sdk.documents.classify_async(project_type: <enum 'ProjectType, tag: Optional[str]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None) -> typing.List[uipath.platform.documents.documents.ClassificationResult]
+sdk.documents.classify_async(project_type: <enum 'ProjectType, tag: Optional[str]=None, version: Optional[int]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None) -> typing.List[uipath.platform.documents.documents.ClassificationResult]
 
 # Create a validate classification action for a document based on the classification results. More details about validation actions can be found in the [official documentation](https://docs.uipath.com/ixp/automation-cloud/latest/user-guide/validating-classifications).
-sdk.documents.create_validate_classification_action(action_title: str, action_priority: <enum 'ActionPriority, action_catalog: str, action_folder: str, storage_bucket_name: str, storage_bucket_directory_path: str, classification_results: List[uipath.platform.documents.documents.ClassificationResult]) -> uipath.platform.documents.documents.ValidateClassificationAction
+sdk.documents.create_validate_classification_action(classification_results: List[uipath.platform.documents.documents.ClassificationResult], action_title: str, action_priority: Optional[uipath.platform.documents.documents.ActionPriority]=None, action_catalog: Optional[str]=None, action_folder: Optional[str]=None, storage_bucket_name: Optional[str]=None, storage_bucket_directory_path: Optional[str]=None) -> uipath.platform.documents.documents.ValidateClassificationAction
 
 # Asynchronous version of the [`create_validation_action`][uipath.platform.documents._documents_service.DocumentsService.create_validate_classification_action] method.
-sdk.documents.create_validate_classification_action_async(action_title: str, action_priority: <enum 'ActionPriority, action_catalog: str, action_folder: str, storage_bucket_name: str, storage_bucket_directory_path: str, classification_results: List[uipath.platform.documents.documents.ClassificationResult]) -> uipath.platform.documents.documents.ValidateClassificationAction
+sdk.documents.create_validate_classification_action_async(classification_results: List[uipath.platform.documents.documents.ClassificationResult], action_title: str, action_priority: Optional[uipath.platform.documents.documents.ActionPriority]=None, action_catalog: Optional[str]=None, action_folder: Optional[str]=None, storage_bucket_name: Optional[str]=None, storage_bucket_directory_path: Optional[str]=None) -> uipath.platform.documents.documents.ValidateClassificationAction
 
 # Create a validate extraction action for a document based on the extraction response. More details about validation actions can be found in the [official documentation](https://docs.uipath.com/ixp/automation-cloud/latest/user-guide/validating-extractions).
-sdk.documents.create_validate_extraction_action(action_title: str, action_priority: <enum 'ActionPriority, action_catalog: str, action_folder: str, storage_bucket_name: str, storage_bucket_directory_path: str, extraction_response: uipath.platform.documents.documents.ExtractionResponse) -> uipath.platform.documents.documents.ValidateExtractionAction
+sdk.documents.create_validate_extraction_action(extraction_response: uipath.platform.documents.documents.ExtractionResponse, action_title: str, action_priority: Optional[uipath.platform.documents.documents.ActionPriority]=None, action_catalog: Optional[str]=None, action_folder: Optional[str]=None, storage_bucket_name: Optional[str]=None, storage_bucket_directory_path: Optional[str]=None) -> uipath.platform.documents.documents.ValidateExtractionAction
 
 # Asynchronous version of the [`create_validation_action`][uipath.platform.documents._documents_service.DocumentsService.create_validate_extraction_action] method.
-sdk.documents.create_validate_extraction_action_async(action_title: str, action_priority: <enum 'ActionPriority, action_catalog: str, action_folder: str, storage_bucket_name: str, storage_bucket_directory_path: str, extraction_response: uipath.platform.documents.documents.ExtractionResponse) -> uipath.platform.documents.documents.ValidateExtractionAction
+sdk.documents.create_validate_extraction_action_async(extraction_response: uipath.platform.documents.documents.ExtractionResponse, action_title: str, action_priority: Optional[uipath.platform.documents.documents.ActionPriority]=None, action_catalog: Optional[str]=None, action_folder: Optional[str]=None, storage_bucket_name: Optional[str]=None, storage_bucket_directory_path: Optional[str]=None) -> uipath.platform.documents.documents.ValidateExtractionAction
 
 # Extract predicted data from a document using an DU Modern/IXP project.
-sdk.documents.extract(tag: Optional[str]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None, classification_result: Optional[uipath.platform.documents.documents.ClassificationResult]=None, project_type: Optional[uipath.platform.documents.documents.ProjectType]=None, document_type_name: Optional[str]=None) -> typing.Union[uipath.platform.documents.documents.ExtractionResponse, uipath.platform.documents.documents.ExtractionResponseIXP]
+sdk.documents.extract(tag: Optional[str]=None, version: Optional[int]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None, classification_result: Optional[uipath.platform.documents.documents.ClassificationResult]=None, project_type: Optional[uipath.platform.documents.documents.ProjectType]=None, document_type_name: Optional[str]=None) -> typing.Union[uipath.platform.documents.documents.ExtractionResponse, uipath.platform.documents.documents.ExtractionResponseIXP]
 
 # Asynchronously version of the [`extract`][uipath.platform.documents._documents_service.DocumentsService.extract] method.
-sdk.documents.extract_async(tag: Optional[str]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None, classification_result: Optional[uipath.platform.documents.documents.ClassificationResult]=None, project_type: Optional[uipath.platform.documents.documents.ProjectType]=None, document_type_name: Optional[str]=None) -> typing.Union[uipath.platform.documents.documents.ExtractionResponse, uipath.platform.documents.documents.ExtractionResponseIXP]
+sdk.documents.extract_async(tag: Optional[str]=None, version: Optional[int]=None, project_name: Optional[str]=None, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None, classification_result: Optional[uipath.platform.documents.documents.ClassificationResult]=None, project_type: Optional[uipath.platform.documents.documents.ProjectType]=None, document_type_name: Optional[str]=None) -> typing.Union[uipath.platform.documents.documents.ExtractionResponse, uipath.platform.documents.documents.ExtractionResponseIXP]
 
 # Get the result of a validate classification action.
 sdk.documents.get_validate_classification_result(validation_action: uipath.platform.documents.documents.ValidateClassificationAction) -> typing.List[uipath.platform.documents.documents.ClassificationResult]
@@ -365,11 +450,23 @@ sdk.documents.retrieve_ixp_extraction_result(project_id: str, tag: str, operatio
 # Asynchronous version of the [`retrieve_ixp_extraction_result`][uipath.platform.documents._documents_service.DocumentsService.retrieve_ixp_extraction_result] method.
 sdk.documents.retrieve_ixp_extraction_result_async(project_id: str, tag: str, operation_id: str) -> uipath.platform.documents.documents.ExtractionResponseIXP
 
+# Retrieve the result of an IXP create validate extraction action operation (single-shot, non-blocking).
+sdk.documents.retrieve_ixp_extraction_validation_result(project_id: str, tag: str, operation_id: str) -> uipath.platform.documents.documents.ValidateExtractionAction
+
+# Asynchronous version of the [`retrieve_ixp_extraction_validation_result`][uipath.platform.documents._documents_service.DocumentsService.retrieve_ixp_extraction_validation_result] method.
+sdk.documents.retrieve_ixp_extraction_validation_result_async(project_id: str, tag: str, operation_id: str) -> uipath.platform.documents.documents.ValidateExtractionAction
+
 # Start an IXP extraction process without waiting for results (non-blocking).
 sdk.documents.start_ixp_extraction(project_name: str, tag: str, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None) -> uipath.platform.documents.documents.StartExtractionResponse
 
 # Asynchronous version of the [`start_ixp_extraction`][uipath.platform.documents._documents_service.DocumentsService.start_ixp_extraction] method.
 sdk.documents.start_ixp_extraction_async(project_name: str, tag: str, file: Union[IO[bytes], bytes, str, NoneType]=None, file_path: Optional[str]=None) -> uipath.platform.documents.documents.StartExtractionResponse
+
+# Start an IXP extraction validation action without waiting for results (non-blocking).
+sdk.documents.start_ixp_extraction_validation(extraction_response: uipath.platform.documents.documents.ExtractionResponseIXP, action_title: str, action_catalog: Optional[str]=None, action_priority: Optional[uipath.platform.documents.documents.ActionPriority]=None, action_folder: Optional[str]=None, storage_bucket_name: Optional[str]=None, storage_bucket_directory_path: Optional[str]=None) -> uipath.platform.documents.documents.StartExtractionValidationResponse
+
+# Asynchronous version of the [`start_ixp_extraction_validation`][uipath.platform.documents._documents_service.DocumentsService.start_ixp_extraction_validation] method.
+sdk.documents.start_ixp_extraction_validation_async(extraction_response: uipath.platform.documents.documents.ExtractionResponseIXP, action_title: str, action_catalog: Optional[str]=None, action_priority: Optional[uipath.platform.documents.documents.ActionPriority]=None, action_folder: Optional[str]=None, storage_bucket_name: Optional[str]=None, storage_bucket_directory_path: Optional[str]=None) -> uipath.platform.documents.documents.StartExtractionValidationResponse
 
 ```
 
@@ -401,6 +498,12 @@ sdk.entities.list_records(entity_key: str, schema: Optional[Type[Any]]=None, sta
 
 # Asynchronously list records from an entity with optional pagination and schema validation.
 sdk.entities.list_records_async(entity_key: str, schema: Optional[Type[Any]]=None, start: Optional[int]=None, limit: Optional[int]=None) -> typing.List[uipath.platform.entities.entities.EntityRecord]
+
+# Query entity records using a validated SQL query.
+sdk.entities.query_entity_records(sql_query: str, routing_context: Optional[uipath.platform.entities.entities.QueryRoutingOverrideContext]=None) -> typing.List[typing.Dict[str, typing.Any]]
+
+# Asynchronously query entity records using a validated SQL query.
+sdk.entities.query_entity_records_async(sql_query: str, routing_context: Optional[uipath.platform.entities.entities.QueryRoutingOverrideContext]=None) -> typing.List[typing.Dict[str, typing.Any]]
 
 # Retrieve an entity by its key.
 sdk.entities.retrieve(entity_key: str) -> uipath.platform.entities.entities.Entity
@@ -566,16 +669,29 @@ sdk.mcp.retrieve_async(slug: str, folder_path: str | None=None) -> uipath.platfo
 
 ```
 
+### Orchestrator Setup
+
+Orchestrator Setup service
+
+```python
+# Fire-and-forget POST requests to enable first run for StudioWeb.
+sdk.orchestrator_setup.enable_first_run() -> None
+
+# Fire-and-forget POST requests to enable first run for StudioWeb.
+sdk.orchestrator_setup.enable_first_run_async() -> None
+
+```
+
 ### Processes
 
 Processes service
 
 ```python
 # Start execution of a process by its name.
-sdk.processes.invoke(name: str, input_arguments: Optional[Dict[str, Any]]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.orchestrator.job.Job
+sdk.processes.invoke(name: str, input_arguments: Optional[Dict[str, Any]]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None, attachments: Optional[list[uipath.platform.attachments.attachments.Attachment]]=None, parent_operation_id: Optional[str]=None, **kwargs) -> uipath.platform.orchestrator.job.Job
 
 # Asynchronously start execution of a process by its name.
-sdk.processes.invoke_async(name: str, input_arguments: Optional[Dict[str, Any]]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.orchestrator.job.Job
+sdk.processes.invoke_async(name: str, input_arguments: Optional[Dict[str, Any]]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None, attachments: Optional[list[uipath.platform.attachments.attachments.Attachment]]=None, parent_operation_id: Optional[str]=None, **kwargs) -> uipath.platform.orchestrator.job.Job
 
 ```
 
@@ -585,40 +701,59 @@ Queues service
 
 ```python
 # Completes a transaction item with the specified result.
-sdk.queues.complete_transaction_item(transaction_key: str, result: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItemResult]) -> httpx.Response
+sdk.queues.complete_transaction_item(transaction_key: str, result: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItemResult], queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Asynchronously completes a transaction item with the specified result.
-sdk.queues.complete_transaction_item_async(transaction_key: str, result: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItemResult]) -> httpx.Response
+sdk.queues.complete_transaction_item_async(transaction_key: str, result: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItemResult], queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Creates a new queue item in the Orchestrator.
-sdk.queues.create_item(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem]) -> httpx.Response
+sdk.queues.create_item(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem], queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Asynchronously creates a new queue item in the Orchestrator.
-sdk.queues.create_item_async(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem]) -> httpx.Response
+sdk.queues.create_item_async(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem], queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Creates multiple queue items in bulk.
-sdk.queues.create_items(items: List[Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem]], queue_name: str, commit_type: <enum 'CommitType) -> httpx.Response
+sdk.queues.create_items(items: List[Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem]], queue_name: str, commit_type: <enum 'CommitType, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Asynchronously creates multiple queue items in bulk.
-sdk.queues.create_items_async(items: List[Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem]], queue_name: str, commit_type: <enum 'CommitType) -> httpx.Response
+sdk.queues.create_items_async(items: List[Union[Dict[str, Any], uipath.platform.orchestrator.queues.QueueItem]], queue_name: str, commit_type: <enum 'CommitType, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Creates a new transaction item in a queue.
-sdk.queues.create_transaction_item(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItem], no_robot: bool=False) -> httpx.Response
+sdk.queues.create_transaction_item(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItem], queue_name: Optional[str]=None, no_robot: bool=False, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Asynchronously creates a new transaction item in a queue.
-sdk.queues.create_transaction_item_async(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItem], no_robot: bool=False) -> httpx.Response
+sdk.queues.create_transaction_item_async(item: Union[Dict[str, Any], uipath.platform.orchestrator.queues.TransactionItem], queue_name: Optional[str]=None, no_robot: bool=False, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Retrieves a list of queue items from the Orchestrator.
-sdk.queues.list_items() -> httpx.Response
+sdk.queues.list_items(queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Asynchronously retrieves a list of queue items from the Orchestrator.
-sdk.queues.list_items_async() -> httpx.Response
+sdk.queues.list_items_async(queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Updates the progress of a transaction item.
-sdk.queues.update_progress_of_transaction_item(transaction_key: str, progress: str) -> httpx.Response
+sdk.queues.update_progress_of_transaction_item(transaction_key: str, progress: str, queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
 
 # Asynchronously updates the progress of a transaction item.
-sdk.queues.update_progress_of_transaction_item_async(transaction_key: str, progress: str) -> httpx.Response
+sdk.queues.update_progress_of_transaction_item_async(transaction_key: str, progress: str, queue_name: Optional[str]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> httpx.Response
+
+```
+
+### Remote A2A
+
+Remote A2A service
+
+```python
+# List Remote A2A agents.
+sdk.remote_a2a.list(top: int | None=None, skip: int | None=None, search: str | None=None, folder_path: str | None=None) -> typing.List[uipath.platform.agenthub.remote_a2a.RemoteA2aAgent]
+
+# Asynchronously list Remote A2A agents.
+sdk.remote_a2a.list_async(top: int | None=None, skip: int | None=None, search: str | None=None, folder_path: str | None=None) -> typing.List[uipath.platform.agenthub.remote_a2a.RemoteA2aAgent]
+
+# Retrieve a specific Remote A2A agent by slug.
+sdk.remote_a2a.retrieve(slug: str, folder_path: str | None=None) -> uipath.platform.agenthub.remote_a2a.RemoteA2aAgent
+
+# Asynchronously retrieve a specific Remote A2A agent by slug.
+sdk.remote_a2a.retrieve_async(slug: str, folder_path: str | None=None) -> uipath.platform.agenthub.remote_a2a.RemoteA2aAgent
 
 ```
 
@@ -653,16 +788,16 @@ Tasks service
 
 ```python
 # Creates a new task synchronously.
-sdk.tasks.create(title: str, data: Optional[Dict[str, Any]]=None, app_name: Optional[str]=None, app_key: Optional[str]=None, app_folder_path: Optional[str]=None, app_folder_key: Optional[str]=None, assignee: Optional[str]=None) -> uipath.platform.action_center.tasks.Task
+sdk.tasks.create(title: str, data: Optional[Dict[str, Any]]=None, app_name: Optional[str]=None, app_key: Optional[str]=None, app_folder_path: Optional[str]=None, app_folder_key: Optional[str]=None, assignee: Optional[str]=None, recipient: Optional[uipath.platform.action_center.tasks.TaskRecipient]=None, priority: Optional[str]=None, labels: Optional[List[str]]=None, is_actionable_message_enabled: Optional[bool]=None, actionable_message_metadata: Optional[Dict[str, Any]]=None, source_name: str="Agent") -> uipath.platform.action_center.tasks.Task
 
 # Creates a new action asynchronously.
-sdk.tasks.create_async(title: str, data: Optional[Dict[str, Any]]=None, app_name: Optional[str]=None, app_key: Optional[str]=None, app_folder_path: Optional[str]=None, app_folder_key: Optional[str]=None, assignee: Optional[str]=None) -> uipath.platform.action_center.tasks.Task
+sdk.tasks.create_async(title: str, data: Optional[Dict[str, Any]]=None, app_name: Optional[str]=None, app_key: Optional[str]=None, app_folder_path: Optional[str]=None, app_folder_key: Optional[str]=None, assignee: Optional[str]=None, recipient: Optional[uipath.platform.action_center.tasks.TaskRecipient]=None, priority: Optional[str]=None, labels: Optional[List[str]]=None, is_actionable_message_enabled: Optional[bool]=None, actionable_message_metadata: Optional[Dict[str, Any]]=None, source_name: str="Agent") -> uipath.platform.action_center.tasks.Task
 
 # Retrieves a task by its key synchronously.
-sdk.tasks.retrieve(action_key: str, app_folder_path: str="", app_folder_key: str="", app_name: str | None=None) -> uipath.platform.action_center.tasks.Task
+sdk.tasks.retrieve(action_key: str, app_folder_path: Optional[str]=None, app_folder_key: Optional[str]=None, app_name: str | None=None) -> uipath.platform.action_center.tasks.Task
 
 # Retrieves a task by its key asynchronously.
-sdk.tasks.retrieve_async(action_key: str, app_folder_path: str="", app_folder_key: str="", app_name: str | None=None) -> uipath.platform.action_center.tasks.Task
+sdk.tasks.retrieve_async(action_key: str, app_folder_path: Optional[str]=None, app_folder_key: Optional[str]=None, app_name: str | None=None) -> uipath.platform.action_center.tasks.Task
 
 ```
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.39"
+version = "2.10.40"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This pull request makes a minor update to the `GenericResourceOverwrite` class in `_bindings.py` by adding support for a new resource type. Specifically, it allows the `resource_type` field to accept `"entity"` as a valid value.

- Added `"entity"` to the list of allowed values for the `resource_type` field in the `GenericResourceOverwrite` class (`_bindings.py`).