### PR TITLE
ci: trigger docs rebuild on platform/core source changes

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,6 +9,10 @@ on:
       - "packages/uipath/docs/**"
       - "packages/uipath/mkdocs.yml"
       - "packages/uipath/pyproject.toml"
+      - "packages/uipath-platform/src/**"
+      - "packages/uipath-platform/pyproject.toml"
+      - "packages/uipath-core/src/**"
+      - "packages/uipath-core/pyproject.toml"
   repository_dispatch:
     types: [publish-docs]
 

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.27"
+version = "0.1.28"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add `packages/uipath-platform/src/**`, `packages/uipath-platform/pyproject.toml`, `packages/uipath-core/src/**`, and `packages/uipath-core/pyproject.toml` to the publish-docs workflow trigger paths
- version bump to 0.1.28 to verify the workflow triggers on merge via the new `pyproject.toml` path

## Why
docs are generated from docstrings via mkdocstrings but the workflow only triggered on changes under `packages/uipath/docs/`. new service methods (like the choiceset support just merged) didn't show up on the docs site until an unrelated docs file was changed.