### PR TITLE
fix: exclude start and limit from params if not provided

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.25"
+version = "0.1.26"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
@@ -1115,12 +1115,17 @@ class EntitiesService(BaseService):
         start: Optional[int] = None,
         limit: Optional[int] = None,
     ) -> RequestSpec:
+        params: dict[str, Any] = {}
+        if start is not None:
+            params["start"] = start
+        if limit is not None:
+            params["limit"] = limit
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(
                 f"datafabric_/api/EntityService/entity/{entity_key}/read"
             ),
-            params=({"start": start, "limit": limit}),
+            params=params,
         )
 
     def _query_entity_records_spec(

--- a/packages/uipath-platform/tests/services/test_entities_service.py
+++ b/packages/uipath-platform/tests/services/test_entities_service.py
@@ -267,6 +267,41 @@ class TestEntitiesService:
                     limit=1,
                 )
 
+    def test_retrieve_records_without_start_and_limit(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        entity_key = uuid.uuid4()
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/EntityService/entity/{str(entity_key)}/read",
+            status_code=200,
+            json={
+                "totalCount": 1,
+                "value": [
+                    {"Id": "12345", "name": "record_name", "integer_field": 10},
+                ],
+            },
+        )
+
+        records = service.list_records(entity_key=str(entity_key))
+
+        sent_request = httpx_mock.get_request()
+        if sent_request is None:
+            raise Exception("No request was sent")
+
+        # Verify no start or limit query params are sent
+        assert "start" not in str(sent_request.url.params)
+        assert "limit" not in str(sent_request.url.params)
+
+        assert isinstance(records, list)
+        assert len(records) == 1
+        assert records[0].id == "12345"
+
     @pytest.mark.parametrize(
         "sql_query",
         [

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
See summary from Claude below.
`start` and `limit` params are optional but still included in the route like `start=` which returns a `400 bad request`.
Manually tried the same request with the SDK which now works.
<img width="2242" height="532" alt="image" src="https://github.com/user-attachments/assets/970f8b87-fdc3-4ae1-a98b-6f75f6236141" />
