### PR TITLE
feat: add choiceset support to entities service

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.26"
+version = "0.1.27"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/entities/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/__init__.py
@@ -5,6 +5,7 @@ This module contains models related to UiPath Entities service.
 
 from ._entities_service import EntitiesService
 from .entities import (
+    ChoiceSetValue,
     DataFabricEntityItem,
     Entity,
     EntityField,
@@ -24,6 +25,7 @@ from .entities import (
 )
 
 __all__ = [
+    "ChoiceSetValue",
     "DataFabricEntityItem",
     "EntitiesService",
     "Entity",

--- a/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
@@ -1,3 +1,4 @@
+import json as json_module
 import logging
 from typing import Any, Dict, List, Optional, Type
 
@@ -24,6 +25,7 @@ from ._entity_resolution import (
     fetch_resolved_entities_async,
 )
 from .entities import (
+    ChoiceSetValue,
     DataFabricEntityItem,
     Entity,
     EntityRecord,
@@ -281,6 +283,99 @@ class EntitiesService(BaseService):
 
         entities_data = response.json()
         return [Entity.model_validate(entity) for entity in entities_data]
+
+    @traced(name="list_choicesets", run_type="uipath")
+    def list_choicesets(self) -> List[Entity]:
+        """List all choice sets in Data Service.
+
+        Returns:
+            List[Entity]: A list of all choice set entities.
+
+        Examples:
+            List all choice sets::
+
+                choicesets = entities_service.list_choicesets()
+                for cs in choicesets:
+                    print(f"{cs.display_name} ({cs.id})")
+        """
+        spec = self._list_choicesets_spec()
+        response = self.request(spec.method, spec.endpoint)
+        return [Entity.model_validate(item) for item in response.json()]
+
+    @traced(name="list_choicesets", run_type="uipath")
+    async def list_choicesets_async(self) -> List[Entity]:
+        """Asynchronously list all choice sets in Data Service.
+
+        Returns:
+            List[Entity]: A list of all choice set entities.
+        """
+        spec = self._list_choicesets_spec()
+        response = await self.request_async(spec.method, spec.endpoint)
+        return [Entity.model_validate(item) for item in response.json()]
+
+    @traced(name="get_choiceset_values", run_type="uipath")
+    def get_choiceset_values(
+        self,
+        choiceset_id: str,
+        start: int | None = None,
+        limit: int | None = None,
+    ) -> List[ChoiceSetValue]:
+        """Get the values of a choice set by its ID.
+
+        Args:
+            choiceset_id: The unique identifier of the choice set.
+            start: Optional offset for pagination.
+            limit: Optional page size for pagination.
+
+        Returns:
+            List[ChoiceSetValue]: The values in the choice set, each containing
+                id, name, display_name, and number_id.
+
+        Examples:
+            Get all values in a choice set::
+
+                values = entities_service.get_choiceset_values("choiceset-id")
+                for v in values:
+                    print(f"{v.number_id}: {v.display_name}")
+        """
+        spec = self._get_choiceset_values_spec(choiceset_id, start=start, limit=limit)
+        response = self.request(
+            spec.method, spec.endpoint, params=spec.params, json=spec.json
+        )
+        data = response.json()
+        raw_values = data.get("jsonValue", "[]")
+        items = (
+            json_module.loads(raw_values) if isinstance(raw_values, str) else raw_values
+        )
+        return [ChoiceSetValue.model_validate(item) for item in items]
+
+    @traced(name="get_choiceset_values", run_type="uipath")
+    async def get_choiceset_values_async(
+        self,
+        choiceset_id: str,
+        start: int | None = None,
+        limit: int | None = None,
+    ) -> List[ChoiceSetValue]:
+        """Asynchronously get the values of a choice set by its ID.
+
+        Args:
+            choiceset_id: The unique identifier of the choice set.
+            start: Optional offset for pagination.
+            limit: Optional page size for pagination.
+
+        Returns:
+            List[ChoiceSetValue]: The values in the choice set.
+        """
+        spec = self._get_choiceset_values_spec(choiceset_id, start=start, limit=limit)
+        response = await self.request_async(
+            spec.method, spec.endpoint, params=spec.params, json=spec.json
+        )
+        data = response.json()
+        raw_values = data.get("jsonValue", "[]")
+        items = (
+            json_module.loads(raw_values) if isinstance(raw_values, str) else raw_values
+        )
+        return [ChoiceSetValue.model_validate(item) for item in items]
 
     @traced(name="entity_list_records", run_type="uipath")
     def list_records(
@@ -1171,6 +1266,32 @@ class EntitiesService(BaseService):
                 f"datafabric_/api/EntityService/entity/{entity_key}/delete-batch"
             ),
             json=record_ids,
+        )
+
+    def _list_choicesets_spec(self) -> RequestSpec:
+        return RequestSpec(
+            method="GET",
+            endpoint=Endpoint("datafabric_/api/Entity/choiceset"),
+        )
+
+    def _get_choiceset_values_spec(
+        self,
+        choiceset_id: str,
+        start: int | None = None,
+        limit: int | None = None,
+    ) -> RequestSpec:
+        params: dict[str, Any] = {}
+        if start is not None:
+            params["start"] = start
+        if limit is not None:
+            params["limit"] = limit
+        return RequestSpec(
+            method="POST",
+            endpoint=Endpoint(
+                f"datafabric_/api/EntityService/entity/{choiceset_id}/query_expansion"
+            ),
+            params=params,
+            json={},
         )
 
     def _validate_sql_query(self, sql_query: str) -> None:

--- a/packages/uipath-platform/src/uipath/platform/entities/entities.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/entities.py
@@ -222,6 +222,25 @@ class SourceJoinCriteria(BaseModel):
     related_source_field_name: str = Field(alias="relatedSourceFieldName")
 
 
+class ChoiceSetValue(BaseModel):
+    """Model representing a single value within a choice set."""
+
+    model_config = ConfigDict(
+        validate_by_name=True,
+        validate_by_alias=True,
+    )
+
+    id: str = Field(alias="Id")
+    name: str = Field(alias="Name")
+    display_name: str = Field(alias="DisplayName")
+    number_id: int = Field(alias="NumberId")
+    created_time: str | None = Field(default=None, alias="CreateTime")
+    updated_time: str | None = Field(default=None, alias="UpdateTime")
+    created_by: str | None = Field(default=None, alias="CreatedBy")
+    updated_by: str | None = Field(default=None, alias="UpdatedBy")
+    record_owner: str | None = Field(default=None, alias="RecordOwner")
+
+
 class EntityRecord(BaseModel):
     """Model representing a record within an entity."""
 

--- a/packages/uipath-platform/tests/services/test_entities_service.py
+++ b/packages/uipath-platform/tests/services/test_entities_service.py
@@ -1,3 +1,4 @@
+import json
 import re
 import uuid
 from dataclasses import make_dataclass
@@ -12,7 +13,7 @@ from uipath.platform.common._bindings import (
     EntityResourceOverwrite,
     _resource_overwrites,
 )
-from uipath.platform.entities import DataFabricEntityItem, Entity
+from uipath.platform.entities import ChoiceSetValue, DataFabricEntityItem, Entity
 from uipath.platform.entities._entities_service import EntitiesService
 
 
@@ -810,3 +811,243 @@ class TestEntitiesService:
                 },
             ]
         }
+
+    def test_list_choicesets(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/Entity/choiceset",
+            status_code=200,
+            json=[
+                {
+                    "name": "Status",
+                    "displayName": "Status",
+                    "entityType": "ChoiceSet",
+                    "description": "Status choices",
+                    "isRbacEnabled": False,
+                    "id": "cs-001",
+                },
+                {
+                    "name": "Priority",
+                    "displayName": "Priority",
+                    "entityType": "ChoiceSet",
+                    "description": "Priority levels",
+                    "isRbacEnabled": False,
+                    "id": "cs-002",
+                },
+            ],
+        )
+
+        choicesets = service.list_choicesets()
+
+        assert isinstance(choicesets, list)
+        assert len(choicesets) == 2
+        assert choicesets[0].name == "Status"
+        assert choicesets[0].entity_type == "ChoiceSet"
+        assert choicesets[0].id == "cs-001"
+        assert choicesets[1].name == "Priority"
+
+        sent_request = httpx_mock.get_request()
+        assert sent_request is not None
+        assert sent_request.method == "GET"
+        assert str(sent_request.url).endswith("/datafabric_/api/Entity/choiceset")
+
+    @pytest.mark.anyio
+    async def test_list_choicesets_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/Entity/choiceset",
+            status_code=200,
+            json=[
+                {
+                    "name": "Role",
+                    "displayName": "Role",
+                    "entityType": "ChoiceSet",
+                    "isRbacEnabled": False,
+                    "id": "cs-003",
+                },
+            ],
+        )
+
+        choicesets = await service.list_choicesets_async()
+
+        assert len(choicesets) == 1
+        assert choicesets[0].name == "Role"
+        assert choicesets[0].id == "cs-003"
+
+    def test_get_choiceset_values(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        choiceset_id = "cs-001"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/EntityService/entity/{choiceset_id}/query_expansion",
+            status_code=200,
+            json={
+                "totalRecordCount": 3,
+                "jsonValue": json.dumps(
+                    [
+                        {
+                            "Id": "v1",
+                            "Name": "Active",
+                            "DisplayName": "Active",
+                            "NumberId": 0,
+                            "CreateTime": "2026-01-01T00:00:00Z",
+                            "UpdateTime": "2026-01-01T00:00:00Z",
+                        },
+                        {
+                            "Id": "v2",
+                            "Name": "Inactive",
+                            "DisplayName": "Inactive",
+                            "NumberId": 1,
+                            "CreateTime": "2026-01-01T00:00:00Z",
+                            "UpdateTime": "2026-01-01T00:00:00Z",
+                        },
+                        {
+                            "Id": "v3",
+                            "Name": "Pending",
+                            "DisplayName": "Pending",
+                            "NumberId": 2,
+                        },
+                    ]
+                ),
+            },
+        )
+
+        values = service.get_choiceset_values(choiceset_id)
+
+        assert isinstance(values, list)
+        assert len(values) == 3
+        assert isinstance(values[0], ChoiceSetValue)
+        assert values[0].id == "v1"
+        assert values[0].name == "Active"
+        assert values[0].display_name == "Active"
+        assert values[0].number_id == 0
+        assert values[1].number_id == 1
+        assert values[2].name == "Pending"
+        assert values[2].created_by is None
+
+        sent_request = httpx_mock.get_request()
+        assert sent_request is not None
+        assert sent_request.method == "POST"
+
+    def test_get_choiceset_values_with_pagination(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        choiceset_id = "cs-001"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/EntityService/entity/{choiceset_id}/query_expansion?start=0&limit=2",
+            status_code=200,
+            json={
+                "totalRecordCount": 5,
+                "jsonValue": json.dumps(
+                    [
+                        {
+                            "Id": "v1",
+                            "Name": "Active",
+                            "DisplayName": "Active",
+                            "NumberId": 0,
+                        },
+                        {
+                            "Id": "v2",
+                            "Name": "Inactive",
+                            "DisplayName": "Inactive",
+                            "NumberId": 1,
+                        },
+                    ]
+                ),
+            },
+        )
+
+        values = service.get_choiceset_values(choiceset_id, start=0, limit=2)
+
+        assert len(values) == 2
+        assert values[0].name == "Active"
+        assert values[1].name == "Inactive"
+
+        sent_request = httpx_mock.get_request()
+        assert sent_request is not None
+        assert "start=0" in str(sent_request.url)
+        assert "limit=2" in str(sent_request.url)
+
+    @pytest.mark.anyio
+    async def test_get_choiceset_values_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        choiceset_id = "cs-002"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/EntityService/entity/{choiceset_id}/query_expansion",
+            status_code=200,
+            json={
+                "totalRecordCount": 1,
+                "jsonValue": json.dumps(
+                    [
+                        {
+                            "Id": "v1",
+                            "Name": "ReadOnly",
+                            "DisplayName": "Read Only",
+                            "NumberId": 0,
+                        },
+                    ]
+                ),
+            },
+        )
+
+        values = await service.get_choiceset_values_async(choiceset_id)
+
+        assert len(values) == 1
+        assert values[0].display_name == "Read Only"
+        assert values[0].number_id == 0
+
+    def test_get_choiceset_values_empty(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        choiceset_id = "cs-empty"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/EntityService/entity/{choiceset_id}/query_expansion",
+            status_code=200,
+            json={
+                "totalRecordCount": 0,
+                "jsonValue": "[]",
+            },
+        )
+
+        values = service.get_choiceset_values(choiceset_id)
+
+        assert values == []

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add `list_choicesets()` and `get_choiceset_values()` to `EntitiesService` (sync + async)
- new `ChoiceSetValue` model for choice set value responses
- consumes `GET /api/Entity/choiceset` and `POST /api/EntityService/entity/{id}/query_expansion`
- handles API quirk where `jsonValue` is returned as a JSON string, not a list

## Why
choicesets are entities in data service but weren't accessible through the python sdk. users querying entities with choiceset fields only get numeric ids back and had no way to resolve them to display names. mirrors the existing typescript sdk support https://uipath.github.io/uipath-typescript/api/interfaces/ChoiceSetServiceModel/. 