### PR TITLE
fix(platform): add HEADER_MODE request header constant

### DIFF
--- a/packages/uipath-platform/src/uipath/platform/common/constants.py
+++ b/packages/uipath-platform/src/uipath/platform/common/constants.py
@@ -37,6 +37,7 @@ HEADER_PROCESS_KEY = "x-uipath-processkey"
 HEADER_TRACE_ID = "x-uipath-traceid"
 HEADER_AGENTHUB_CONFIG = "x-uipath-agenthub-config"
 HEADER_LLMGATEWAY_BYO_CONNECTION_ID = "x-uipath-llmgateway-byoisconnectionid"
+HEADER_MODE = "x-uipath-mode"
 HEADER_SW_LOCK_KEY = "x-uipath-sw-lockkey"
 HEADER_LICENSING_CONTEXT = "x-uipath-licensing-context"
 


### PR DESCRIPTION
 ## Summary
  - Add `HEADER_MODE = "x-uipath-mode"` to `uipath.platform.common.constants`

  ## Test plan
  - [x] `ruff check .` passes
  - [x] `ruff format --check .` passes
  - [x] `mypy src tests` — no issues in 166 source files
  - [x] `pytest` — 999 passed, 7 skipped (unrelated credential-required tests)
  - [x] No behavior change in this package; constant is an addition.
