### PR TITLE
fix: accept remoteA2aAgent in GenericResourceOverwrite

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.32"
+version = "0.1.33"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_bindings.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_bindings.py
@@ -52,7 +52,14 @@ class ResourceOverwrite(BaseModel, ABC):
 
 class GenericResourceOverwrite(ResourceOverwrite):
     resource_type: Literal[
-        "process", "index", "app", "asset", "bucket", "mcpServer", "queue"
+        "process",
+        "index",
+        "app",
+        "asset",
+        "bucket",
+        "mcpServer",
+        "queue",
+        "remoteA2aAgent",
     ]
     name: str = Field(alias="name")
     folder_path: str = Field(alias="folderPath")

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/tests/sdk/test_bindings.py
+++ b/packages/uipath/tests/sdk/test_bindings.py
@@ -391,3 +391,28 @@ class TestConnectionResourceOverwriteAliases:
         assert isinstance(overwrite, ConnectionResourceOverwrite)
         assert overwrite.connection_id == "conn-456"
         assert overwrite.folder_key == "folder2"
+
+
+class TestRemoteA2aAgentResourceOverwrite:
+    """Test that Remote A2A agent resources parse as GenericResourceOverwrite."""
+
+    def test_remote_a2a_agent_resource_overwrite(self):
+        overwrite = GenericResourceOverwrite(
+            resource_type="remoteA2aAgent",
+            name="basica2a",
+            folder_path="Customers/ProjectA",
+        )
+        assert overwrite.resource_type == "remoteA2aAgent"
+        assert overwrite.resource_identifier == "basica2a"
+        assert overwrite.folder_identifier == "Customers/ProjectA"
+
+    def test_parse_remote_a2a_agent(self):
+        """Parser accepts a remoteA2aAgent-keyed overwrite without discriminator error."""
+        overwrite = ResourceOverwriteParser.parse(
+            key="remoteA2aAgent.basica2a.solution_folder",
+            value={"name": "basica2a", "folderPath": "Customers/ProjectA"},
+        )
+        assert isinstance(overwrite, GenericResourceOverwrite)
+        assert overwrite.resource_type == "remoteA2aAgent"
+        assert overwrite.resource_identifier == "basica2a"
+        assert overwrite.folder_identifier == "Customers/ProjectA"

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds `remoteA2aAgent` to the accepted `resource_type` tags of `GenericResourceOverwrite`. Unblocks agents that reference Remote A2A resources — they currently fail to start in Alpha with a Pydantic `union_tag_invalid` error.

## Root cause

Solutions containing Remote A2A resources emit runtime overwrites keyed by `remoteA2aAgent.<name>[.<folder>]` (see AgentHubService `Kind.RemoteA2aAgent` → serialized as camelCase `remoteA2aAgent`). At agent startup the runtime deserializes the overwrite map via `ResourceOverwriteParser.parse`, which validates each entry against the discriminated union `ResourceOverwriteUnion`.

The parser extracts `remoteA2aAgent` as the discriminator but the `GenericResourceOverwrite.resource_type` Literal only listed `process | index | app | asset | bucket | mcpServer | queue`. Pydantic rejects the tag → the whole overwrite batch fails → agent never starts.

Observed error (from Alpha job logs):
```
1 validation error for tagged-union[GenericResourceOverwrite, ..., EntityResourceOverwrite, ConnectionResourceOverwrite]
  Input tag 'remoteA2aAgent' found using 'resource_type' does not match any of the expected tags:
  'process', 'index', 'app', 'asset', 'bucket', 'mcpServer', 'queue', 'entity', 'connection'
  [type=union_tag_invalid, input_value={'resource_type': 'remote...', 'name': 'basica2a'}, input_type=dict]
```

## Fix

Extend the Literal with `"remoteA2aAgent"`. Remote A2A overwrites have the same `name` + `folderPath` shape as other generic resources, so no dedicated subclass is needed.

Bumps `uipath-platform` to `0.1.33`.

## What was missing from the original rollout

Remote A2A support was added across the stack — `AgentA2aResourceConfig` (agent.json authoring), `a2a_tool.py` in `uipath-langchain-python`, the langgraph wiring in `uipath-agents-python`, and the CRUD + proxy endpoints in `AgentHubService`. This overwrite binding was the one gap: the parser is the gate every agent runtime passes through at startup, regardless of whether the A2A code itself uses the override today.

## Test plan

- [x] New test class `TestRemoteA2aAgentResourceOverwrite` covers:
  - Direct `GenericResourceOverwrite(resource_type="remoteA2aAgent", ...)` construction
  - `ResourceOverwriteParser.parse(key="remoteA2aAgent.basica2a.solution_folder", ...)` roundtrip
- [x] Full `uipath` test suite: 1786 passed, 0 failures
- [ ] End-to-end validation in Alpha: deploy a solution containing a low-code agent with an A2A resource, start a job, confirm no `union_tag_invalid` error

## Links

Observed in Alpha against low-code agent `2d2417eb-881b-4828-9018-f9eb7683c5dc` with an A2A resource `basica2a` (external `a2a-test-agent-192161339979.us-central1.run.app`).