### PR TITLE
feat: create virtual resources on push when catalog lookup misses

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.34"
+version = "0.1.35"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/resource_catalog/_resource_catalog_service.py
+++ b/packages/uipath-platform/src/uipath/platform/resource_catalog/_resource_catalog_service.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+from typing import Any, AsyncGenerator, Dict, Iterator, List, Optional
 
 from uipath.core.tracing import traced
 
@@ -110,7 +110,7 @@ class ResourceCatalogService(FolderContext, BaseService):
         resource_types: Optional[List[ResourceType]] = None,
         resource_sub_types: Optional[List[str]] = None,
         page_size: int = _DEFAULT_PAGE_SIZE,
-    ) -> AsyncIterator[Resource]:
+    ) -> AsyncGenerator[Resource, None]:
         """Asynchronously search for tenant scoped resources and folder scoped resources (accessible to the user).
 
         This method automatically handles pagination and yields resources one by one.
@@ -258,7 +258,7 @@ class ResourceCatalogService(FolderContext, BaseService):
         folder_path: Optional[str] = None,
         folder_key: Optional[str] = None,
         page_size: int = _DEFAULT_PAGE_SIZE,
-    ) -> AsyncIterator[Resource]:
+    ) -> AsyncGenerator[Resource, None]:
         """Asynchronously get tenant scoped resources and folder scoped resources (accessible to the user).
 
         If no folder identifier is provided (path or key) only tenant resources will be retrieved.
@@ -428,7 +428,7 @@ class ResourceCatalogService(FolderContext, BaseService):
         folder_path: Optional[str] = None,
         folder_key: Optional[str] = None,
         page_size: int = _DEFAULT_PAGE_SIZE,
-    ) -> AsyncIterator[Resource]:
+    ) -> AsyncGenerator[Resource, None]:
         """Asynchronously get resources of a specific type (tenant scoped or folder scoped).
 
         If no folder identifier is provided (path or key) only tenant resources will be retrieved.

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.34"
+version = "0.1.35"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.51"
+version = "2.10.52"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_push/_resolvers.py
+++ b/packages/uipath/src/uipath/_cli/_push/_resolvers.py
@@ -1,0 +1,177 @@
+from typing import AsyncIterator
+
+from uipath.platform.connections import ConnectionsService
+from uipath.platform.errors import EnrichedException, FolderNotFoundException
+from uipath.platform.resource_catalog import (
+    Resource,
+    ResourceCatalogService,
+    ResourceType,
+)
+
+from .._utils._studio_project import (
+    ReferencedResourceFolder,
+    ReferencedResourceRequest,
+    VirtualResourceRequest,
+)
+from ..models.runtime_schema import BindingResource, Bindings
+from ._resource_actions import CreateReference, CreateVirtual, ResourceAction, Skip
+
+_NOT_FOUND_SUFFIX = "was not found and will not be added to the solution."
+
+
+async def resolve_bindings(
+    bindings: Bindings,
+    resource_catalog: ResourceCatalogService,
+    connections: ConnectionsService,
+    supported_virtual_kinds: set[str],
+) -> AsyncIterator[ResourceAction]:
+    """Yield one ResourceAction per importable binding.
+
+    Bindings that should be silently ignored (e.g. guardrail bindings without a
+    folderPath) are filtered out here.
+    """
+    for binding in bindings.resources:
+        action = await _resolve_binding(
+            binding, resource_catalog, connections, supported_virtual_kinds
+        )
+        if action is not None:
+            yield action
+
+
+async def _resolve_binding(
+    binding: BindingResource,
+    resource_catalog: ResourceCatalogService,
+    connections: ConnectionsService,
+    supported_virtual_kinds: set[str],
+) -> ResourceAction | None:
+    if binding.resource == "connection":
+        return await _resolve_connection(binding, resource_catalog, connections)
+    return await _resolve_regular(binding, resource_catalog, supported_virtual_kinds)
+
+
+async def _resolve_connection(
+    binding: BindingResource,
+    resource_catalog: ResourceCatalogService,
+    connections: ConnectionsService,
+) -> ResourceAction | None:
+    connection_id_value = binding.value.get("ConnectionId")
+    if connection_id_value is None:
+        raise ValueError(
+            f"Connection binding {binding.key!r} is missing required field 'ConnectionId'"
+        )
+    connection_key = connection_id_value.default_value
+
+    try:
+        connection = await connections.retrieve_async(connection_key)
+    except EnrichedException:
+        connector_name = (binding.metadata or {}).get("Connector")
+        return Skip(
+            message=(
+                f"Connection with key '{connection_key}' of type "
+                f"'{connector_name}' {_NOT_FOUND_SUFFIX}"
+            )
+        )
+
+    resource_name: str = connection.name
+    folder_path: str = connection.folder.get("path")
+
+    found = await _find_in_resource_catalog(
+        resource_catalog, "connection", resource_name, folder_path
+    )
+    if found is None:
+        return Skip(
+            message=(
+                f"Resource '{resource_name}' of type 'connection' at folder path "
+                f"'{folder_path}' {_NOT_FOUND_SUFFIX}"
+            )
+        )
+    return _build_create_reference(found, resource_name)
+
+
+async def _resolve_regular(
+    binding: BindingResource,
+    resource_catalog: ResourceCatalogService,
+    supported_virtual_kinds: set[str],
+) -> ResourceAction | None:
+    name_value = binding.value.get("name")
+    folder_path_value = binding.value.get("folderPath")
+    if not folder_path_value:
+        # guardrail resource, nothing to import
+        return None
+    if name_value is None:
+        raise ValueError(f"Binding {binding.key!r} is missing required field 'name'")
+    resource_name: str = name_value.default_value
+    folder_path: str = folder_path_value.default_value
+    resource_type: str = binding.resource
+
+    found = await _find_in_resource_catalog(
+        resource_catalog, resource_type, resource_name, folder_path
+    )
+    if found is not None:
+        return _build_create_reference(found, resource_name)
+
+    if resource_type not in supported_virtual_kinds:
+        return Skip(
+            message=(
+                f"Cannot create virtual resource '{resource_name}' — "
+                f"kind '{resource_type}' is not supported."
+            )
+        )
+
+    sub_type: str | None = (binding.metadata or {}).get("SubType")
+    return CreateVirtual(
+        request=VirtualResourceRequest(
+            kind=resource_type,
+            name=resource_name,
+            type=sub_type,
+        )
+    )
+
+
+async def _find_in_resource_catalog(
+    resource_catalog: ResourceCatalogService,
+    resource_type: str,
+    name: str,
+    folder_path: str,
+) -> Resource | None:
+    """Look up a single resource in the Resource Catalog.
+
+    Returns the first match or None if the catalog can't search this kind, the
+    folder is unknown, or no resource matches.
+    """
+    catalog_type = next(
+        (m for m in ResourceType if m.value == resource_type.lower()), None
+    )
+    if catalog_type is None:
+        return None
+
+    resources = resource_catalog.list_by_type_async(
+        resource_type=catalog_type, name=name, folder_path=folder_path
+    )
+    try:
+        return await anext(resources, None)
+    except FolderNotFoundException:
+        return None
+    finally:
+        await resources.aclose()
+
+
+def _build_create_reference(
+    found_resource: Resource, resource_name: str
+) -> CreateReference:
+    folder = next(iter(found_resource.folders))
+    return CreateReference(
+        request=ReferencedResourceRequest(
+            key=found_resource.resource_key,
+            kind=found_resource.resource_type,
+            type=found_resource.resource_sub_type,
+            folder=ReferencedResourceFolder(
+                folder_key=folder.key,
+                fully_qualified_name=folder.fully_qualified_name,
+                path=folder.path,
+            ),
+        ),
+        resource_name=resource_name,
+        kind=found_resource.resource_type,
+        sub_type=found_resource.resource_sub_type,
+    )

--- a/packages/uipath/src/uipath/_cli/_push/_resource_actions.py
+++ b/packages/uipath/src/uipath/_cli/_push/_resource_actions.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from .._utils._studio_project import (
+    ReferencedResourceRequest,
+    VirtualResourceRequest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CreateReference:
+    request: ReferencedResourceRequest
+    resource_name: str
+    kind: str
+    sub_type: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CreateVirtual:
+    request: VirtualResourceRequest
+
+
+@dataclass(frozen=True, slots=True)
+class Skip:
+    message: str
+
+
+ResourceAction = CreateReference | CreateVirtual | Skip

--- a/packages/uipath/src/uipath/_cli/_push/_summary.py
+++ b/packages/uipath/src/uipath/_cli/_push/_summary.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+import click
+
+
+@dataclass
+class ResourceImportSummary:
+    created: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    virtual_created: int = 0
+    virtual_existing: int = 0
+    not_found: int = 0
+
+    @property
+    def total(self) -> int:
+        return (
+            self.created
+            + self.updated
+            + self.unchanged
+            + self.virtual_created
+            + self.virtual_existing
+            + self.not_found
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"\n \U0001f535 Resource import summary: {self.total} total resources - "
+            f"{click.style(str(self.created), fg='green')} created, "
+            f"{click.style(str(self.updated), fg='blue')} updated, "
+            f"{click.style(str(self.unchanged), fg='yellow')} unchanged, "
+            f"{click.style(str(self.virtual_created), fg='green')} virtual-created, "
+            f"{click.style(str(self.virtual_existing), fg='yellow')} virtual-existing, "
+            f"{click.style(str(self.not_found), fg='red')} not found"
+        )

--- a/packages/uipath/src/uipath/_cli/_push/_virtual_kinds.py
+++ b/packages/uipath/src/uipath/_cli/_push/_virtual_kinds.py
@@ -1,0 +1,34 @@
+import logging
+
+from .._utils._studio_project import ResourceBuilderMetadataEntry, StudioClient
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK: frozenset[str] = frozenset(
+    {"app", "asset", "bucket", "process", "queue", "taskCatalog", "trigger"}
+)
+
+
+async def fetch_supported_virtual_kinds(studio_client: StudioClient) -> set[str]:
+    """Return the set of resource kinds that support inline creation.
+
+    Falls back to a static list on any failure — the caller shouldn't have to
+    care whether the metadata endpoint was reachable.
+    """
+    try:
+        metadata = await studio_client.get_resource_builder_metadata()
+    except Exception as e:
+        logger.debug("Resource Builder metadata fetch failed, using fallback: %s", e)
+        return set(_FALLBACK)
+    return _extract_supported_kinds(metadata)
+
+
+def _extract_supported_kinds(
+    metadata: list[ResourceBuilderMetadataEntry],
+) -> set[str]:
+    # metadata has one entry per (kind, type), so a kind may appear multiple times
+    return {
+        entry.kind
+        for entry in metadata
+        if any(version.supports_in_line_creation for version in entry.versions)
+    }

--- a/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
@@ -6,7 +6,6 @@ from functools import wraps
 from pathlib import PurePath
 from typing import Any, Callable, List, Optional, Union
 
-import click
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from uipath._utils.constants import (
@@ -152,12 +151,20 @@ class LockInfo(BaseModel):
     solution_lock_key: Optional[str] = Field(alias="solutionLockKey")
 
 
-class Severity(str, Enum):
-    """Severity level for virtual resource operation results."""
+class ResourceBuilderMetadataVersion(BaseModel):
+    model_config = ConfigDict(extra="allow")
 
-    SUCCESS = "success"
-    ATTENTION = "attention"
-    WARN = "warn"
+    supports_in_line_creation: bool = Field(
+        default=False, alias="supportsInLineCreation"
+    )
+
+
+class ResourceBuilderMetadataEntry(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    kind: str
+    type: str | None = None
+    versions: list[ResourceBuilderMetadataVersion] = Field(default_factory=list)
 
 
 class VirtualResourceRequest(BaseModel):
@@ -173,16 +180,20 @@ class VirtualResourceRequest(BaseModel):
     api_version: Optional[str] = Field(default=None, alias="apiVersion")
 
 
-class VirtualResourceResult(BaseModel):
-    """Result of a virtual resource creation operation.
+class Status(str, Enum):
+    ADDED = "ADDED"
+    UNCHANGED = "UNCHANGED"
+    UPDATED = "UPDATED"
 
-    Attributes:
-        severity: The severity level (log, warn or attention)
-        message: The result message with styling
+
+class VirtualResourceResult(BaseModel):
+    """Structured outcome of a virtual resource creation attempt.
+
+    Only `ADDED` and `UNCHANGED` are possible — virtual resources are never
+    updated in place.
     """
 
-    severity: Severity
-    message: str
+    status: Status
 
 
 class ReferencedResourceFolder(BaseModel):
@@ -362,12 +373,6 @@ class ProjectLockUnavailableError(RuntimeError):
     pass
 
 
-class Status(str, Enum):
-    ADDED = "ADDED"
-    UNCHANGED = "UNCHANGED"
-    UPDATED = "UPDATED"
-
-
 class ReferencedResourceResponse(BaseModel):
     """Response from creating a referenced resource.
 
@@ -528,6 +533,19 @@ class StudioClient:
             response.read().decode("utf-8")
         )
 
+    async def get_resource_builder_metadata(
+        self,
+    ) -> list[ResourceBuilderMetadataEntry]:
+        response = await self.uipath.api_client.request_async(
+            "GET",
+            url="/studio_/backend/api/resourcebuilder/metadata",
+            scoped="org",
+        )
+        return [
+            ResourceBuilderMetadataEntry.model_validate(entry)
+            for entry in response.json()
+        ]
+
     async def _get_existing_resources(self) -> List[dict[str, Any]]:
         if self._resources_cache is not None:
             return self._resources_cache
@@ -599,68 +617,19 @@ class StudioClient:
     async def create_virtual_resource(
         self, virtual_resource_request: VirtualResourceRequest
     ) -> VirtualResourceResult:
-        """Create a virtual resource or return appropriate status if it already exists.
+        """Create a virtual resource, or report UNCHANGED if already present.
 
-        Args:
-            virtual_resource_request: The virtual resource request details
-
-        Returns:
-            VirtualResourceResult: Result indicating the operation status and a formatted message
+        Returns UNCHANGED when the same name+kind already exists in the
+        solution. Name collisions with a different kind are not checked
+        client-side — they surface as a server error via EnrichedException.
         """
-        # Build base message with resource details
-        base_message_parts = [
-            f"Resource {click.style(virtual_resource_request.name, fg='cyan')}",
-            f" (kind: {click.style(virtual_resource_request.kind, fg='yellow')}",
-        ]
-
-        if virtual_resource_request.type:
-            base_message_parts.append(
-                f", type: {click.style(virtual_resource_request.type, fg='yellow')}"
-            )
-
-        if virtual_resource_request.activity_name:
-            base_message_parts.append(
-                f", activity: {click.style(virtual_resource_request.activity_name, fg='yellow')}"
-            )
-
-        base_message_parts.append(")")
-        base_message = "".join(base_message_parts)
-
+        name = virtual_resource_request.name
+        kind = virtual_resource_request.kind
         existing_resources = await self._get_existing_resources()
 
-        # Check if resource with same kind and name exists
-        existing_same_kind = next(
-            (
-                r
-                for r in existing_resources
-                if r["name"] == virtual_resource_request.name
-                and r["kind"] == virtual_resource_request.kind
-            ),
-            None,
-        )
-        if existing_same_kind:
-            message = f"{base_message} already exists. Skipping..."
-            return VirtualResourceResult(severity=Severity.ATTENTION, message=message)
+        if any(r["name"] == name and r["kind"] == kind for r in existing_resources):
+            return VirtualResourceResult(status=Status.UNCHANGED)
 
-        # Check if resource with same name but different kind exists
-        existing_diff_kind = next(
-            (
-                r
-                for r in existing_resources
-                if r["name"] == virtual_resource_request.name
-                and r["kind"] != virtual_resource_request.kind
-            ),
-            None,
-        )
-        if existing_diff_kind:
-            message = (
-                f"Cannot create {base_message}. "
-                f"A resource with this name already exists with kind {click.style(existing_diff_kind['kind'], fg='yellow')}. "
-                f"Consider renaming the resource in code."
-            )
-            return VirtualResourceResult(severity=Severity.WARN, message=message)
-
-        # Create the virtual resource
         solution_id = await self._get_solution_id()
         response = await self.uipath.api_client.request_async(
             "POST",
@@ -669,21 +638,12 @@ class StudioClient:
             json=virtual_resource_request.model_dump(exclude_none=True),
         )
         resource_key = response.json()["key"]
-        await self._update_resource_specs(
-            resource_key, new_specs={"name": virtual_resource_request.name}
-        )
+        await self._update_resource_specs(resource_key, new_specs={"name": name})
 
-        # Update cache with newly created resource
         if self._resources_cache is not None:
-            self._resources_cache.append(
-                {
-                    "name": virtual_resource_request.name,
-                    "kind": virtual_resource_request.kind,
-                }
-            )
+            self._resources_cache.append({"name": name, "kind": kind})
 
-        message = f"{base_message} created successfully."
-        return VirtualResourceResult(severity=Severity.SUCCESS, message=message)
+        return VirtualResourceResult(status=Status.ADDED)
 
     async def create_referenced_resource(
         self, referenced_resource_request: ReferencedResourceRequest

--- a/packages/uipath/src/uipath/_cli/cli_push.py
+++ b/packages/uipath/src/uipath/_cli/cli_push.py
@@ -5,9 +5,17 @@ from urllib.parse import urlparse
 import click
 
 from uipath.platform.common import UiPathConfig
-from uipath.platform.errors import EnrichedException, FolderNotFoundException
+from uipath.platform.errors import EnrichedException
 
-from ..platform.resource_catalog import ResourceType
+from ._push._resolvers import resolve_bindings
+from ._push._resource_actions import (
+    CreateReference,
+    CreateVirtual,
+    ResourceAction,
+    Skip,
+)
+from ._push._summary import ResourceImportSummary
+from ._push._virtual_kinds import fetch_supported_virtual_kinds
 from ._push.sw_file_handler import SwFileHandler
 from ._telemetry import track_command
 from ._utils._common import ensure_coded_agent_project, may_override_files
@@ -22,10 +30,9 @@ from ._utils._project_files import (
 )
 from ._utils._studio_project import (
     ProjectLockUnavailableError,
-    ReferencedResourceFolder,
-    ReferencedResourceRequest,
     Status,
     StudioClient,
+    VirtualResourceRequest,
 )
 from ._utils._uv_helpers import handle_uv_operations
 from .models.runtime_schema import Bindings
@@ -42,133 +49,104 @@ def get_org_scoped_url(base_url: str) -> str:
     return org_scoped_url
 
 
-async def create_resources(studio_client: StudioClient):
+async def create_resources(studio_client: StudioClient) -> None:
     console.info("\nImporting referenced resources to Studio Web project...")
 
     from uipath.platform import UiPath
 
     uipath = UiPath()
-    resource_catalog = uipath.resource_catalog
-    connections = uipath.connections
 
     with open(UiPathConfig.bindings_file_path, "r") as f:
-        bindings_file_content = f.read()
+        bindings = Bindings.model_validate_json(f.read())
 
-    bindings = Bindings.model_validate_json(bindings_file_content)
+    supported_virtual_kinds = await fetch_supported_virtual_kinds(studio_client)
 
-    resources_not_found = 0
-    resources_unchanged = 0
-    resources_created = 0
-    resource_updated = 0
+    summary = ResourceImportSummary()
+    async for action in resolve_bindings(
+        bindings,
+        uipath.resource_catalog,
+        uipath.connections,
+        supported_virtual_kinds,
+    ):
+        await _execute_action(action, studio_client, summary)
 
-    for bindings_resource in bindings.resources:
-        not_found_warning = "was not found and will not be added to the solution."
-        found_resource = None
-        resource_type = bindings_resource.resource
-        if resource_type == "connection":
-            connection_key_resource_value = bindings_resource.value.get("ConnectionId")
-            assert connection_key_resource_value
-            connection_key = connection_key_resource_value.default_value
+    console.info(str(summary))
+
+
+async def _execute_action(
+    action: ResourceAction,
+    studio_client: StudioClient,
+    summary: ResourceImportSummary,
+) -> None:
+    match action:
+        case Skip(message=message):
+            console.warning(message)
+            summary.not_found += 1
+
+        case CreateVirtual(request=request):
             try:
-                connection = await connections.retrieve_async(connection_key)
-            except EnrichedException:
-                resources_not_found += 1
-                assert bindings_resource.metadata is not None
-                connector_name = bindings_resource.metadata.get("Connector")
+                result = await studio_client.create_virtual_resource(request)
+            except EnrichedException as e:
                 console.warning(
-                    f"Connection with key '{connection_key}' of type '{connector_name}' "
-                    f"{not_found_warning}"
+                    f"Failed to create virtual resource '{request.name}' of type "
+                    f"'{request.kind}': {e}"
                 )
-                continue
-            resource_name = connection.name
-            folder_path = connection.folder.get("path")
-        else:
-            name_resource_value = bindings_resource.value.get("name")
-            folder_path_resource_value = bindings_resource.value.get("folderPath")
+                summary.not_found += 1
+                return
+            label = _format_virtual_label(request)
+            match result.status:
+                case Status.ADDED:
+                    console.success(f"{label} created successfully.")
+                    summary.virtual_created += 1
+                case Status.UNCHANGED:
+                    console.info(f"{label} already exists. Skipping...")
+                    summary.virtual_existing += 1
 
-            if not folder_path_resource_value:
-                # guardrail resource, nothing to import
-                continue
-
-            assert name_resource_value
-            resource_name = name_resource_value.default_value
-            folder_path = folder_path_resource_value.default_value
-
-        resources = resource_catalog.list_by_type_async(
-            resource_type=ResourceType.from_string(resource_type),
-            name=resource_name,
-            folder_path=folder_path,
-        )
-
-        try:
-            async for resource in resources:
-                found_resource = resource
-                break
-            await resources.aclose()
-
-        except FolderNotFoundException:
-            pass
-
-        if not found_resource:
-            console.warning(
-                f"Resource '{resource_name}' of type '{resource_type}' at folder path '{folder_path}' "
-                f"{not_found_warning}"
+        case CreateReference(
+            request=request,
+            resource_name=resource_name,
+            kind=kind,
+            sub_type=sub_type,
+        ):
+            response = await studio_client.create_referenced_resource(request)
+            details = (
+                f"(kind = {click.style(kind, fg='cyan')}, "
+                f"type = {click.style(sub_type, fg='cyan')})"
             )
-            resources_not_found += 1
-            continue
+            match response.status:
+                case Status.ADDED:
+                    console.success(
+                        f"Created reference for resource: "
+                        f"{click.style(resource_name, fg='cyan')} {details}"
+                    )
+                    summary.created += 1
+                case Status.UNCHANGED:
+                    console.info(
+                        f"Resource reference already exists "
+                        f"({click.style('unchanged', fg='yellow')}): "
+                        f"{click.style(resource_name, fg='cyan')} {details}"
+                    )
+                    summary.unchanged += 1
+                case Status.UPDATED:
+                    console.info(
+                        f"Resource reference already exists "
+                        f"({click.style('updated', fg='blue')}): "
+                        f"{click.style(resource_name, fg='cyan')} {details}"
+                    )
+                    summary.updated += 1
 
-        referenced_resource_request = ReferencedResourceRequest(
-            key=found_resource.resource_key,
-            kind=found_resource.resource_type,
-            type=found_resource.resource_sub_type,
-            folder=next(
-                ReferencedResourceFolder(
-                    folder_key=folder.key,
-                    fully_qualified_name=folder.fully_qualified_name,
-                    path=folder.path,
-                )
-                for folder in found_resource.folders
-            ),
-        )
-        response = await studio_client.create_referenced_resource(
-            referenced_resource_request
-        )
 
-        resource_details = (
-            f"(kind = {click.style(found_resource.resource_type, fg='cyan')}, "
-            f"type = {click.style(found_resource.resource_sub_type, fg='cyan')})"
-        )
-
-        match response.status:
-            case Status.ADDED:
-                console.success(
-                    f"Created reference for resource: {click.style(resource_name, fg='cyan')} "
-                    f"{resource_details}"
-                )
-                resources_created += 1
-            case Status.UNCHANGED:
-                console.info(
-                    f"Resource reference already exists ({click.style('unchanged', fg='yellow')}): {click.style(resource_name, fg='cyan')} "
-                    f"{resource_details}"
-                )
-                resources_unchanged += 1
-            case Status.UPDATED:
-                console.info(
-                    f"Resource reference already exists ({click.style('updated', fg='blue')}): {click.style(resource_name, fg='cyan')} "
-                    f"{resource_details}"
-                )
-                resource_updated += 1
-
-    total_resources = (
-        resources_created + resources_unchanged + resources_not_found + resource_updated
-    )
-    console.info(
-        f"\n \U0001f535 Resource import summary: {total_resources} total resources - "
-        f"{click.style(str(resources_created), fg='green')} created, "
-        f"{click.style(str(resource_updated), fg='blue')} updated, "
-        f"{click.style(str(resources_unchanged), fg='yellow')} unchanged, "
-        f"{click.style(str(resources_not_found), fg='red')} not found"
-    )
+def _format_virtual_label(request: VirtualResourceRequest) -> str:
+    parts = [
+        f"Resource {click.style(request.name, fg='cyan')}",
+        f" (kind: {click.style(request.kind, fg='yellow')}",
+    ]
+    if request.type:
+        parts.append(f", type: {click.style(request.type, fg='yellow')}")
+    if request.activity_name:
+        parts.append(f", activity: {click.style(request.activity_name, fg='yellow')}")
+    parts.append(")")
+    return "".join(parts)
 
 
 async def upload_source_files_to_project(
@@ -262,7 +240,6 @@ def push(root: str, ignore_resources: bool, nolock: bool, overwrite: bool) -> No
     project_id = UiPathConfig.project_id
     if not project_id:
         console.error("UIPATH_PROJECT_ID environment variable not found.")
-        return
 
     studio_client = StudioClient(project_id=project_id)
 

--- a/packages/uipath/tests/cli/test_create_resources.py
+++ b/packages/uipath/tests/cli/test_create_resources.py
@@ -1,0 +1,414 @@
+"""Unit tests for cli_push.create_resources virtual-resource fallback."""
+
+import json
+import os
+from types import SimpleNamespace
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from uipath._cli._utils._studio_project import (
+    Status,
+    VirtualResourceResult,
+)
+from uipath.platform.errors import EnrichedException, FolderNotFoundException
+
+
+def _enriched_exc(
+    status_code: int = 404, body: bytes = b"not found"
+) -> EnrichedException:
+    """Build an EnrichedException backed by a real HTTPStatusError."""
+    request = httpx.Request("GET", "https://example.test/x")
+    response = httpx.Response(status_code, content=body, request=request)
+    http_err = httpx.HTTPStatusError("x", request=request, response=response)
+    return EnrichedException(http_err)
+
+
+class _AsyncIterator:
+    """Minimal async iterator with aclose() to mimic resource_catalog pagination."""
+
+    def __init__(self, items: List[Any], raise_exc: Optional[Exception] = None):
+        self._items = iter(items)
+        self._raise_exc = raise_exc
+        self.aclose = AsyncMock()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        try:
+            return next(self._items)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _make_bindings(resources: List[dict[str, Any]]) -> str:
+    return json.dumps({"version": "2.2", "resources": resources})
+
+
+def _asset_binding(
+    name: str = "my_asset",
+    folder_path: str = "Shared",
+    metadata: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    return {
+        "resource": "asset",
+        "key": f"binding-{name}",
+        "value": {
+            "name": {
+                "defaultValue": name,
+                "isExpression": False,
+                "displayName": "name",
+            },
+            "folderPath": {
+                "defaultValue": folder_path,
+                "isExpression": False,
+                "displayName": "folderPath",
+            },
+        },
+        "metadata": metadata,
+    }
+
+
+def _found_resource(
+    key: str = "resource-key",
+    resource_type: str = "asset",
+    resource_sub_type: str = "stringAsset",
+    folder_path: str = "Shared",
+) -> SimpleNamespace:
+    folder = SimpleNamespace(
+        key="folder-key",
+        fully_qualified_name=folder_path,
+        path=folder_path,
+    )
+    return SimpleNamespace(
+        resource_key=key,
+        resource_type=resource_type,
+        resource_sub_type=resource_sub_type,
+        folders=[folder],
+    )
+
+
+@pytest.fixture
+def bindings_file(tmp_path, monkeypatch):
+    """Write a bindings file to a tmp path and patch UiPathConfig.bindings_file_path."""
+    path = tmp_path / "bindings.json"
+
+    def _writer(content: str) -> str:
+        path.write_text(content, encoding="utf-8")
+        return str(path)
+
+    from uipath.platform.common._config import ConfigurationManager
+
+    monkeypatch.setattr(
+        ConfigurationManager,
+        "bindings_file_path",
+        property(lambda self: path),
+    )
+    return _writer
+
+
+@pytest.fixture
+def mock_uipath():
+    """Patch UiPath() in cli_push to return a mock with resource_catalog + connections.
+
+    cli_push imports `UiPath` lazily from `uipath.platform` inside create_resources,
+    so we patch the source module.
+    """
+    with patch("uipath.platform.UiPath") as mock_cls:
+        instance = MagicMock()
+        instance.resource_catalog = MagicMock()
+        instance.connections = MagicMock()
+        mock_cls.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def studio_client():
+    from uipath._cli._utils._studio_project import (
+        ResourceBuilderMetadataEntry,
+        ResourceBuilderMetadataVersion,
+    )
+
+    client = MagicMock()
+    client.create_referenced_resource = AsyncMock()
+    client.create_virtual_resource = AsyncMock()
+    supported = ResourceBuilderMetadataVersion(supportsInLineCreation=True)
+    # /metadata response — every kind our tests use supports inline creation.
+    client.get_resource_builder_metadata = AsyncMock(
+        return_value=[
+            ResourceBuilderMetadataEntry(kind="asset", versions=[supported]),
+            ResourceBuilderMetadataEntry(kind="bucket", versions=[supported]),
+            ResourceBuilderMetadataEntry(kind="queue", versions=[supported]),
+            ResourceBuilderMetadataEntry(kind="taskCatalog", versions=[supported]),
+        ]
+    )
+    return client
+
+
+async def _run_create_resources(studio_client):
+    from uipath._cli.cli_push import create_resources
+
+    await create_resources(studio_client)
+
+
+async def test_catalog_hit_calls_referenced_resource_only(
+    bindings_file, mock_uipath, studio_client
+):
+    bindings_file(_make_bindings([_asset_binding(metadata={"SubType": "stringAsset"})]))
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator(
+        [_found_resource()]
+    )
+    studio_client.create_referenced_resource.return_value = SimpleNamespace(
+        status=Status.ADDED
+    )
+
+    await _run_create_resources(studio_client)
+
+    studio_client.create_referenced_resource.assert_awaited_once()
+    studio_client.create_virtual_resource.assert_not_awaited()
+
+
+async def test_catalog_miss_with_subtype_creates_virtual_with_type(
+    bindings_file, mock_uipath, studio_client
+):
+    bindings_file(_make_bindings([_asset_binding(metadata={"SubType": "stringAsset"})]))
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator([])
+    studio_client.create_virtual_resource.return_value = VirtualResourceResult(
+        status=Status.ADDED,
+    )
+
+    await _run_create_resources(studio_client)
+
+    studio_client.create_virtual_resource.assert_awaited_once()
+    req = studio_client.create_virtual_resource.call_args.args[0]
+    assert req.kind == "asset"
+    assert req.name == "my_asset"
+    assert req.type == "stringAsset"
+    studio_client.create_referenced_resource.assert_not_awaited()
+
+
+async def test_catalog_miss_without_subtype_creates_virtual_kind_only(
+    bindings_file, mock_uipath, studio_client
+):
+    bindings_file(_make_bindings([_asset_binding(metadata=None)]))
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator([])
+    studio_client.create_virtual_resource.return_value = VirtualResourceResult(
+        status=Status.ADDED,
+    )
+
+    await _run_create_resources(studio_client)
+
+    studio_client.create_virtual_resource.assert_awaited_once()
+    req = studio_client.create_virtual_resource.call_args.args[0]
+    assert req.kind == "asset"
+    assert req.name == "my_asset"
+    assert req.type is None
+    # Body that will actually be sent excludes None → no "type" key.
+    body = req.model_dump(exclude_none=True)
+    assert "type" not in body
+
+
+async def test_catalog_miss_metadata_without_subtype_key_creates_virtual_kind_only(
+    bindings_file, mock_uipath, studio_client
+):
+    bindings_file(_make_bindings([_asset_binding(metadata={"Other": "x"})]))
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator([])
+    studio_client.create_virtual_resource.return_value = VirtualResourceResult(
+        status=Status.ADDED,
+    )
+
+    await _run_create_resources(studio_client)
+
+    req = studio_client.create_virtual_resource.call_args.args[0]
+    assert req.type is None
+
+
+async def test_unknown_resource_type_skips_catalog_and_creates_virtual(
+    bindings_file, mock_uipath, studio_client
+):
+    """Bindings with a resource kind unknown to ResourceType enum but supported
+    by the virtual endpoint (e.g. 'taskCatalog') should skip the resource
+    catalog lookup and fall through to the virtual fallback instead of raising
+    ValueError."""
+    task_catalog_binding = {
+        "resource": "taskCatalog",
+        "key": "live.good.taskcatalog.Shared",
+        "value": {
+            "name": {
+                "defaultValue": "live.good.taskcatalog",
+                "isExpression": False,
+                "displayName": "Name",
+            },
+            "folderPath": {
+                "defaultValue": "Shared",
+                "isExpression": False,
+                "displayName": "Folder Path",
+            },
+        },
+        "metadata": None,
+    }
+    bindings_file(_make_bindings([task_catalog_binding]))
+    studio_client.create_virtual_resource.return_value = VirtualResourceResult(
+        status=Status.ADDED,
+    )
+
+    await _run_create_resources(studio_client)
+
+    mock_uipath.resource_catalog.list_by_type_async.assert_not_called()
+    studio_client.create_virtual_resource.assert_awaited_once()
+    req = studio_client.create_virtual_resource.call_args.args[0]
+    assert req.kind == "taskCatalog"
+    assert req.type is None
+
+
+async def test_unsupported_virtual_kind_is_skipped_with_warning(
+    bindings_file, mock_uipath, studio_client
+):
+    """Bindings whose kind the virtual endpoint cannot materialize (e.g.
+    'entity', 'choiceSet', 'webhook') should be skipped with a warning and
+    never reach create_virtual_resource."""
+    entity_binding = {
+        "resource": "entity",
+        "key": "live.good.entity.Shared",
+        "value": {
+            "name": {
+                "defaultValue": "live.good.entity",
+                "isExpression": False,
+                "displayName": "Name",
+            },
+            "folderPath": {
+                "defaultValue": "Shared",
+                "isExpression": False,
+                "displayName": "Folder Path",
+            },
+        },
+        "metadata": None,
+    }
+    bindings_file(_make_bindings([entity_binding]))
+
+    await _run_create_resources(studio_client)
+
+    mock_uipath.resource_catalog.list_by_type_async.assert_not_called()
+    studio_client.create_virtual_resource.assert_not_awaited()
+    studio_client.create_referenced_resource.assert_not_awaited()
+
+
+async def test_folder_not_found_falls_back_to_virtual(
+    bindings_file, mock_uipath, studio_client
+):
+    bindings_file(_make_bindings([_asset_binding(metadata={"SubType": "stringAsset"})]))
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator(
+        [], raise_exc=FolderNotFoundException("missing folder")
+    )
+    studio_client.create_virtual_resource.return_value = VirtualResourceResult(
+        status=Status.ADDED,
+    )
+
+    await _run_create_resources(studio_client)
+
+    studio_client.create_virtual_resource.assert_awaited_once()
+    req = studio_client.create_virtual_resource.call_args.args[0]
+    assert req.kind == "asset"
+    assert req.type == "stringAsset"
+
+
+async def test_virtual_enriched_exception_caught_and_logged_as_warning(
+    bindings_file, mock_uipath, studio_client
+):
+    bindings_file(
+        _make_bindings(
+            [
+                _asset_binding(name="first"),
+                _asset_binding(name="second"),
+            ]
+        )
+    )
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator([])
+    # First binding raises, second succeeds → loop must continue past the raise.
+    studio_client.create_virtual_resource.side_effect = [
+        _enriched_exc(status_code=500, body=b"boom"),
+        VirtualResourceResult(status=Status.ADDED),
+    ]
+
+    await _run_create_resources(studio_client)
+
+    assert studio_client.create_virtual_resource.await_count == 2
+
+
+async def test_connection_branch_unchanged_no_virtual_fallback(
+    bindings_file, mock_uipath, studio_client
+):
+    """Connection bindings retain old behavior: retrieve_async + warn on miss, no virtual."""
+    connection_binding = {
+        "resource": "connection",
+        "key": "binding-conn",
+        "value": {
+            "ConnectionId": {
+                "defaultValue": "missing-conn-id",
+                "isExpression": False,
+                "displayName": "ConnectionId",
+            }
+        },
+        "metadata": {"Connector": "salesforce"},
+    }
+    bindings_file(_make_bindings([connection_binding]))
+    mock_uipath.connections.retrieve_async = AsyncMock(side_effect=_enriched_exc())
+
+    await _run_create_resources(studio_client)
+
+    mock_uipath.connections.retrieve_async.assert_awaited_once()
+    studio_client.create_virtual_resource.assert_not_awaited()
+    studio_client.create_referenced_resource.assert_not_awaited()
+
+
+async def test_guardrail_binding_without_folder_path_is_skipped(
+    bindings_file, mock_uipath, studio_client
+):
+    # No folderPath in value → guardrail; should be skipped entirely.
+    guardrail_binding = {
+        "resource": "asset",
+        "key": "binding-guard",
+        "value": {
+            "name": {
+                "defaultValue": "g",
+                "isExpression": False,
+                "displayName": "name",
+            }
+        },
+        "metadata": None,
+    }
+    bindings_file(_make_bindings([guardrail_binding]))
+
+    await _run_create_resources(studio_client)
+
+    mock_uipath.resource_catalog.list_by_type_async.assert_not_called()
+    studio_client.create_virtual_resource.assert_not_awaited()
+    studio_client.create_referenced_resource.assert_not_awaited()
+
+
+# Ensure env doesn't leak solution ids between tests.
+@pytest.fixture(autouse=True)
+def _reset_solution_id():
+    from uipath.platform.common._config import ConfigurationManager
+
+    ConfigurationManager.studio_solution_id = None
+    yield
+    ConfigurationManager.studio_solution_id = None
+
+
+# Set minimal env so UiPath() construction inside create_resources (if not mocked
+# away cleanly) doesn't trip on missing creds. The mock_uipath fixture patches
+# the class, so this is defense-in-depth.
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("UIPATH_URL", "https://cloud.uipath.com/org/tenant")
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "mock_token")
+    yield
+    for k in ("UIPATH_URL", "UIPATH_ACCESS_TOKEN"):
+        if k in os.environ:
+            monkeypatch.delenv(k, raising=False)

--- a/packages/uipath/tests/cli/test_push.py
+++ b/packages/uipath/tests/cli/test_push.py
@@ -1928,6 +1928,14 @@ class TestResourceCreation:
             json=mock_structure,
         )
 
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/resourcebuilder/metadata",
+            json=[
+                {"kind": "asset", "versions": [{"supportsInLineCreation": True}]},
+            ],
+        )
+
         # Mock getting the solution ID
         httpx_mock.add_response(
             method="GET",
@@ -2171,7 +2179,7 @@ class TestResourceCreation:
             assert "Created reference for resource" not in result.output
             assert "Resource import summary" not in result.output
 
-    def test_push_with_resource_not_found_shows_warning(
+    def test_push_with_resource_not_found_creates_virtual(
         self,
         runner: CliRunner,
         temp_dir: str,
@@ -2179,9 +2187,11 @@ class TestResourceCreation:
         mock_env_vars: dict[str, str],
         httpx_mock: HTTPXMock,
     ) -> None:
-        """Test that push shows warning when referenced resource is not found in catalog."""
+        """When catalog lookup misses, push creates a virtual resource placeholder."""
         base_url = "https://cloud.uipath.com/organization"
         project_id = "test-project-id"
+        solution_id = "test-solution-id"
+        tenant_id = "test-tenant-id"
 
         mock_structure = {
             "id": "root",
@@ -2226,6 +2236,43 @@ class TestResourceCreation:
             json=mock_structure,
         )
 
+        # Resource Builder metadata — declares which kinds support inline creation.
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/resourcebuilder/metadata",
+            json=[
+                {"kind": "asset", "versions": [{"supportsInLineCreation": True}]},
+            ],
+        )
+
+        # Solution ID lookup for the virtual-resource fallback
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}",
+            json={"solutionId": solution_id},
+        )
+
+        # Existing resources in the solution (empty → no conflict with our new virtual)
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/resourcebuilder/solutions/{solution_id}/entities",
+            json={"resources": []},
+        )
+
+        # Virtual resource POST
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/studio_/backend/api/resourcebuilder/solutions/{solution_id}/resources/virtual",
+            json={"key": "virtual-resource-key-123"},
+        )
+
+        # Configuration PATCH after virtual creation
+        httpx_mock.add_response(
+            method="PATCH",
+            url=f"{base_url}/studio_/backend/api/resourcebuilder/solutions/{solution_id}/resources/virtual-resource-key-123/configuration",
+            json={},
+        )
+
         with runner.isolated_filesystem(temp_dir=temp_dir):
             # Create required files
             with open("uipath.json", "w") as f:
@@ -2255,6 +2302,7 @@ class TestResourceCreation:
                                     "ActivityName": "retrieve_async",
                                     "BindingsVersion": "2.2",
                                     "DisplayLabel": "FullName",
+                                    "SubType": "stringAsset",
                                 },
                             }
                         ],
@@ -2273,6 +2321,7 @@ class TestResourceCreation:
 
             configure_env_vars(mock_env_vars)
             os.environ["UIPATH_PROJECT_ID"] = project_id
+            os.environ["UIPATH_TENANT_ID"] = tenant_id
 
             # Mock resource catalog list_by_type_async to return no resources
             async def mock_list_by_type_async_empty(*args, **kwargs):
@@ -2291,16 +2340,14 @@ class TestResourceCreation:
                 result = runner.invoke(cli, ["push", "./"])
                 assert result.exit_code == 0
 
-            # Check that warning was shown for missing resource
+            # Check that the virtual-resource fallback ran and succeeded
             assert (
                 "Importing referenced resources to Studio Web project" in result.output
             )
-            assert (
-                "Resource 'missing.asset' of type 'asset' at folder path 'Default' was not found"
-                in result.output
-            )
+            assert "missing.asset" in result.output
+            assert "created successfully" in result.output
             assert "Resource import summary:" in result.output
-            assert "1 not found" in result.output
+            assert "1 virtual-created" in result.output
 
     def test_push_with_resource_already_exists_shows_unchanged(
         self,
@@ -2357,6 +2404,14 @@ class TestResourceCreation:
         httpx_mock.add_response(
             url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
             json=mock_structure,
+        )
+
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{base_url}/studio_/backend/api/resourcebuilder/metadata",
+            json=[
+                {"kind": "asset", "versions": [{"supportsInLineCreation": True}]},
+            ],
         )
 
         # Mock getting the solution ID

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.51"
+version = "2.10.52"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.34"
+version = "0.1.35"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `uipath push` now creates virtual resources for bindings that aren't found in resource catalog, so projects can be deployed before their dependencies exist
- supported kinds are discovered dynamically from the studio web metadata endpoint, with a static fallback if the call fails
- bindings for unsupported kinds are skipped with a warning instead of crashing

## Why
push used to abort or silently drop bindings whose resources weren't provisioned yet. creating virtual resources lets users ship the project and wire up the real resources afterwards