### PR TITLE
fix: pass through error details to CAS for unrecognized error IDs [JAR-9616]

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.48"
+version = "2.10.49"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_chat/_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_chat/_bridge.py
@@ -75,7 +75,9 @@ def _extract_error_info(error: Exception) -> tuple[str, str]:
             message = title or detail or _CAS_ERROR_MESSAGES[CASErrorId.DEFAULT_ERROR]
         return code, message
 
-    return CASErrorId.DEFAULT_ERROR, _CAS_ERROR_MESSAGES[CASErrorId.DEFAULT_ERROR]
+    return CASErrorId.DEFAULT_ERROR, str(error) or _CAS_ERROR_MESSAGES[
+        CASErrorId.DEFAULT_ERROR
+    ]
 
 
 def _resolve_cas_error(error: Exception) -> tuple[str, str]:
@@ -89,7 +91,10 @@ def _resolve_cas_error(error: Exception) -> tuple[str, str]:
     error_code, error_message = _extract_error_info(error)
     suffix = error_code.rsplit(".", 1)[-1] if error_code else ""
     cas_error_id = _CAS_ERROR_ID_MAP.get(suffix, CASErrorId.DEFAULT_ERROR)
-    cas_message = _CAS_ERROR_MESSAGES.get(cas_error_id) or error_message
+    if cas_error_id == CASErrorId.DEFAULT_ERROR:
+        cas_message = error_message
+    else:
+        cas_message = _CAS_ERROR_MESSAGES.get(cas_error_id) or error_message
     return cas_error_id, cas_message
 
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.48"
+version = "2.10.49"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- https://uipath.atlassian.net/browse/JAR-9616
- Pass through actual error details to CAS for unrecognized error IDs instead of showing a generic "An unexpected error has occurred." message                                                                     
 - Known error IDs (licensing, max steps, incomplete response) continue to use hardcoded CAS messages                                                                                                               