### PR TITLE
feat: add memorySpace to resource overwrite types

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.35"
+version = "0.1.36"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_bindings.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_bindings.py
@@ -60,6 +60,7 @@ class GenericResourceOverwrite(ResourceOverwrite):
         "mcpServer",
         "queue",
         "remoteA2aAgent",
+        "memorySpace",
     ]
     name: str = Field(alias="name")
     folder_path: str = Field(alias="folderPath")

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.35"
+version = "0.1.36"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.35"
+version = "0.1.36"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Add `"memorySpace"` to `GenericResourceOverwrite.resource_type` Literal so the `ResourceOverwriteParser` recognizes memory space resource overwrites during agent debug

## Context

When running agents with episodic memory enabled, the Studio debug flow sends `memorySpace` resource overwrites (with `name` and `folderPath`). Without this change, `ResourceOverwriteParser.parse()` raises a `ValidationError` because `memorySpace` is not in the tagged union discriminator.

## Test plan

- [ ] Run agent with memory space configured in debug mode — no longer crashes on resource overwrite parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)