### PR TITLE
fix: handle debug signalR bridge race condition

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.54"
+version = "2.10.55"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_debug/_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_debug/_bridge.py
@@ -747,6 +747,9 @@ class SignalRDebugBridge:
             f"Debug started: breakpoints={self.state.breakpoints}, step_mode={step_mode}"
         )
 
+        # handle race conditions, runtime connected to debug bridge before the receiver
+        await self.emit_execution_started()
+
     async def _handle_resume(self, args: list[Any]) -> None:
         """Handle Resume command from SignalR server.
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.54"
+version = "2.10.55"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- handle debug signalR bridge race condition

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.55.dev1015906222",

  # Any version from PR
  "uipath>=2.10.55.dev1015900000,<2.10.55.dev1015910000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```