### PR TITLE
feat(guardrails): add decorator framework to uipath-platform [AL-288]

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.10"
+version = "0.5.11"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/guardrails/guardrails.py
+++ b/packages/uipath-core/src/uipath/core/guardrails/guardrails.py
@@ -227,7 +227,7 @@ class BaseGuardrail(BaseModel):
     name: str
     description: str | None = None
     enabled_for_evals: bool = Field(True, alias="enabledForEvals")
-    selector: GuardrailSelector
+    selector: GuardrailSelector | None = None
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.19"
+version = "0.1.20"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/__init__.py
@@ -14,6 +14,27 @@ from uipath.core.guardrails import (
 )
 
 from ._guardrails_service import GuardrailsService
+from .decorators import (
+    BlockAction,
+    BuiltInGuardrailValidator,
+    CustomGuardrailValidator,
+    CustomValidator,
+    GuardrailAction,
+    GuardrailBlockException,
+    GuardrailExclude,
+    GuardrailExecutionStage,
+    GuardrailTargetAdapter,
+    GuardrailValidatorBase,
+    LogAction,
+    LoggingSeverityLevel,
+    PIIDetectionEntity,
+    PIIDetectionEntityType,
+    PIIValidator,
+    PromptInjectionValidator,
+    RuleFunction,
+    guardrail,
+    register_guardrail_adapter,
+)
 from .guardrails import (
     BuiltInValidatorGuardrail,
     EnumListParameterValue,
@@ -22,7 +43,9 @@ from .guardrails import (
 )
 
 __all__ = [
+    # Service
     "GuardrailsService",
+    # Guardrail models
     "BuiltInValidatorGuardrail",
     "GuardrailType",
     "GuardrailValidationResultType",
@@ -33,4 +56,24 @@ __all__ = [
     "GuardrailValidationResult",
     "EnumListParameterValue",
     "MapEnumParameterValue",
+    # Decorator framework
+    "guardrail",
+    "GuardrailValidatorBase",
+    "BuiltInGuardrailValidator",
+    "CustomGuardrailValidator",
+    "PIIValidator",
+    "PromptInjectionValidator",
+    "CustomValidator",
+    "RuleFunction",
+    "PIIDetectionEntity",
+    "PIIDetectionEntityType",
+    "GuardrailExecutionStage",
+    "GuardrailAction",
+    "LogAction",
+    "BlockAction",
+    "LoggingSeverityLevel",
+    "GuardrailBlockException",
+    "GuardrailExclude",
+    "GuardrailTargetAdapter",
+    "register_guardrail_adapter",
 ]

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/__init__.py
@@ -1,0 +1,52 @@
+"""Guardrail decorator framework for UiPath Platform.
+
+Provides the ``@guardrail`` decorator, built-in validators, actions, and an
+adapter registry that framework integrations (e.g. *uipath-langchain*) use to
+teach the decorator how to wrap their specific object types.
+"""
+
+from ._actions import BlockAction, LogAction, LoggingSeverityLevel
+from ._core import GuardrailExclude
+from ._enums import GuardrailExecutionStage, PIIDetectionEntityType
+from ._exceptions import GuardrailBlockException
+from ._guardrail import guardrail
+from ._models import GuardrailAction, PIIDetectionEntity
+from ._registry import GuardrailTargetAdapter, register_guardrail_adapter
+from .validators import (
+    BuiltInGuardrailValidator,
+    CustomGuardrailValidator,
+    CustomValidator,
+    GuardrailValidatorBase,
+    PIIValidator,
+    PromptInjectionValidator,
+    RuleFunction,
+)
+
+__all__ = [
+    # Decorator
+    "guardrail",
+    # Validators
+    "GuardrailValidatorBase",
+    "BuiltInGuardrailValidator",
+    "CustomGuardrailValidator",
+    "PIIValidator",
+    "PromptInjectionValidator",
+    "CustomValidator",
+    "RuleFunction",
+    # Models & enums
+    "PIIDetectionEntity",
+    "PIIDetectionEntityType",
+    "GuardrailExecutionStage",
+    "GuardrailAction",
+    # Actions
+    "LogAction",
+    "BlockAction",
+    "LoggingSeverityLevel",
+    # Exception
+    "GuardrailBlockException",
+    # Exclude marker
+    "GuardrailExclude",
+    # Adapter registry
+    "GuardrailTargetAdapter",
+    "register_guardrail_adapter",
+]

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_actions.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_actions.py
@@ -1,0 +1,82 @@
+"""Built-in GuardrailAction implementations."""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+from uipath.core.guardrails import (
+    GuardrailValidationResult,
+    GuardrailValidationResultType,
+)
+
+from ._exceptions import GuardrailBlockException
+from ._models import GuardrailAction
+
+
+class LoggingSeverityLevel(int, Enum):
+    """Logging severity level for :class:`LogAction`."""
+
+    ERROR = logging.ERROR
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    DEBUG = logging.DEBUG
+
+
+@dataclass
+class LogAction(GuardrailAction):
+    """Log guardrail violations without stopping execution.
+
+    Args:
+        severity_level: Python logging level. Defaults to ``WARNING``.
+        message: Custom log message. If omitted, the validation reason is used.
+    """
+
+    severity_level: LoggingSeverityLevel = LoggingSeverityLevel.WARNING
+    message: Optional[str] = None
+
+    def handle_validation_result(
+        self,
+        result: GuardrailValidationResult,
+        data: str | dict[str, Any],
+        guardrail_name: str,
+    ) -> str | dict[str, Any] | None:
+        """Log the violation and return ``None`` (no data modification)."""
+        if result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+            msg = self.message or f"Failed: {result.reason}"
+            logging.getLogger(__name__).log(
+                self.severity_level,
+                "[GUARDRAIL] [%s] %s",
+                guardrail_name,
+                msg,
+            )
+        return None
+
+
+@dataclass
+class BlockAction(GuardrailAction):
+    """Block execution by raising :class:`GuardrailBlockException`.
+
+    Framework adapters catch ``GuardrailBlockException`` at the wrapper boundary
+    and convert it to their own runtime error type.
+
+    Args:
+        title: Exception title. Defaults to a message derived from the guardrail name.
+        detail: Exception detail. Defaults to the validation reason.
+    """
+
+    title: Optional[str] = None
+    detail: Optional[str] = None
+
+    def handle_validation_result(
+        self,
+        result: GuardrailValidationResult,
+        data: str | dict[str, Any],
+        guardrail_name: str,
+    ) -> str | dict[str, Any] | None:
+        """Raise :class:`GuardrailBlockException` when validation fails."""
+        if result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+            title = self.title or f"Guardrail [{guardrail_name}] blocked execution"
+            detail = self.detail or result.reason or "Guardrail validation failed"
+            raise GuardrailBlockException(title=title, detail=detail)
+        return None

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_core.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_core.py
@@ -1,0 +1,302 @@
+"""Core framework-agnostic utilities for guardrail decorators."""
+
+import ast
+import dataclasses
+import inspect
+import json
+import logging
+from typing import Annotated, Any, Callable, get_args, get_origin, get_type_hints
+
+from uipath.core.guardrails import (
+    GuardrailValidationResult,
+)
+
+from ._enums import GuardrailExecutionStage
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GuardrailExclude marker
+# ---------------------------------------------------------------------------
+
+
+class GuardrailExclude:
+    """Marker to exclude a parameter from guardrail input serialization.
+
+    Use with :data:`typing.Annotated` to prevent a specific function parameter
+    from being collected into the guardrail evaluation payload::
+
+        async def process(
+            text: str,
+            config: Annotated[dict, GuardrailExclude()],
+        ) -> str: ...
+    """
+
+
+# ---------------------------------------------------------------------------
+# Evaluator type alias
+# ---------------------------------------------------------------------------
+
+_EvaluatorFn = Callable[
+    [
+        "str | dict[str, Any]",  # data
+        GuardrailExecutionStage,  # stage
+        "dict[str, Any] | None",  # input_data
+        "dict[str, Any] | None",  # output_data
+    ],
+    GuardrailValidationResult,
+]
+"""Type alias for the unified evaluation callable used by all wrappers."""
+
+
+# ---------------------------------------------------------------------------
+# Evaluator factory
+# ---------------------------------------------------------------------------
+
+
+def _make_evaluator(
+    validator: Any,
+    name: str,
+    description: str | None,
+    enabled_for_evals: bool,
+) -> _EvaluatorFn:
+    """Return a unified evaluation callable.
+
+    Delegates to ``validator.run()`` which each validator subclass implements
+    (:class:`BuiltInGuardrailValidator` hits the UiPath API;
+    :class:`CustomGuardrailValidator` runs a local Python rule).
+
+    Args:
+        validator: :class:`GuardrailValidatorBase` instance.
+        name: Guardrail name — forwarded to ``validator.run()`` on each call.
+        description: Optional description — forwarded to ``validator.run()``.
+        enabled_for_evals: Whether active in evaluation scenarios.
+
+    Returns:
+        Callable with signature ``(data, stage, input_data, output_data)``.
+    """
+
+    def _eval(
+        data: str | dict[str, Any],
+        stage: GuardrailExecutionStage,
+        input_data: dict[str, Any] | None,
+        output_data: dict[str, Any] | None,
+    ) -> GuardrailValidationResult:
+        return validator.run(
+            name, description, enabled_for_evals, data, stage, input_data, output_data
+        )
+
+    return _eval
+
+
+# ---------------------------------------------------------------------------
+# Parameter introspection
+# ---------------------------------------------------------------------------
+
+
+def _get_excluded_params(func: Any) -> set[str]:
+    """Return parameter names annotated with :class:`GuardrailExclude`.
+
+    Args:
+        func: Callable to inspect.
+
+    Returns:
+        Set of parameter names that should be excluded from guardrail input.
+    """
+    try:
+        hints = get_type_hints(func, include_extras=True)
+    except Exception:
+        return set()
+    excluded: set[str] = set()
+    for name, hint in hints.items():
+        if get_origin(hint) is Annotated:
+            for meta in get_args(hint)[1:]:
+                if isinstance(meta, GuardrailExclude):
+                    excluded.add(name)
+    return excluded
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialize_value(value: Any) -> Any:
+    """Serialize *value* to a JSON-compatible type for guardrail evaluation.
+
+    Pydantic models → ``model_dump()``, dataclasses → ``asdict()``,
+    primitives → as-is, everything else → ``str()``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {k: _serialize_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialize_value(v) for v in value]
+    # Pydantic v2
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    # Pydantic v1
+    if hasattr(value, "dict") and callable(value.dict):
+        try:
+            return value.dict()
+        except Exception:
+            pass
+    # dataclasses
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    return str(value)
+
+
+def _collect_input(
+    bound: inspect.BoundArguments,
+    excluded: set[str],
+) -> dict[str, Any]:
+    """Collect non-excluded function parameters into a guardrail input dict.
+
+    Args:
+        bound: Bound arguments from ``inspect.Signature.bind()``.
+        excluded: Parameter names to skip.
+
+    Returns:
+        ``{param_name: serialized_value}`` for all non-excluded parameters.
+    """
+    result: dict[str, Any] = {}
+    for name, value in bound.arguments.items():
+        if name in excluded or name in ("self", "cls"):
+            continue
+        result[name] = _serialize_value(value)
+    return result
+
+
+def _collect_output(return_value: Any) -> dict[str, Any]:
+    """Serialize a function return value into a dict for guardrail evaluation.
+
+    Args:
+        return_value: The value returned by the wrapped function.
+
+    Returns:
+        A ``dict`` representation suitable for guardrail evaluation.
+    """
+    serialized = _serialize_value(return_value)
+    if isinstance(serialized, dict):
+        return serialized
+    return {"return": serialized}
+
+
+def _reconstruct_output(original: Any, modified: Any) -> Any:
+    """Reconstruct a return value from a guardrail-modified payload.
+
+    Args:
+        original: The original return value (used to determine target type).
+        modified: The modified value returned by the guardrail action.
+
+    Returns:
+        Reconstructed value of the same type as *original* where possible.
+    """
+    if modified is None:
+        return original
+    # Pydantic v2 model + dict modification → reconstruct via model_validate
+    if hasattr(original, "model_validate") and isinstance(modified, dict):
+        try:
+            return type(original).model_validate(modified)
+        except Exception:
+            pass
+    # Pydantic v1
+    if hasattr(original, "parse_obj") and isinstance(modified, dict):
+        try:
+            return type(original).parse_obj(modified)
+        except Exception:
+            pass
+    return modified
+
+
+def _apply_pre_modification(
+    bound: inspect.BoundArguments,
+    modified: Any,
+    excluded: set[str],
+) -> None:
+    """Apply guardrail PRE-stage modifications back to bound function arguments.
+
+    If the action returned a modified dict, keys matching non-excluded parameters
+    are updated in-place. If the action returned a plain string and there is exactly
+    one non-excluded parameter, that parameter is updated.
+
+    Args:
+        bound: Bound arguments to mutate in-place.
+        modified: Value returned by the guardrail action.
+        excluded: Parameter names that were excluded from evaluation.
+    """
+    if modified is None:
+        return
+    non_excluded = [
+        n for n in bound.arguments if n not in excluded and n not in ("self", "cls")
+    ]
+    if isinstance(modified, dict):
+        for name in non_excluded:
+            if name in modified:
+                bound.arguments[name] = modified[name]
+    elif isinstance(modified, str) and len(non_excluded) == 1:
+        bound.arguments[non_excluded[0]] = modified
+
+
+# ---------------------------------------------------------------------------
+# Tool I/O normalisation helpers (used by LangChain adapter)
+# ---------------------------------------------------------------------------
+
+
+def _is_tool_call_envelope(tool_input: Any) -> bool:
+    """Return ``True`` if *tool_input* is a LangGraph tool-call envelope dict."""
+    return (
+        isinstance(tool_input, dict)
+        and "args" in tool_input
+        and tool_input.get("type") == "tool_call"
+    )
+
+
+def _extract_input(tool_input: Any) -> dict[str, Any]:
+    """Normalise tool input to a plain dict for rule / guardrail evaluation.
+
+    LangGraph wraps tool inputs as ``{"name": ..., "args": {...}, "type": "tool_call"}``.
+    This function unwraps ``args`` so rules can access the actual tool arguments.
+    """
+    if _is_tool_call_envelope(tool_input):
+        args = tool_input["args"]
+        if isinstance(args, dict):
+            return args
+    if isinstance(tool_input, dict):
+        return tool_input
+    return {"input": tool_input}
+
+
+def _rewrap_input(original_tool_input: Any, modified_args: dict[str, Any]) -> Any:
+    """Re-wrap modified args back into the original tool-call envelope (if applicable)."""
+    if _is_tool_call_envelope(original_tool_input):
+        import copy
+
+        wrapped = copy.copy(original_tool_input)
+        wrapped["args"] = modified_args
+        return wrapped
+    return modified_args
+
+
+def _extract_output(result: Any) -> dict[str, Any]:
+    """Normalise tool output to a dict for guardrail / rule evaluation.
+
+    Falls back to ``{"output": content}`` for plain strings and anything else.
+    """
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+            return parsed if isinstance(parsed, dict) else {"output": parsed}
+        except ValueError:
+            try:
+                parsed = ast.literal_eval(result)
+                return parsed if isinstance(parsed, dict) else {"output": parsed}
+            except (ValueError, SyntaxError):
+                return {"output": result}
+    return {"output": result}

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_enums.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_enums.py
@@ -1,0 +1,44 @@
+"""Enums for guardrail decorators."""
+
+from enum import Enum
+
+
+class GuardrailExecutionStage(str, Enum):
+    """Execution stage for guardrails."""
+
+    PRE = "pre"
+    """Evaluate before the target executes."""
+
+    POST = "post"
+    """Evaluate after the target executes."""
+
+    PRE_AND_POST = "pre&post"
+    """Evaluate both before and after the target executes."""
+
+
+class PIIDetectionEntityType(str, Enum):
+    """PII detection entity types supported by UiPath guardrails.
+
+    These entities match the available options from the UiPath guardrails service
+    backend. The enum values correspond to the exact strings expected by the API.
+    """
+
+    PERSON = "Person"
+    ADDRESS = "Address"
+    DATE = "Date"
+    PHONE_NUMBER = "PhoneNumber"
+    EUGPS_COORDINATES = "EugpsCoordinates"
+    EMAIL = "Email"
+    CREDIT_CARD_NUMBER = "CreditCardNumber"
+    INTERNATIONAL_BANKING_ACCOUNT_NUMBER = "InternationalBankingAccountNumber"
+    SWIFT_CODE = "SwiftCode"
+    ABA_ROUTING_NUMBER = "ABARoutingNumber"
+    US_DRIVERS_LICENSE_NUMBER = "USDriversLicenseNumber"
+    UK_DRIVERS_LICENSE_NUMBER = "UKDriversLicenseNumber"
+    US_INDIVIDUAL_TAXPAYER_IDENTIFICATION = "USIndividualTaxpayerIdentification"
+    UK_UNIQUE_TAXPAYER_NUMBER = "UKUniqueTaxpayerNumber"
+    US_BANK_ACCOUNT_NUMBER = "USBankAccountNumber"
+    US_SOCIAL_SECURITY_NUMBER = "USSocialSecurityNumber"
+    USUK_PASSPORT_NUMBER = "UsukPassportNumber"
+    URL = "URL"
+    IP_ADDRESS = "IPAddress"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_exceptions.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_exceptions.py
@@ -1,0 +1,18 @@
+"""Exceptions for guardrail decorators."""
+
+
+class GuardrailBlockException(Exception):
+    """Raised by BlockAction when a guardrail blocks execution.
+
+    Framework adapters (e.g. LangChain) should catch this and convert it to
+    their own runtime exception type at the outermost wrapper boundary.
+
+    Args:
+        title: Brief title for the block event.
+        detail: Detailed reason for the block.
+    """
+
+    def __init__(self, title: str, detail: str) -> None:
+        self.title = title
+        self.detail = detail
+        super().__init__(f"{title}: {detail}")

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_guardrail.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_guardrail.py
@@ -1,0 +1,224 @@
+"""Single ``@guardrail`` decorator for all guardrail types."""
+
+import inspect
+import logging
+from functools import wraps
+from typing import Any
+
+from ._core import (
+    _apply_pre_modification,
+    _collect_input,
+    _collect_output,
+    _EvaluatorFn,
+    _get_excluded_params,
+    _make_evaluator,
+    _reconstruct_output,
+)
+from ._enums import GuardrailExecutionStage
+from ._models import GuardrailAction
+from ._registry import is_recognized_by_adapter, wrap_with_adapter
+from .validators._base import GuardrailValidatorBase
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_pre(
+    evaluator: _EvaluatorFn,
+    action: GuardrailAction,
+    name: str,
+    bound: inspect.BoundArguments,
+    excluded: set[str],
+) -> None:
+    """Evaluate PRE guardrail and apply any modifications to *bound* in-place."""
+    input_data = _collect_input(bound, excluded)
+    try:
+        result = evaluator(input_data, GuardrailExecutionStage.PRE, input_data, None)
+    except Exception as exc:
+        logger.error("Error evaluating PRE guardrail %r: %s", name, exc, exc_info=True)
+        return
+    from uipath.core.guardrails import GuardrailValidationResultType
+
+    if result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+        modified = action.handle_validation_result(result, input_data, name)
+        _apply_pre_modification(bound, modified, excluded)
+
+
+def _run_post(
+    evaluator: _EvaluatorFn,
+    action: GuardrailAction,
+    name: str,
+    bound: inspect.BoundArguments,
+    excluded: set[str],
+    return_value: Any,
+) -> Any:
+    """Evaluate POST guardrail and return (possibly modified) return value."""
+    input_data = _collect_input(bound, excluded)
+    output_data = _collect_output(return_value)
+    try:
+        result = evaluator(
+            output_data, GuardrailExecutionStage.POST, input_data, output_data
+        )
+    except Exception as exc:
+        logger.error("Error evaluating POST guardrail %r: %s", name, exc, exc_info=True)
+        return return_value
+    from uipath.core.guardrails import GuardrailValidationResultType
+
+    if result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+        modified = action.handle_validation_result(result, output_data, name)
+        return _reconstruct_output(return_value, modified)
+    return return_value
+
+
+def _wrap_function(
+    func: Any,
+    evaluator: _EvaluatorFn,
+    action: GuardrailAction,
+    name: str,
+    stage: GuardrailExecutionStage,
+    excluded: set[str],
+) -> Any:
+    """Wrap *func* as a pure Python function with PRE/POST guardrail evaluation."""
+    sig = inspect.signature(func)
+
+    def _dispatch_return(return_value: Any) -> Any:
+        """For factory functions: if the return value is recognized by an adapter, wrap it."""
+        if is_recognized_by_adapter(return_value):
+            return wrap_with_adapter(return_value, evaluator, action, name, stage)
+        return return_value
+
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        async def _wrapped_async(*args: Any, **kwargs: Any) -> Any:
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            if stage in (
+                GuardrailExecutionStage.PRE,
+                GuardrailExecutionStage.PRE_AND_POST,
+            ):
+                _run_pre(evaluator, action, name, bound, excluded)
+            return_value = await func(*bound.args, **bound.kwargs)
+            return_value = _dispatch_return(return_value)
+            if stage in (
+                GuardrailExecutionStage.POST,
+                GuardrailExecutionStage.PRE_AND_POST,
+            ):
+                # Only run POST on plain (non-adapter-wrapped) values
+                if not is_recognized_by_adapter(return_value):
+                    return_value = _run_post(
+                        evaluator, action, name, bound, excluded, return_value
+                    )
+            return return_value
+
+        return _wrapped_async
+
+    @wraps(func)
+    def _wrapped(*args: Any, **kwargs: Any) -> Any:
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        if stage in (
+            GuardrailExecutionStage.PRE,
+            GuardrailExecutionStage.PRE_AND_POST,
+        ):
+            _run_pre(evaluator, action, name, bound, excluded)
+        return_value = func(*bound.args, **bound.kwargs)
+        return_value = _dispatch_return(return_value)
+        if stage in (
+            GuardrailExecutionStage.POST,
+            GuardrailExecutionStage.PRE_AND_POST,
+        ):
+            if not is_recognized_by_adapter(return_value):
+                return_value = _run_post(
+                    evaluator, action, name, bound, excluded, return_value
+                )
+        return return_value
+
+    return _wrapped
+
+
+# ---------------------------------------------------------------------------
+# Public @guardrail decorator
+# ---------------------------------------------------------------------------
+
+
+def guardrail(
+    func: Any = None,
+    *,
+    validator: GuardrailValidatorBase,
+    action: GuardrailAction,
+    name: str = "Guardrail",
+    description: str | None = None,
+    stage: GuardrailExecutionStage = GuardrailExecutionStage.PRE_AND_POST,
+    enabled_for_evals: bool = True,
+) -> Any:
+    """Apply a guardrail to any callable — tool functions, LLM factories, agent nodes.
+
+    When applied to a plain function or async function, the decorator collects
+    function parameters (PRE) and return value (POST) and evaluates them against
+    the guardrail. Use :class:`~._core.GuardrailExclude` to opt individual
+    parameters out of serialization.
+
+    When applied to a factory function whose return value is recognised by a
+    registered framework adapter (e.g. a LangChain ``BaseChatModel``), the
+    returned object is wrapped so every subsequent ``invoke()`` call is guarded.
+
+    Multiple ``@guardrail`` decorators can be stacked on the same callable.
+
+    Args:
+        func: Callable to decorate. Supplied directly when used without parentheses.
+        validator: :class:`~.validators.GuardrailValidatorBase` defining what to check.
+        action: :class:`~._models.GuardrailAction` defining how to respond on violation.
+        name: Human-readable name for this guardrail instance.
+        description: Optional description passed to API-based guardrails.
+        stage: When to evaluate — ``PRE``, ``POST``, or ``PRE_AND_POST``.
+            Defaults to ``PRE_AND_POST``.
+        enabled_for_evals: Whether this guardrail is active in evaluation scenarios.
+            Defaults to ``True``.
+
+    Returns:
+        The decorated callable (or framework object).
+
+    Raises:
+        ValueError: If *action* is invalid, or the validator does not support
+            the requested stage.
+        GuardrailBlockException: Raised at runtime by :class:`~._actions.BlockAction`
+            when a violation is detected.
+    """
+    if action is None:
+        raise ValueError("action must be provided")
+    if not isinstance(action, GuardrailAction):
+        raise ValueError("action must be an instance of GuardrailAction")
+    if not isinstance(enabled_for_evals, bool):
+        raise ValueError("enabled_for_evals must be a boolean")
+
+    def _apply(obj: Any) -> Any:
+        # ------------------------------------------------------------------
+        # 1. Adapter-recognised direct object (e.g. BaseTool after @tool)
+        # ------------------------------------------------------------------
+        if is_recognized_by_adapter(obj):
+            validator.validate_stage(stage)
+            evaluator = _make_evaluator(validator, name, description, enabled_for_evals)
+            return wrap_with_adapter(obj, evaluator, action, name, stage)
+
+        # ------------------------------------------------------------------
+        # 2. Plain callable — wrap as pure function
+        # ------------------------------------------------------------------
+        if callable(obj):
+            validator.validate_stage(stage)
+            evaluator = _make_evaluator(validator, name, description, enabled_for_evals)
+            excluded = _get_excluded_params(obj)
+            return _wrap_function(obj, evaluator, action, name, stage, excluded)
+
+        raise ValueError(
+            f"@guardrail cannot be applied to {type(obj)!r}. "
+            "Target must be a callable or a framework-registered object. "
+            "Ensure the relevant framework adapter is imported before using @guardrail."
+        )
+
+    if func is None:
+        return _apply
+    return _apply(func)

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_models.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_models.py
@@ -1,0 +1,59 @@
+"""Models for guardrail decorators."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from uipath.core.guardrails import GuardrailValidationResult
+
+
+@dataclass
+class PIIDetectionEntity:
+    """PII entity configuration with detection threshold.
+
+    Args:
+        name: The entity type name (e.g. ``PIIDetectionEntityType.EMAIL``).
+        threshold: Confidence threshold (0.0 to 1.0) for detection.
+    """
+
+    name: str
+    threshold: float = 0.5
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.threshold <= 1.0:
+            raise ValueError(
+                f"Threshold must be between 0.0 and 1.0, got {self.threshold}"
+            )
+
+
+class GuardrailAction(ABC):
+    """Interface for defining custom actions when a guardrail violation is detected.
+
+    Subclass this to implement custom behaviour on validation failure, such as
+    logging, blocking, or content sanitisation. Built-in implementations are
+    :class:`LogAction` and :class:`BlockAction`.
+    """
+
+    @abstractmethod
+    def handle_validation_result(
+        self,
+        result: GuardrailValidationResult,
+        data: str | dict[str, Any],
+        guardrail_name: str,
+    ) -> "str | dict[str, Any] | None":
+        """Handle a guardrail validation result.
+
+        Called when guardrail validation fails. May return modified data to
+        sanitise/filter the validated content before execution continues, or
+        ``None`` to leave it unchanged.
+
+        Args:
+            result: The validation result from the guardrails service.
+            data: The data that was validated (string or dictionary). Depending
+                on context this can be tool input, tool output, or message text.
+            guardrail_name: The name of the guardrail that triggered.
+
+        Returns:
+            Modified data if the action wants to replace the original, or
+            ``None`` if no modification is needed.
+        """

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_registry.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_registry.py
@@ -1,0 +1,105 @@
+"""Adapter registry for guardrail target recognition and wrapping."""
+
+from typing import Any, Protocol, runtime_checkable
+
+from ._core import _EvaluatorFn
+from ._enums import GuardrailExecutionStage
+from ._models import GuardrailAction
+
+
+@runtime_checkable
+class GuardrailTargetAdapter(Protocol):
+    """Protocol for framework-specific guardrail adapters.
+
+    Implement this protocol to teach :func:`guardrail` how to handle objects
+    from a particular framework. Register instances via
+    :func:`register_guardrail_adapter`.
+    """
+
+    def recognize(self, target: Any) -> bool:
+        """Return ``True`` if this adapter handles *target*.
+
+        Args:
+            target: Object being decorated or returned by a factory function.
+
+        Returns:
+            ``True`` if this adapter can wrap *target*, ``False`` otherwise.
+        """
+        ...
+
+    def wrap(
+        self,
+        target: Any,
+        evaluator: _EvaluatorFn,
+        action: GuardrailAction,
+        name: str,
+        stage: GuardrailExecutionStage,
+    ) -> Any:
+        """Wrap *target* with guardrail enforcement logic.
+
+        Args:
+            target: Object to wrap.
+            evaluator: Unified evaluation callable from :func:`_make_evaluator`.
+            action: Action to invoke on validation failure.
+            name: Human-readable guardrail name.
+            stage: When to evaluate (PRE, POST, or PRE_AND_POST).
+
+        Returns:
+            Wrapped object, same type or duck-type compatible.
+        """
+        ...
+
+
+# Module-level registry. Later-registered adapters take priority (inserted at 0).
+_adapters: list[GuardrailTargetAdapter] = []
+
+
+def register_guardrail_adapter(adapter: GuardrailTargetAdapter) -> None:
+    """Register a framework adapter for the ``@guardrail`` decorator.
+
+    Later-registered adapters are tried first.
+
+    Args:
+        adapter: An instance implementing :class:`GuardrailTargetAdapter`.
+    """
+    _adapters.insert(0, adapter)
+
+
+def is_recognized_by_adapter(target: Any) -> bool:
+    """Return ``True`` if any registered adapter recognizes *target*.
+
+    Args:
+        target: The object being decorated.
+
+    Returns:
+        ``True`` if a registered adapter handles *target*.
+    """
+    for adapter in _adapters:
+        if adapter.recognize(target):
+            return True
+    return False
+
+
+def wrap_with_adapter(
+    target: Any,
+    evaluator: _EvaluatorFn,
+    action: GuardrailAction,
+    name: str,
+    stage: GuardrailExecutionStage,
+) -> Any:
+    """Ask the first matching adapter to wrap *target*.
+
+    Args:
+        target: The object to wrap.
+        evaluator: Unified evaluation callable.
+        action: Action on violation.
+        name: Guardrail name.
+        stage: Execution stage.
+
+    Returns:
+        Wrapped object, or *target* unchanged if no adapter handles it.
+    """
+    for adapter in _adapters:
+        if adapter.recognize(target):
+            return adapter.wrap(target, evaluator, action, name, stage)
+    return target

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/__init__.py
@@ -1,0 +1,20 @@
+"""Guardrail validators for the ``@guardrail`` decorator."""
+
+from ._base import (
+    BuiltInGuardrailValidator,
+    CustomGuardrailValidator,
+    GuardrailValidatorBase,
+)
+from .custom import CustomValidator, RuleFunction
+from .pii import PIIValidator
+from .prompt_injection import PromptInjectionValidator
+
+__all__ = [
+    "GuardrailValidatorBase",
+    "BuiltInGuardrailValidator",
+    "CustomGuardrailValidator",
+    "PIIValidator",
+    "PromptInjectionValidator",
+    "CustomValidator",
+    "RuleFunction",
+]

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/_base.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/_base.py
@@ -1,0 +1,182 @@
+"""Abstract base classes for guardrail validators."""
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from uipath.core.guardrails import GuardrailValidationResult
+
+from uipath.platform.guardrails.guardrails import BuiltInValidatorGuardrail
+
+from .._enums import GuardrailExecutionStage
+
+
+class GuardrailValidatorBase:
+    """Root base class for guardrail validators.
+
+    Concrete validators should subclass either
+    :class:`BuiltInGuardrailValidator` (for UiPath API-backed validation)
+    or :class:`CustomGuardrailValidator` (for in-process Python validation).
+    """
+
+    supported_stages: ClassVar[list[GuardrailExecutionStage]] = []
+    """Stages this validator supports. Empty list means all stages are allowed."""
+
+    def validate_stage(self, stage: GuardrailExecutionStage) -> None:
+        """Raise ``ValueError`` if *stage* is not in :attr:`supported_stages`.
+
+        Args:
+            stage: Requested execution stage.
+
+        Raises:
+            ValueError: If :attr:`supported_stages` is non-empty and *stage* is absent.
+        """
+        if self.supported_stages and stage not in self.supported_stages:
+            raise ValueError(
+                f"{type(self).__name__} does not support stage {stage!r}. "
+                f"Supported stages: {[s.value for s in self.supported_stages]}"
+            )
+
+    def run(
+        self,
+        name: str,
+        description: str | None,
+        enabled_for_evals: bool,
+        data: "str | dict[str, Any]",
+        stage: GuardrailExecutionStage,
+        input_data: "dict[str, Any] | None",
+        output_data: "dict[str, Any] | None",
+    ) -> GuardrailValidationResult:
+        """Execute the guardrail evaluation.
+
+        Called by the ``@guardrail`` decorator at each function invocation.
+        Subclasses override this via :class:`BuiltInGuardrailValidator` or
+        :class:`CustomGuardrailValidator`.
+
+        Raises:
+            NotImplementedError: Always — subclass one of the two ABCs instead.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must subclass BuiltInGuardrailValidator "
+            "or CustomGuardrailValidator and implement the required abstract method."
+        )
+
+
+class BuiltInGuardrailValidator(GuardrailValidatorBase, ABC):
+    """Base for validators that delegate to the UiPath Guardrails API.
+
+    Subclass this and implement :meth:`get_built_in_guardrail` to create an
+    API-backed guardrail validator (e.g. PII detection, prompt injection).
+
+    Example::
+
+        class MyValidator(BuiltInGuardrailValidator):
+            def get_built_in_guardrail(self, name, description, enabled_for_evals):
+                return BuiltInValidatorGuardrail(
+                    id=str(uuid4()),
+                    name=name,
+                    ...
+                )
+    """
+
+    @abstractmethod
+    def get_built_in_guardrail(
+        self,
+        name: str,
+        description: str | None,
+        enabled_for_evals: bool,
+    ) -> BuiltInValidatorGuardrail:
+        """Build the UiPath API guardrail definition for this validator.
+
+        Args:
+            name: Name for the guardrail instance.
+            description: Optional description.
+            enabled_for_evals: Whether active in evaluation scenarios.
+
+        Returns:
+            :class:`BuiltInValidatorGuardrail` ready to be sent to the API.
+        """
+        ...
+
+    def run(
+        self,
+        name: str,
+        description: str | None,
+        enabled_for_evals: bool,
+        data: "str | dict[str, Any]",
+        stage: GuardrailExecutionStage,
+        input_data: "dict[str, Any] | None",
+        output_data: "dict[str, Any] | None",
+    ) -> GuardrailValidationResult:
+        """Evaluate via the UiPath Guardrails API.
+
+        Lazily initialises the ``UiPath`` client on the first call and reuses
+        it for all subsequent invocations.
+        """
+        built_in = self.get_built_in_guardrail(name, description, enabled_for_evals)
+        if not hasattr(self, "_uipath"):
+            from uipath.platform import UiPath
+
+            self._uipath: Any = UiPath()
+        return self._uipath.guardrails.evaluate_guardrail(data, built_in)
+
+
+class CustomGuardrailValidator(GuardrailValidatorBase, ABC):
+    """Base for validators that run entirely in-process.
+
+    Subclass this and implement :meth:`evaluate` to create a local guardrail
+    validator that requires no UiPath API call.
+
+    Example::
+
+        class ProfanityValidator(CustomGuardrailValidator):
+            BANNED = {"badword"}
+
+            def evaluate(self, data, stage, input_data, output_data):
+                text = (input_data or {}).get("message", "")
+                if any(w in text.lower() for w in self.BANNED):
+                    return GuardrailValidationResult(
+                        result=GuardrailValidationResultType.VALIDATION_FAILED,
+                        reason="Profanity detected",
+                    )
+                return GuardrailValidationResult(result=GuardrailValidationResultType.PASSED)
+    """
+
+    @abstractmethod
+    def evaluate(
+        self,
+        data: "str | dict[str, Any]",
+        stage: GuardrailExecutionStage,
+        input_data: "dict[str, Any] | None",
+        output_data: "dict[str, Any] | None",
+    ) -> GuardrailValidationResult:
+        """Perform local validation without a UiPath API call.
+
+        Return a result with ``VALIDATION_FAILED`` to **trigger** the guardrail
+        (causing the configured :class:`~uipath.platform.guardrails.decorators.GuardrailAction`
+        to fire), or ``PASSED`` to let execution continue unchanged.
+
+        Args:
+            data: Primary data being evaluated.
+            stage: Current execution stage (PRE or POST).
+            input_data: Normalised function input dict, or ``None``.
+            output_data: Normalised function output dict, or ``None`` at PRE stage.
+
+        Returns:
+            :class:`~uipath.core.guardrails.GuardrailValidationResult` —
+            return ``VALIDATION_FAILED`` to activate the guardrail,
+            ``PASSED`` to allow execution to continue.
+        """
+        ...
+
+    def run(
+        self,
+        name: str,
+        description: str | None,
+        enabled_for_evals: bool,
+        data: "str | dict[str, Any]",
+        stage: GuardrailExecutionStage,
+        input_data: "dict[str, Any] | None",
+        output_data: "dict[str, Any] | None",
+    ) -> GuardrailValidationResult:
+        """Delegate to :meth:`evaluate`."""
+        return self.evaluate(data, stage, input_data, output_data)

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/custom.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/custom.py
@@ -1,0 +1,125 @@
+"""Custom (rule-based) guardrail validator."""
+
+import inspect
+from typing import Any, Callable
+
+from uipath.core.guardrails import (
+    GuardrailValidationResult,
+    GuardrailValidationResultType,
+)
+
+from .._enums import GuardrailExecutionStage
+from ._base import CustomGuardrailValidator
+
+RuleFunction = (
+    Callable[[dict[str, Any]], bool] | Callable[[dict[str, Any], dict[str, Any]], bool]
+)
+"""Type alias for custom rule functions passed to :class:`CustomValidator`.
+
+The rule must return ``True`` to **trigger** the guardrail (i.e. signal a
+violation that causes the configured action to fire), or ``False`` to let
+execution continue unchanged.
+
+It accepts either one parameter (the input or output dict) or two parameters
+(input dict, output dict — POST stage only).
+
+Examples::
+
+    # Triggered when "donkey" appears in the joke argument
+    CustomValidator(lambda args: "donkey" in args.get("joke", "").lower())
+
+    # Triggered when the output joke exceeds 500 characters
+    CustomValidator(lambda args: len(args.get("joke", "")) > 500)
+
+    # Two-parameter form: triggered at POST when output contains input keyword
+    CustomValidator(lambda inp, out: inp.get("topic", "") in out.get("joke", ""))
+"""
+
+
+class CustomValidator(CustomGuardrailValidator):
+    """Validate function input/output using a local Python rule function.
+
+    No UiPath API call is made. Applicable at any stage.
+
+    The *rule* is called with the collected parameter dict (PRE stage) or the
+    serialised return-value dict (POST stage).  It must return ``True`` to
+    **activate** the guardrail — i.e. to signal a violation and invoke the
+    configured :class:`~uipath.platform.guardrails.decorators.GuardrailAction`.
+    Return ``False`` (or any falsy value) to let execution continue unchanged.
+
+    Args:
+        rule: A :data:`RuleFunction` that returns ``True`` to trigger the
+            guardrail.  Must accept 1 or 2 parameters.
+
+    Raises:
+        ValueError: If *rule* is not callable or has an unsupported parameter count.
+    """
+
+    def __init__(self, rule: RuleFunction) -> None:
+        """Initialize CustomValidator with a rule callable."""
+        if not callable(rule):
+            raise ValueError(f"rule must be callable, got {type(rule)}")
+        sig = inspect.signature(rule)
+        param_count = len(sig.parameters)
+        if param_count not in (1, 2):
+            raise ValueError(f"rule must have 1 or 2 parameters, got {param_count}")
+        self.rule = rule
+        self._param_count = param_count
+
+    def evaluate(
+        self,
+        data: str | dict[str, Any],
+        stage: GuardrailExecutionStage,
+        input_data: dict[str, Any] | None,
+        output_data: dict[str, Any] | None,
+    ) -> GuardrailValidationResult:
+        """Run the rule against the collected input or output dict.
+
+        The rule receives the PRE parameter dict or POST return-value dict and
+        must return ``True`` to **trigger** the guardrail (VALIDATION_FAILED),
+        or ``False`` to pass.
+
+        Args:
+            data: Unused; the rule operates on *input_data* or *output_data*.
+            stage: Current stage (PRE or POST).
+            input_data: Collected function input dict.
+            output_data: Collected function output dict, or ``None`` at PRE stage.
+
+        Returns:
+            :class:`~uipath.core.guardrails.GuardrailValidationResult` —
+            ``VALIDATION_FAILED`` when the rule returns ``True`` (guardrail
+            triggered), ``PASSED`` otherwise.
+        """
+        try:
+            if self._param_count == 2:
+                if input_data is None or output_data is None:
+                    return GuardrailValidationResult(
+                        result=GuardrailValidationResultType.PASSED,
+                        reason="Two-parameter rule skipped: input or output data unavailable",
+                    )
+                violation = self.rule(input_data, output_data)  # type: ignore[call-arg]
+            else:
+                target = (
+                    input_data if stage == GuardrailExecutionStage.PRE else output_data
+                )
+                if target is None:
+                    return GuardrailValidationResult(
+                        result=GuardrailValidationResultType.PASSED,
+                        reason="Rule skipped: data unavailable at this stage",
+                    )
+                violation = self.rule(target)  # type: ignore[call-arg]
+        except Exception as exc:
+            return GuardrailValidationResult(
+                result=GuardrailValidationResultType.PASSED,
+                reason=f"Rule raised exception: {exc}",
+            )
+
+        if violation:
+            return GuardrailValidationResult(
+                result=GuardrailValidationResultType.VALIDATION_FAILED,
+                reason="Rule detected violation",
+            )
+        return GuardrailValidationResult(
+            result=GuardrailValidationResultType.PASSED,
+            reason="Rule passed",
+        )

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/pii.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/pii.py
@@ -1,0 +1,76 @@
+"""PII detection guardrail validator."""
+
+from typing import Any, Sequence
+from uuid import uuid4
+
+from uipath.platform.guardrails.guardrails import (
+    BuiltInValidatorGuardrail,
+    EnumListParameterValue,
+    MapEnumParameterValue,
+)
+
+from .._models import PIIDetectionEntity
+from ._base import BuiltInGuardrailValidator
+
+
+class PIIValidator(BuiltInGuardrailValidator):
+    """Validate data for PII entities using the UiPath PII detection API.
+
+    Supported at all stages.
+
+    Args:
+        entities: One or more :class:`~uipath.platform.guardrails.decorators.PIIDetectionEntity`
+            instances specifying which PII types to detect and their confidence thresholds.
+
+    Raises:
+        ValueError: If *entities* is empty.
+    """
+
+    def __init__(self, entities: Sequence[PIIDetectionEntity]) -> None:
+        """Initialize PIIValidator with a list of entities to detect."""
+        if not entities:
+            raise ValueError("entities must be provided and non-empty")
+        self.entities = list(entities)
+
+    def get_built_in_guardrail(
+        self,
+        name: str,
+        description: str | None,
+        enabled_for_evals: bool,
+    ) -> BuiltInValidatorGuardrail:
+        """Build a PII detection :class:`BuiltInValidatorGuardrail`.
+
+        Args:
+            name: Name for the guardrail.
+            description: Optional description.
+            enabled_for_evals: Whether active in evaluation scenarios.
+
+        Returns:
+            Configured :class:`BuiltInValidatorGuardrail` for PII detection.
+        """
+        entity_names = [entity.name for entity in self.entities]
+        entity_thresholds: dict[str, Any] = {
+            entity.name: entity.threshold for entity in self.entities
+        }
+
+        return BuiltInValidatorGuardrail(
+            id=str(uuid4()),
+            name=name,
+            description=description
+            or f"Detects PII entities: {', '.join(entity_names)}",
+            enabled_for_evals=enabled_for_evals,
+            guardrail_type="builtInValidator",
+            validator_type="pii_detection",
+            validator_parameters=[
+                EnumListParameterValue(
+                    parameter_type="enum-list",
+                    id="entities",
+                    value=entity_names,
+                ),
+                MapEnumParameterValue(
+                    parameter_type="map-enum",
+                    id="entityThresholds",
+                    value=entity_thresholds,
+                ),
+            ],
+        )

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/prompt_injection.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/prompt_injection.py
@@ -1,0 +1,65 @@
+"""Prompt injection detection guardrail validator."""
+
+from uuid import uuid4
+
+from uipath.platform.guardrails.guardrails import (
+    BuiltInValidatorGuardrail,
+    NumberParameterValue,
+)
+
+from .._enums import GuardrailExecutionStage
+from ._base import BuiltInGuardrailValidator
+
+
+class PromptInjectionValidator(BuiltInGuardrailValidator):
+    """Validate input for prompt injection attacks via the UiPath API.
+
+    Restricted to PRE stage only — prompt injection is an input-only concern.
+
+    Args:
+        threshold: Detection confidence threshold (0.0–1.0). Defaults to ``0.5``.
+
+    Raises:
+        ValueError: If *threshold* is outside [0.0, 1.0].
+    """
+
+    supported_stages = [GuardrailExecutionStage.PRE]
+
+    def __init__(self, threshold: float = 0.5) -> None:
+        """Initialize PromptInjectionValidator with a detection threshold."""
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError(f"threshold must be between 0.0 and 1.0, got {threshold}")
+        self.threshold = threshold
+
+    def get_built_in_guardrail(
+        self,
+        name: str,
+        description: str | None,
+        enabled_for_evals: bool,
+    ) -> BuiltInValidatorGuardrail:
+        """Build a prompt injection :class:`BuiltInValidatorGuardrail`.
+
+        Args:
+            name: Name for the guardrail.
+            description: Optional description.
+            enabled_for_evals: Whether active in evaluation scenarios.
+
+        Returns:
+            Configured :class:`BuiltInValidatorGuardrail` for prompt injection.
+        """
+        return BuiltInValidatorGuardrail(
+            id=str(uuid4()),
+            name=name,
+            description=description
+            or f"Detects prompt injection with threshold {self.threshold}",
+            enabled_for_evals=enabled_for_evals,
+            guardrail_type="builtInValidator",
+            validator_type="prompt_injection",
+            validator_parameters=[
+                NumberParameterValue(
+                    parameter_type="number",
+                    id="threshold",
+                    value=self.threshold,
+                ),
+            ],
+        )

--- a/packages/uipath-platform/tests/services/test_guardrails_decorators.py
+++ b/packages/uipath-platform/tests/services/test_guardrails_decorators.py
@@ -1,0 +1,1171 @@
+"""Tests for the guardrails decorator framework in uipath-platform.
+
+Focus: meaningful business behaviour — serialization, PRE/POST evaluation,
+modification flow, stage enforcement, factory-function path, and integration
+scenarios modelled on the joke-agent-decorator sample.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Annotated, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+from uipath.core.guardrails import (
+    GuardrailValidationResult,
+    GuardrailValidationResultType,
+)
+
+from uipath.platform.guardrails.decorators import (
+    BlockAction,
+    CustomValidator,
+    GuardrailAction,
+    GuardrailBlockException,
+    GuardrailExclude,
+    GuardrailExecutionStage,
+    LogAction,
+    LoggingSeverityLevel,
+    PIIDetectionEntity,
+    PIIDetectionEntityType,
+    PIIValidator,
+    PromptInjectionValidator,
+    guardrail,
+    register_guardrail_adapter,
+)
+from uipath.platform.guardrails.decorators._core import (
+    _collect_output,
+    _get_excluded_params,
+    _make_evaluator,
+    _reconstruct_output,
+    _serialize_value,
+)
+from uipath.platform.guardrails.decorators._registry import (
+    _adapters,
+)
+
+# ---------------------------------------------------------------------------
+# Shared result constants
+# ---------------------------------------------------------------------------
+
+_PASSED = GuardrailValidationResult(
+    result=GuardrailValidationResultType.PASSED,
+    reason="ok",
+)
+_FAILED = GuardrailValidationResult(
+    result=GuardrailValidationResultType.VALIDATION_FAILED,
+    reason="violation detected",
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry isolation fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_adapter_registry():
+    """Snapshot and restore the global adapter registry around every test."""
+    snapshot = list(_adapters)
+    yield
+    _adapters.clear()
+    _adapters.extend(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake types for adapter tests (no LangChain dependency)
+# ---------------------------------------------------------------------------
+
+
+class _DummyTarget:
+    """Minimal callable target recognised by _DummyAdapter."""
+
+    def __init__(self, return_value: Any = None) -> None:
+        self.return_value = (
+            return_value if return_value is not None else {"output": "result"}
+        )
+        self.invoke_calls: list[Any] = []
+
+    def invoke(self, args: Any) -> Any:
+        self.invoke_calls.append(args)
+        return self.return_value
+
+
+class _WrappedDummyTarget:
+    """A _DummyTarget wrapped with guardrail evaluation."""
+
+    def __init__(
+        self,
+        target: Any,
+        evaluator: Any,
+        action: GuardrailAction,
+        name: str,
+        stage: GuardrailExecutionStage,
+    ) -> None:
+        self._target = target
+        self._evaluator = evaluator
+        self._action = action
+        self._name = name
+        self._stage = stage
+
+    def invoke(self, args: Any) -> Any:
+        input_data = args if isinstance(args, dict) else {"input": args}
+        if self._stage in (
+            GuardrailExecutionStage.PRE,
+            GuardrailExecutionStage.PRE_AND_POST,
+        ):
+            result = self._evaluator(
+                input_data, GuardrailExecutionStage.PRE, input_data, None
+            )
+            if result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+                self._action.handle_validation_result(result, input_data, self._name)
+        raw = self._target.invoke(args)
+        output_data = raw if isinstance(raw, dict) else {"output": raw}
+        if self._stage in (
+            GuardrailExecutionStage.POST,
+            GuardrailExecutionStage.PRE_AND_POST,
+        ):
+            result = self._evaluator(
+                output_data, GuardrailExecutionStage.POST, input_data, output_data
+            )
+            if result.result == GuardrailValidationResultType.VALIDATION_FAILED:
+                self._action.handle_validation_result(result, output_data, self._name)
+        return raw
+
+
+class _DummyAdapter:
+    """Adapter that handles _DummyTarget and _WrappedDummyTarget instances."""
+
+    def recognize(self, target: Any) -> bool:
+        return isinstance(target, (_DummyTarget, _WrappedDummyTarget))
+
+    def wrap(
+        self,
+        target: Any,
+        evaluator: Any,
+        action: GuardrailAction,
+        name: str,
+        stage: GuardrailExecutionStage,
+    ) -> Any:
+        return _WrappedDummyTarget(target, evaluator, action, name, stage)
+
+
+# ---------------------------------------------------------------------------
+# 1. PIIDetectionEntity — threshold boundary enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPIIDetectionEntity:
+    def test_threshold_below_zero_raises(self):
+        with pytest.raises(ValueError, match="0.0 and 1.0"):
+            PIIDetectionEntity(name="Email", threshold=-0.1)
+
+    def test_threshold_above_one_raises(self):
+        with pytest.raises(ValueError, match="0.0 and 1.0"):
+            PIIDetectionEntity(name="Email", threshold=1.1)
+
+
+# ---------------------------------------------------------------------------
+# 2. LogAction — does NOT stop execution; uses configured severity
+# ---------------------------------------------------------------------------
+
+
+class TestLogAction:
+    def test_violation_logs_guardrail_name_and_execution_continues(self, caplog):
+        action = LogAction()
+        with caplog.at_level(logging.WARNING):
+            result = action.handle_validation_result(_FAILED, "data", "MyGuardrail")
+        assert result is None  # execution continues
+        assert any("MyGuardrail" in r.message for r in caplog.records)
+
+    def test_pass_emits_no_log(self, caplog):
+        action = LogAction()
+        with caplog.at_level(logging.WARNING):
+            action.handle_validation_result(_PASSED, "data", "G")
+        assert not caplog.records
+
+    def test_custom_message_overrides_reason(self, caplog):
+        action = LogAction(message="custom alert")
+        with caplog.at_level(logging.WARNING):
+            action.handle_validation_result(_FAILED, "data", "G")
+        assert any("custom alert" in r.message for r in caplog.records)
+
+    def test_default_message_includes_validation_reason(self, caplog):
+        action = LogAction()
+        with caplog.at_level(logging.WARNING):
+            action.handle_validation_result(_FAILED, "data", "G")
+        assert any("violation detected" in r.message for r in caplog.records)
+
+    def test_debug_severity(self, caplog):
+        action = LogAction(severity_level=LoggingSeverityLevel.DEBUG)
+        with caplog.at_level(logging.DEBUG):
+            action.handle_validation_result(_FAILED, "data", "G")
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert debug_records
+
+
+# ---------------------------------------------------------------------------
+# 3. BlockAction — raises GuardrailBlockException on violation
+# ---------------------------------------------------------------------------
+
+
+class TestBlockAction:
+    def test_raises_on_violation(self):
+        action = BlockAction()
+        with pytest.raises(GuardrailBlockException):
+            action.handle_validation_result(_FAILED, "data", "G")
+
+    def test_no_raise_on_pass(self):
+        action = BlockAction()
+        result = action.handle_validation_result(_PASSED, "data", "G")
+        assert result is None
+
+    def test_title_and_detail_from_result(self):
+        action = BlockAction()
+        with pytest.raises(GuardrailBlockException) as exc_info:
+            action.handle_validation_result(_FAILED, "data", "MyGuardrail")
+        assert exc_info.value.title
+        assert exc_info.value.detail
+
+    def test_custom_title_and_detail(self):
+        action = BlockAction(title="Blocked", detail="Not allowed")
+        with pytest.raises(GuardrailBlockException) as exc_info:
+            action.handle_validation_result(_FAILED, "data", "G")
+        assert exc_info.value.title == "Blocked"
+        assert exc_info.value.detail == "Not allowed"
+
+
+# ---------------------------------------------------------------------------
+# 4. PIIValidator — builds correct BuiltInValidatorGuardrail
+# ---------------------------------------------------------------------------
+
+
+class TestPIIValidator:
+    def test_empty_entities_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            PIIValidator(entities=[])
+
+    def test_entity_names_and_thresholds_in_api_parameters(self):
+        v = PIIValidator(
+            entities=[
+                PIIDetectionEntity(PIIDetectionEntityType.EMAIL, 0.6),
+                PIIDetectionEntity(PIIDetectionEntityType.PERSON, 0.8),
+            ]
+        )
+        g = v.get_built_in_guardrail("G", None, True)
+        param_by_id = {p.id: p for p in g.validator_parameters}
+        entities_value = param_by_id["entities"].value
+        assert isinstance(entities_value, list)
+        assert "Email" in entities_value
+        assert "Person" in entities_value
+        thresholds_value = param_by_id["entityThresholds"].value
+        assert isinstance(thresholds_value, dict)
+        assert thresholds_value["Email"] == 0.6
+        assert thresholds_value["Person"] == 0.8
+
+    def test_no_scope_restriction(self):
+        v = PIIValidator(entities=[PIIDetectionEntity(PIIDetectionEntityType.EMAIL)])
+        # All stages allowed — no ValueError raised
+        v.validate_stage(GuardrailExecutionStage.PRE)
+        v.validate_stage(GuardrailExecutionStage.POST)
+
+    def test_selector_is_none(self):
+        v = PIIValidator(entities=[PIIDetectionEntity(PIIDetectionEntityType.EMAIL)])
+        g = v.get_built_in_guardrail("G", None, True)
+        assert g.selector is None
+
+
+# ---------------------------------------------------------------------------
+# 5. PromptInjectionValidator — LLM-only, PRE-only, threshold validation
+# ---------------------------------------------------------------------------
+
+
+class TestPromptInjectionValidator:
+    def test_threshold_below_zero_raises(self):
+        with pytest.raises(ValueError, match="threshold"):
+            PromptInjectionValidator(threshold=-0.1)
+
+    def test_threshold_above_one_raises(self):
+        with pytest.raises(ValueError, match="threshold"):
+            PromptInjectionValidator(threshold=1.1)
+
+    def test_restricted_to_pre_stage_only(self):
+        v = PromptInjectionValidator()
+        v.validate_stage(GuardrailExecutionStage.PRE)  # ok
+        with pytest.raises(ValueError):
+            v.validate_stage(GuardrailExecutionStage.POST)
+
+    def test_builds_prompt_injection_guardrail_with_threshold(self):
+        v = PromptInjectionValidator(threshold=0.7)
+        g = v.get_built_in_guardrail("PI", None, True)
+        assert g.validator_type == "prompt_injection"
+        threshold_param = next(p for p in g.validator_parameters if p.id == "threshold")
+        assert threshold_param.value == 0.7
+
+    def test_selector_is_none(self):
+        v = PromptInjectionValidator()
+        g = v.get_built_in_guardrail("PI", None, True)
+        assert g.selector is None
+
+
+# ---------------------------------------------------------------------------
+# 6. CustomValidator — rule routing and error handling
+# ---------------------------------------------------------------------------
+
+
+class TestCustomValidator:
+    def test_non_callable_raises(self):
+        with pytest.raises(ValueError, match="callable"):
+            CustomValidator(rule="not_a_function")  # type: ignore[arg-type]
+
+    def test_wrong_arity_raises(self):
+        with pytest.raises(ValueError, match="1 or 2"):
+            CustomValidator(rule=lambda: True)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="1 or 2"):
+            CustomValidator(rule=lambda a, b, c: True)  # type: ignore[arg-type]
+
+    def test_one_param_pre_receives_input_data(self):
+        received: list[Any] = []
+
+        def capture_pre(args: dict[str, Any]) -> bool:
+            received.append(args)
+            return False
+
+        CustomValidator(rule=capture_pre).evaluate(
+            {}, GuardrailExecutionStage.PRE, {"a": 1}, None
+        )
+        assert received == [{"a": 1}]
+
+    def test_one_param_post_receives_output_data(self):
+        received: list[Any] = []
+
+        def capture_post(args: dict[str, Any]) -> bool:
+            received.append(args)
+            return False
+
+        CustomValidator(rule=capture_post).evaluate(
+            {}, GuardrailExecutionStage.POST, {"in": 1}, {"out": 2}
+        )
+        assert received == [{"out": 2}]
+
+    def test_two_param_post_receives_input_and_output(self):
+        received: list[Any] = []
+
+        def rule(inp: dict[str, Any], out: dict[str, Any]) -> bool:
+            received.append((inp, out))
+            return False
+
+        CustomValidator(rule=rule).evaluate(
+            {}, GuardrailExecutionStage.POST, {"in": 1}, {"out": 2}
+        )
+        assert received == [({"in": 1}, {"out": 2})]
+
+    def test_two_param_rule_skipped_when_input_missing(self):
+        result = CustomValidator(rule=lambda a, b: True).evaluate(
+            {}, GuardrailExecutionStage.POST, None, {"out": 2}
+        )
+        assert result.result == GuardrailValidationResultType.PASSED
+
+    def test_rule_returning_true_means_violation(self):
+        result = CustomValidator(rule=lambda args: True).evaluate(
+            {}, GuardrailExecutionStage.PRE, {"x": 1}, None
+        )
+        assert result.result == GuardrailValidationResultType.VALIDATION_FAILED
+
+    def test_rule_exception_returns_passed(self):
+        def bad(args: dict[str, Any]) -> bool:
+            raise ValueError("boom")
+
+        result = CustomValidator(rule=bad).evaluate(
+            {}, GuardrailExecutionStage.PRE, {"x": 1}, None
+        )
+        assert result.result == GuardrailValidationResultType.PASSED
+
+
+# ---------------------------------------------------------------------------
+# 7. GuardrailExclude — parameter introspection
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrailExclude:
+    def test_excluded_param_not_in_collected_input(self):
+        def func(
+            text: str,
+            config: Annotated[dict[str, Any], GuardrailExclude()],
+        ) -> str:
+            return text
+
+        excluded = _get_excluded_params(func)
+        assert "config" in excluded
+        assert "text" not in excluded
+
+    def test_multiple_excluded_params(self):
+        def func(
+            a: str,
+            b: Annotated[int, GuardrailExclude()],
+            c: Annotated[str, GuardrailExclude()],
+        ) -> str:
+            return a
+
+        excluded = _get_excluded_params(func)
+        assert excluded == {"b", "c"}
+
+    def test_no_annotations_returns_empty_set(self):
+        def func(a: str, b: int) -> str:
+            return a
+
+        assert _get_excluded_params(func) == set()
+
+
+# ---------------------------------------------------------------------------
+# 8. Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+class _PydanticModel(BaseModel):
+    topic: str
+    count: int = 0
+
+
+@dataclasses.dataclass
+class _Dataclass:
+    name: str
+    value: float
+
+
+class TestSerializationHelpers:
+    def test_primitive_str_passthrough(self):
+        assert _serialize_value("hello") == "hello"
+
+    def test_primitive_int_passthrough(self):
+        assert _serialize_value(42) == 42
+
+    def test_dict_passthrough(self):
+        assert _serialize_value({"a": 1}) == {"a": 1}
+
+    def test_pydantic_model_dumps(self):
+        m = _PydanticModel(topic="test", count=3)
+        result = _serialize_value(m)
+        assert result == {"topic": "test", "count": 3}
+
+    def test_dataclass_asdict(self):
+        d = _Dataclass(name="x", value=1.5)
+        result = _serialize_value(d)
+        assert result == {"name": "x", "value": 1.5}
+
+    def test_collect_output_from_pydantic(self):
+        m = _PydanticModel(topic="joke")
+        result = _collect_output(m)
+        assert result == {"topic": "joke", "count": 0}
+
+    def test_collect_output_from_str(self):
+        result = _collect_output("hello")
+        assert result == {"return": "hello"}
+
+    def test_collect_output_from_dict(self):
+        result = _collect_output({"key": "val"})
+        assert result == {"key": "val"}
+
+    def test_reconstruct_output_pydantic(self):
+        original = _PydanticModel(topic="original")
+        modified = {"topic": "modified", "count": 5}
+        result = _reconstruct_output(original, modified)
+        assert isinstance(result, _PydanticModel)
+        assert result.topic == "modified"
+        assert result.count == 5
+
+    def test_reconstruct_output_str(self):
+        result = _reconstruct_output("original", "modified")
+        assert result == "modified"
+
+    def test_reconstruct_output_none_returns_original(self):
+        result = _reconstruct_output("original", None)
+        assert result == "original"
+
+
+# ---------------------------------------------------------------------------
+# 9. @guardrail on sync functions
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrailOnSyncFunction:
+    def test_pre_fires_before_function(self):
+        calls: list[str] = []
+
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.side_effect = lambda *a, **kw: (
+            calls.append("eval") or _PASSED  # type: ignore[func-returns-value]
+        )
+
+        @guardrail(
+            validator=mock_validator,
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(text: str) -> str:
+            calls.append("fn")
+            return text
+
+        fn("hello")
+        assert calls == ["eval", "fn"]
+
+    def test_post_fires_after_function(self):
+        calls: list[str] = []
+
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.side_effect = lambda *a, **kw: (
+            calls.append("eval") or _PASSED  # type: ignore[func-returns-value]
+        )
+
+        @guardrail(
+            validator=mock_validator,
+            action=LogAction(),
+            stage=GuardrailExecutionStage.POST,
+        )
+        def fn(text: str) -> str:
+            calls.append("fn")
+            return text
+
+        fn("hello")
+        assert calls == ["fn", "eval"]
+
+    def test_block_action_raises_guardrail_block_exception(self):
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.return_value = _FAILED
+
+        @guardrail(
+            validator=mock_validator,
+            action=BlockAction(title="Blocked", detail="not allowed"),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(text: str) -> str:
+            return text
+
+        with pytest.raises(GuardrailBlockException):
+            fn("bad input")
+
+    def test_log_action_does_not_stop_execution(self):
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.return_value = _FAILED
+
+        result = []
+
+        @guardrail(
+            validator=mock_validator,
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(text: str) -> str:
+            result.append("called")
+            return text
+
+        fn("input")
+        assert result == ["called"]
+
+    def test_pre_input_contains_function_params(self):
+        captured: list[Any] = []
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(joke: str, count: int) -> str:
+            return joke
+
+        fn("why did the chicken", 3)
+        assert captured == [{"joke": "why did the chicken", "count": 3}]
+
+    def test_excluded_param_absent_from_pre_input(self):
+        captured: list[Any] = []
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(
+            joke: str,
+            config: Annotated[dict[str, Any], GuardrailExclude()],
+        ) -> str:
+            return joke
+
+        fn("why did the chicken", {"debug": True})
+        assert "config" not in captured[0]
+        assert "joke" in captured[0]
+
+    def test_pre_modification_updates_function_args(self):
+        class _ReplaceAction(GuardrailAction):
+            def handle_validation_result(self, result, data, name):
+                if isinstance(data, dict) and "joke" in data:
+                    return {"joke": data["joke"].replace("donkey", "[censored]")}
+                return data
+
+        @guardrail(
+            validator=CustomValidator(lambda args: "donkey" in args.get("joke", "")),
+            action=_ReplaceAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(joke: str) -> str:
+            return joke
+
+        result = fn("why did the donkey cross the road")
+        assert result == "why did the [censored] cross the road"
+
+    def test_post_output_contains_return_value(self):
+        captured: list[Any] = []
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.POST,
+        )
+        def fn(x: int) -> dict[str, int]:
+            return {"result": x * 2}
+
+        fn(5)
+        assert captured == [{"result": 10}]
+
+    def test_post_modification_updates_return_value(self):
+        class _FixedAction(GuardrailAction):
+            def handle_validation_result(self, result, data, name):
+                return {"result": 99}
+
+        @guardrail(
+            validator=CustomValidator(lambda args: True),
+            action=_FixedAction(),
+            stage=GuardrailExecutionStage.POST,
+        )
+        def fn(x: int) -> dict[str, int]:
+            return {"result": x * 2}
+
+        assert fn(5) == {"result": 99}
+
+    def test_pre_and_post_both_fire(self):
+        calls: list[str] = []
+
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.side_effect = lambda name, desc, enabled, data, stage, *a: (
+            calls.append(stage.value) or _PASSED  # type: ignore[func-returns-value]
+        )
+
+        @guardrail(
+            validator=mock_validator,
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE_AND_POST,
+        )
+        def fn(x: int) -> int:
+            return x + 1
+
+        fn(1)
+        assert "pre" in calls
+        assert "post" in calls
+
+
+# ---------------------------------------------------------------------------
+# 10. @guardrail on async functions
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrailOnAsyncFunction:
+    @pytest.mark.asyncio
+    async def test_pre_fires_before_async_function(self):
+        calls: list[str] = []
+
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.side_effect = lambda *a, **kw: (
+            calls.append("eval") or _PASSED  # type: ignore[func-returns-value]
+        )
+
+        @guardrail(
+            validator=mock_validator,
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        async def fn(text: str) -> str:
+            calls.append("fn")
+            return text
+
+        await fn("hello")
+        assert calls == ["eval", "fn"]
+
+    @pytest.mark.asyncio
+    async def test_block_action_raises_in_async(self):
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.return_value = _FAILED
+
+        @guardrail(
+            validator=mock_validator,
+            action=BlockAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        async def fn(text: str) -> str:
+            return text
+
+        with pytest.raises(GuardrailBlockException):
+            await fn("bad")
+
+    @pytest.mark.asyncio
+    async def test_post_modification_in_async(self):
+        class _FortyTwoAction(GuardrailAction):
+            def handle_validation_result(self, result, data, name):
+                return {"result": 42}
+
+        @guardrail(
+            validator=CustomValidator(lambda args: True),
+            action=_FortyTwoAction(),
+            stage=GuardrailExecutionStage.POST,
+        )
+        async def fn(x: int) -> dict[str, int]:
+            return {"result": x}
+
+        assert await fn(1) == {"result": 42}
+
+
+# ---------------------------------------------------------------------------
+# 11. Stage enforcement at decoration time
+# ---------------------------------------------------------------------------
+
+
+class TestStageEnforcement:
+    def test_prompt_injection_on_post_raises_at_decoration(self):
+        with pytest.raises(ValueError, match="stage"):
+            guardrail(
+                lambda text: text,
+                validator=PromptInjectionValidator(),
+                action=LogAction(),
+                stage=GuardrailExecutionStage.POST,
+            )
+
+    def test_prompt_injection_on_pre_and_post_raises_at_decoration(self):
+        with pytest.raises(ValueError, match="stage"):
+            guardrail(
+                lambda text: text,
+                validator=PromptInjectionValidator(),
+                action=LogAction(),
+                stage=GuardrailExecutionStage.PRE_AND_POST,
+            )
+
+    def test_prompt_injection_on_pre_ok(self):
+        # Should not raise
+        guardrail(
+            lambda text: text,
+            validator=PromptInjectionValidator(),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 12. @guardrail validation (bad arguments)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrailDecorator:
+    def test_missing_action_raises(self):
+        with pytest.raises(ValueError, match="action must be provided"):
+            guardrail(
+                lambda text: text,
+                validator=CustomValidator(lambda args: False),
+                action=None,  # type: ignore[arg-type]
+            )
+
+    def test_non_action_instance_raises(self):
+        with pytest.raises(ValueError, match="GuardrailAction"):
+            guardrail(
+                lambda text: text,
+                validator=CustomValidator(lambda args: False),
+                action="bad",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_enabled_for_evals_type_raises(self):
+        with pytest.raises(ValueError, match="boolean"):
+            guardrail(
+                lambda text: text,
+                validator=CustomValidator(lambda args: False),
+                action=LogAction(),
+                enabled_for_evals="yes",  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# 13. Stacked decorators
+# ---------------------------------------------------------------------------
+
+
+class TestStackedDecorators:
+    def test_both_decorators_fire_on_same_function(self):
+        calls: list[str] = []
+
+        def _make_mock(tag: str) -> Any:
+            m = MagicMock()
+            m.supported_stages = []
+            m.validate_stage = MagicMock()
+            m.get_built_in_guardrail.return_value = None
+            m.run.side_effect = lambda *a, **kw: calls.append(tag) or _PASSED  # type: ignore[func-returns-value]
+            return m
+
+        @guardrail(
+            validator=_make_mock("outer"),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+            name="outer",
+        )
+        @guardrail(
+            validator=_make_mock("inner"),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+            name="inner",
+        )
+        def fn(text: str) -> str:
+            return text
+
+        fn("hello")
+        assert "outer" in calls
+        assert "inner" in calls
+
+    def test_outer_block_prevents_inner_from_firing(self):
+        inner_called = []
+
+        outer_validator = MagicMock()
+        outer_validator.supported_stages = []
+        outer_validator.validate_stage = MagicMock()
+        outer_validator.get_built_in_guardrail.return_value = None
+        outer_validator.run.return_value = _FAILED
+
+        inner_validator = MagicMock()
+        inner_validator.supported_stages = []
+        inner_validator.validate_stage = MagicMock()
+        inner_validator.get_built_in_guardrail.return_value = None
+        inner_validator.run.side_effect = lambda *a, **kw: (
+            inner_called.append(True) or _PASSED  # type: ignore[func-returns-value]
+        )
+
+        @guardrail(
+            validator=outer_validator,
+            action=BlockAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        @guardrail(
+            validator=inner_validator,
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def fn(text: str) -> str:
+            return text
+
+        with pytest.raises(GuardrailBlockException):
+            fn("bad")
+
+        assert not inner_called
+
+
+# ---------------------------------------------------------------------------
+# 14. Factory function path (adapter wraps return value)
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryFunctionPath:
+    def test_adapter_wraps_return_value_of_factory(self):
+        register_guardrail_adapter(_DummyAdapter())
+        target = _DummyTarget(return_value={"output": "ok"})
+
+        @guardrail(
+            validator=CustomValidator(lambda args: False),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def factory() -> _DummyTarget:
+            return target
+
+        wrapped = factory()
+        assert isinstance(wrapped, _WrappedDummyTarget)
+
+    def test_factory_pre_guardrail_fires_on_factory_params(self):
+        register_guardrail_adapter(_DummyAdapter())
+        captured: list[Any] = []
+        target = _DummyTarget()
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def factory(config: str) -> _DummyTarget:
+            return target
+
+        factory("test-config")
+        assert captured == [{"config": "test-config"}]
+
+    def test_adapter_recognizes_direct_object(self):
+        register_guardrail_adapter(_DummyAdapter())
+        target = _DummyTarget()
+
+        wrapped = guardrail(
+            target,
+            validator=CustomValidator(lambda args: False),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        assert isinstance(wrapped, _WrappedDummyTarget)
+
+    def test_stacked_guardrails_on_factory_both_wrap_return_value(self):
+        register_guardrail_adapter(_DummyAdapter())
+        target = _DummyTarget()
+        evals: list[str] = []
+
+        def _make_mock(tag: str) -> Any:
+            m = MagicMock()
+            m.supported_stages = []
+            m.validate_stage = MagicMock()
+            m.get_built_in_guardrail.return_value = None
+            m.run.side_effect = lambda *a, **kw: evals.append(tag) or _PASSED  # type: ignore[func-returns-value]
+            return m
+
+        @guardrail(
+            validator=_make_mock("outer"),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        @guardrail(
+            validator=_make_mock("inner"),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def factory() -> _DummyTarget:
+            return target
+
+        wrapped = factory()
+        wrapped.invoke({"x": 1})
+        assert "outer" in evals
+        assert "inner" in evals
+
+
+# ---------------------------------------------------------------------------
+# 15. _make_evaluator — local vs API path
+# ---------------------------------------------------------------------------
+
+
+class TestMakeEvaluator:
+    def test_custom_validator_path_delegates_to_run(self):
+        """_make_evaluator with a CustomGuardrailValidator calls validator.run()."""
+        mock_validator = MagicMock()
+        mock_validator.run.return_value = _PASSED
+        evaluator = _make_evaluator(mock_validator, "G", None, True)
+        result = evaluator({"data": 1}, GuardrailExecutionStage.PRE, {"a": 1}, None)
+        mock_validator.run.assert_called_once_with(
+            "G", None, True, {"data": 1}, GuardrailExecutionStage.PRE, {"a": 1}, None
+        )
+        assert result == _PASSED
+
+    def test_built_in_validator_path_lazy_initializes_uipath(self):
+        """BuiltInGuardrailValidator.run() lazily creates UiPath() and calls API."""
+        from uipath.platform.guardrails.decorators.validators import (
+            BuiltInGuardrailValidator,
+        )
+        from uipath.platform.guardrails.guardrails import BuiltInValidatorGuardrail
+
+        mock_built_in = MagicMock(spec=BuiltInValidatorGuardrail)
+
+        class _TestBuiltIn(BuiltInGuardrailValidator):
+            def get_built_in_guardrail(self, name, description, enabled_for_evals):
+                return mock_built_in
+
+        validator = _TestBuiltIn()
+        evaluator = _make_evaluator(validator, "G", None, True)
+
+        mock_uipath = MagicMock()
+        mock_uipath.guardrails.evaluate_guardrail.return_value = _PASSED
+        with patch("uipath.platform.UiPath", return_value=mock_uipath):
+            evaluator({"text": "hello"}, GuardrailExecutionStage.PRE, None, None)
+            evaluator({"text": "hello"}, GuardrailExecutionStage.PRE, None, None)
+
+        # UiPath() should be created only once despite two calls
+        assert mock_uipath.guardrails.evaluate_guardrail.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 16. Joke-agent integration scenarios (plain functions)
+# ---------------------------------------------------------------------------
+
+
+class _JokeInput(BaseModel):
+    topic: str
+
+
+class _JokeOutput(BaseModel):
+    joke: str
+
+
+class TestJokeAgentScenarios:
+    """Integration tests modelled on the joke-agent-decorator sample."""
+
+    def test_pii_validator_blocks_person_name_in_topic(self):
+        """Agent-level PRE guardrail blocks person names in the input topic."""
+        calls: list[str] = []
+
+        mock_validator = MagicMock()
+        mock_validator.supported_stages = []
+        mock_validator.validate_stage = MagicMock()
+
+        mock_validator.run.return_value = _FAILED
+
+        @guardrail(
+            validator=mock_validator,
+            action=BlockAction(title="Person detected", detail="Not allowed"),
+            stage=GuardrailExecutionStage.PRE,
+            name="Agent PII",
+        )
+        async def joke_node(state: _JokeInput) -> _JokeOutput:
+            calls.append("called")
+            return _JokeOutput(joke="a joke")
+
+        import asyncio
+
+        with pytest.raises(GuardrailBlockException):
+            asyncio.run(joke_node(_JokeInput(topic="John Smith")))
+        assert not calls
+
+    def test_input_pydantic_model_serialized_for_guardrail(self):
+        """State Pydantic model is serialized to dict and sent to evaluator."""
+        captured: list[Any] = []
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def process(state: _JokeInput) -> _JokeOutput:
+            return _JokeOutput(joke="a joke")
+
+        process(_JokeInput(topic="cats"))
+        assert captured == [{"state": {"topic": "cats"}}]
+
+    def test_output_pydantic_model_serialized_for_guardrail(self):
+        """Return Pydantic model is serialized to dict and sent to POST evaluator."""
+        captured: list[Any] = []
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.POST,
+        )
+        def process(state: _JokeInput) -> _JokeOutput:
+            return _JokeOutput(joke="funny joke about cats")
+
+        process(_JokeInput(topic="cats"))
+        assert captured == [{"joke": "funny joke about cats"}]
+
+    def test_excluded_config_param_not_in_guardrail_input(self):
+        """RunnableConfig-style param excluded from evaluation."""
+        captured: list[Any] = []
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: captured.append(args) or False  # type: ignore[func-returns-value]
+            ),
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def process(
+            state: _JokeInput,
+            config: Annotated[dict[str, Any], GuardrailExclude()],
+        ) -> _JokeOutput:
+            return _JokeOutput(joke="joke")
+
+        process(_JokeInput(topic="dogs"), {"thread_id": "abc"})
+        assert "config" not in captured[0]
+        assert "state" in captured[0]
+
+    def test_word_filter_custom_validator_on_tool_function(self):
+        """CustomValidator on plain function replaces offensive word via action."""
+        censored: list[str] = []
+
+        class CensorAction(GuardrailAction):
+            def handle_validation_result(self, result, data, name):
+                if isinstance(data, dict) and "joke" in data:
+                    censored.append(data["joke"])
+                    return {"joke": data["joke"].replace("donkey", "[censored]")}
+                return data
+
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: "donkey" in args.get("joke", "").lower()
+            ),
+            action=CensorAction(),
+            stage=GuardrailExecutionStage.PRE,
+            name="Word Filter",
+        )
+        def analyze_joke(joke: str) -> str:
+            return f"analyzed: {joke}"
+
+        result = analyze_joke(joke="why did the donkey cross the road")
+        assert "censored" in result
+        assert "donkey" not in result
+
+    def test_log_action_does_not_stop_joke_generation(self):
+        """LogAction on PII violation logs but lets execution continue."""
+
+        @guardrail(
+            validator=CustomValidator(lambda args: True),  # always violate
+            action=LogAction(),
+            stage=GuardrailExecutionStage.PRE,
+            name="Always-Log",
+        )
+        def generate_joke(topic: str) -> str:
+            return f"joke about {topic}"
+
+        result = generate_joke("cats")
+        assert result == "joke about cats"
+
+    def test_length_limiter_blocks_long_joke(self):
+        """BlockAction on length check raises for over-long content."""
+
+        @guardrail(
+            validator=CustomValidator(lambda args: len(args.get("joke", "")) > 10),
+            action=BlockAction(title="Too long", detail="Joke exceeds limit"),
+            stage=GuardrailExecutionStage.PRE,
+        )
+        def submit_joke(joke: str) -> str:
+            return joke
+
+        with pytest.raises(GuardrailBlockException, match="Too long"):
+            submit_joke(joke="a" * 20)
+
+        # Short joke passes through
+        assert submit_joke(joke="short") == "short"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1056,7 +1056,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -723,6 +723,7 @@ class TestAgentBuilderConfig:
             == "This validator is designed to detect personally identifiable information using Azure Cognitive Services"
         )
         assert agent_builtin_guardrail.enabled_for_evals is True
+        assert agent_builtin_guardrail.selector is not None
         assert agent_builtin_guardrail.selector.scopes == ["Tool"]
         assert agent_builtin_guardrail.selector.match_names == ["StringToNumber"]
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2650,7 +2650,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What changed?

Moves the `@guardrail` decorator framework from `uipath-langchain` into `uipath-platform` as a framework-agnostic subpackage, making it available to any Python agent framework — not just LangChain.

New subpackage: `uipath.platform.guardrails.decorators`

- **`@guardrail` decorator** — wraps tools, LLMs, and state graphs; dispatches to registered framework adapters via an adapter/registry pattern
- **Validators**: `PIIValidator`, `PromptInjectionValidator`, `CustomValidator` (with `RuleFunction` type alias)
- **Actions**: `LogAction` (log violations without blocking), `BlockAction` (raise `GuardrailBlockException`)
- **`GuardrailBlockException`** — framework-agnostic exception raised by `BlockAction`; framework adapters (e.g. LangChain) catch and convert to their own error type
- **`GuardrailTargetAdapter` Protocol** + `register_guardrail_adapter()` — allows downstream packages to teach the decorator how to wrap their objects
- **`GuardrailExecutionStage`** enum (`PRE` / `POST`), `PIIDetectionEntityType` enum, `PIIDetectionEntity` model
- All new symbols are exported from `uipath.platform.guardrails`

Version bumped: `0.1.15` → `0.1.16`

## How has this been tested?

- New test file: `packages/uipath-platform/tests/services/test_guardrails_decorators.py` (74 tests)
- Tests use a `_DummyTarget` / `_DummyAdapter` / `_WrappedDummyTarget` pattern to exercise the full decorator pipeline without any LangChain dependency
- Covers: scope/stage enforcement, API guardrail routing, `_evaluate_rules` semantics (empty rules, exception in rule, mixed pass/fail), lazy `UiPath()` initialization, adapter registry priority, stacked decorators, and 9 joke-agent integration scenarios

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations required
- [ ] API removals / changes
- [ ] Other