### PR TITLE
feat: add @resource_override and folder_path support to MemoryService

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.37"
+version = "0.1.38"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/memory/_memory_service.py
+++ b/packages/uipath-platform/src/uipath/platform/memory/_memory_service.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from uipath.core.tracing import traced
 
 from ..common._base_service import BaseService
+from ..common._bindings import resource_override
 from ..common._config import UiPathApiConfig
 from ..common._execution_context import UiPathExecutionContext
 from ..common._folder_context import FolderContext, header_folder
@@ -50,6 +51,7 @@ class MemoryService(FolderContext, BaseService):
 
     # ── Memory space operations (ECS) ──────────────────────────────────
 
+    @resource_override(resource_type="memorySpace")
     @traced(name="memory_create", run_type="uipath")
     def create(
         self,
@@ -57,6 +59,7 @@ class MemoryService(FolderContext, BaseService):
         description: Optional[str] = None,
         is_encrypted: Optional[bool] = None,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> MemorySpace:
         """Create a new memory space.
 
@@ -65,11 +68,12 @@ class MemoryService(FolderContext, BaseService):
             description: Optional description (max 1024 chars).
             is_encrypted: Whether the memory space should be encrypted.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             MemorySpace: The created memory space.
         """
-        spec = self._create_spec(name, description, is_encrypted, folder_key)
+        spec = self._create_spec(name, description, is_encrypted, folder_key, folder_path)
         response = self.request(
             spec.method,
             spec.endpoint,
@@ -78,6 +82,7 @@ class MemoryService(FolderContext, BaseService):
         ).json()
         return MemorySpace.model_validate(response)
 
+    @resource_override(resource_type="memorySpace")
     @traced(name="memory_create", run_type="uipath")
     async def create_async(
         self,
@@ -85,6 +90,7 @@ class MemoryService(FolderContext, BaseService):
         description: Optional[str] = None,
         is_encrypted: Optional[bool] = None,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> MemorySpace:
         """Asynchronously create a new memory space.
 
@@ -93,11 +99,12 @@ class MemoryService(FolderContext, BaseService):
             description: Optional description (max 1024 chars).
             is_encrypted: Whether the memory space should be encrypted.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             MemorySpace: The created memory space.
         """
-        spec = self._create_spec(name, description, is_encrypted, folder_key)
+        spec = self._create_spec(name, description, is_encrypted, folder_key, folder_path)
         response = (
             await self.request_async(
                 spec.method,
@@ -116,6 +123,7 @@ class MemoryService(FolderContext, BaseService):
         top: Optional[int] = None,
         skip: Optional[int] = None,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> MemorySpaceListResponse:
         """List memory spaces with optional OData query parameters.
 
@@ -125,11 +133,12 @@ class MemoryService(FolderContext, BaseService):
             top: Maximum number of results.
             skip: Number of results to skip.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             MemorySpaceListResponse: The list of memory spaces.
         """
-        spec = self._list_spec(filter, orderby, top, skip, folder_key)
+        spec = self._list_spec(filter, orderby, top, skip, folder_key, folder_path)
         response = self.request(
             spec.method,
             spec.endpoint,
@@ -146,6 +155,7 @@ class MemoryService(FolderContext, BaseService):
         top: Optional[int] = None,
         skip: Optional[int] = None,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> MemorySpaceListResponse:
         """Asynchronously list memory spaces.
 
@@ -155,11 +165,12 @@ class MemoryService(FolderContext, BaseService):
             top: Maximum number of results.
             skip: Number of results to skip.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             MemorySpaceListResponse: The list of memory spaces.
         """
-        spec = self._list_spec(filter, orderby, top, skip, folder_key)
+        spec = self._list_spec(filter, orderby, top, skip, folder_key, folder_path)
         response = (
             await self.request_async(
                 spec.method,
@@ -178,6 +189,7 @@ class MemoryService(FolderContext, BaseService):
         memory_space_id: str,
         request: MemorySearchRequest,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> MemorySearchResponse:
         """Search a memory space via LLMOps.
 
@@ -188,11 +200,12 @@ class MemoryService(FolderContext, BaseService):
             memory_space_id: The GUID of the memory space.
             request: The search request payload.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             MemorySearchResponse: Results, metadata, and system prompt injection.
         """
-        spec = self._search_spec(memory_space_id, folder_key)
+        spec = self._search_spec(memory_space_id, folder_key, folder_path)
         response = self.request(
             spec.method,
             spec.endpoint,
@@ -207,6 +220,7 @@ class MemoryService(FolderContext, BaseService):
         memory_space_id: str,
         request: MemorySearchRequest,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> MemorySearchResponse:
         """Asynchronously search a memory space via LLMOps.
 
@@ -217,11 +231,12 @@ class MemoryService(FolderContext, BaseService):
             memory_space_id: The GUID of the memory space.
             request: The search request payload.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             MemorySearchResponse: Results, metadata, and system prompt injection.
         """
-        spec = self._search_spec(memory_space_id, folder_key)
+        spec = self._search_spec(memory_space_id, folder_key, folder_path)
         response = (
             await self.request_async(
                 spec.method,
@@ -240,6 +255,7 @@ class MemoryService(FolderContext, BaseService):
         memory_space_id: str,
         request: MemorySearchRequest,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> EscalationMemorySearchResponse:
         """Search escalation memory for previously resolved outcomes.
 
@@ -250,11 +266,12 @@ class MemoryService(FolderContext, BaseService):
             memory_space_id: The GUID of the memory space.
             request: The search request payload (same as regular search).
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             EscalationMemorySearchResponse: Matched escalation outcomes.
         """
-        spec = self._escalation_search_spec(memory_space_id, folder_key)
+        spec = self._escalation_search_spec(memory_space_id, folder_key, folder_path)
         response = self.request(
             spec.method,
             spec.endpoint,
@@ -269,6 +286,7 @@ class MemoryService(FolderContext, BaseService):
         memory_space_id: str,
         request: MemorySearchRequest,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> EscalationMemorySearchResponse:
         """Asynchronously search escalation memory for previously resolved outcomes.
 
@@ -279,11 +297,12 @@ class MemoryService(FolderContext, BaseService):
             memory_space_id: The GUID of the memory space.
             request: The search request payload (same as regular search).
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
 
         Returns:
             EscalationMemorySearchResponse: Matched escalation outcomes.
         """
-        spec = self._escalation_search_spec(memory_space_id, folder_key)
+        spec = self._escalation_search_spec(memory_space_id, folder_key, folder_path)
         response = (
             await self.request_async(
                 spec.method,
@@ -300,6 +319,7 @@ class MemoryService(FolderContext, BaseService):
         memory_space_id: str,
         request: EscalationMemoryIngestRequest,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> None:
         """Ingest a resolved escalation outcome into memory.
 
@@ -310,8 +330,9 @@ class MemoryService(FolderContext, BaseService):
             memory_space_id: The GUID of the memory space.
             request: The escalation ingest payload.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
         """
-        spec = self._escalation_ingest_spec(memory_space_id, folder_key)
+        spec = self._escalation_ingest_spec(memory_space_id, folder_key, folder_path)
         self.request(
             spec.method,
             spec.endpoint,
@@ -325,6 +346,7 @@ class MemoryService(FolderContext, BaseService):
         memory_space_id: str,
         request: EscalationMemoryIngestRequest,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> None:
         """Asynchronously ingest a resolved escalation outcome into memory.
 
@@ -335,8 +357,9 @@ class MemoryService(FolderContext, BaseService):
             memory_space_id: The GUID of the memory space.
             request: The escalation ingest payload.
             folder_key: The folder key for the operation.
+            folder_path: The folder path for the operation.
         """
-        spec = self._escalation_ingest_spec(memory_space_id, folder_key)
+        spec = self._escalation_ingest_spec(memory_space_id, folder_key, folder_path)
         await self.request_async(
             spec.method,
             spec.endpoint,
@@ -379,8 +402,9 @@ class MemoryService(FolderContext, BaseService):
         description: Optional[str],
         is_encrypted: Optional[bool],
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        folder_key = self._resolve_folder(folder_key)
+        folder_key = self._resolve_folder(folder_key, folder_path)
         body = MemorySpaceCreateRequest(
             name=name,
             description=description,
@@ -400,8 +424,9 @@ class MemoryService(FolderContext, BaseService):
         top: Optional[int],
         skip: Optional[int],
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        folder_key = self._resolve_folder(folder_key)
+        folder_key = self._resolve_folder(folder_key, folder_path)
         params: dict[str, Any] = {}
         if filter is not None:
             params["$filter"] = filter
@@ -424,8 +449,9 @@ class MemoryService(FolderContext, BaseService):
         self,
         memory_space_id: str,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        folder_key = self._resolve_folder(folder_key)
+        folder_key = self._resolve_folder(folder_key, folder_path)
         return RequestSpec(
             method="POST",
             endpoint=Endpoint(f"{_LLMOPS_AGENT_BASE}/{memory_space_id}/search"),
@@ -436,8 +462,9 @@ class MemoryService(FolderContext, BaseService):
         self,
         memory_space_id: str,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        folder_key = self._resolve_folder(folder_key)
+        folder_key = self._resolve_folder(folder_key, folder_path)
         return RequestSpec(
             method="POST",
             endpoint=Endpoint(
@@ -450,8 +477,9 @@ class MemoryService(FolderContext, BaseService):
         self,
         memory_space_id: str,
         folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        folder_key = self._resolve_folder(folder_key)
+        folder_key = self._resolve_folder(folder_key, folder_path)
         return RequestSpec(
             method="POST",
             endpoint=Endpoint(

--- a/packages/uipath-platform/src/uipath/platform/memory/_memory_service.py
+++ b/packages/uipath-platform/src/uipath/platform/memory/_memory_service.py
@@ -73,7 +73,9 @@ class MemoryService(FolderContext, BaseService):
         Returns:
             MemorySpace: The created memory space.
         """
-        spec = self._create_spec(name, description, is_encrypted, folder_key, folder_path)
+        spec = self._create_spec(
+            name, description, is_encrypted, folder_key, folder_path
+        )
         response = self.request(
             spec.method,
             spec.endpoint,
@@ -104,7 +106,9 @@ class MemoryService(FolderContext, BaseService):
         Returns:
             MemorySpace: The created memory space.
         """
-        spec = self._create_spec(name, description, is_encrypted, folder_key, folder_path)
+        spec = self._create_spec(
+            name, description, is_encrypted, folder_key, folder_path
+        )
         response = (
             await self.request_async(
                 spec.method,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.37"
+version = "0.1.38"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.37"
+version = "0.1.38"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Apply `@resource_override(resource_type="memorySpace")` to `create`/`create_async` so folder bindings are automatically resolved from resource overwrites (matching assets, ECS indexes, etc.)
- Add `folder_path` parameter to all public methods as an alternative to `folder_key`
- Plumb `folder_path` through to private spec builders via the existing `_resolve_folder` method

### Why

The memory service was the only resource type that required callers to manually read `_resource_overwrites` to resolve folder bindings. Other services (context grounding, assets, connections) use the `@resource_override` decorator for automatic resolution. This was flagged in UiPath/uipath-agents-python#374 review.

### Changes

**`_memory_service.py`**:
- `create` / `create_async`: Added `@resource_override(resource_type="memorySpace")` decorator + `folder_path` param
- `list` / `list_async`: Added `folder_path` param
- `search` / `search_async`: Added `folder_path` param
- `escalation_search` / `escalation_search_async`: Added `folder_path` param
- `escalation_ingest` / `escalation_ingest_async`: Added `folder_path` param
- All private spec builders updated to accept and forward `folder_path`

### Notes

- `@resource_override` is only applied to `create`/`create_async` since they have a `name` parameter (the decorator matches on `name` by default). `list`/`search`/`escalation_*` methods use `memory_space_id` or OData filters, so the decorator doesn't apply.
- The `memorySpace` resource type was already registered in `GenericResourceOverwrite`.
- Backwards compatible — `folder_path` defaults to `None`.

## Test plan

- [ ] Verify `create` with resource overwrites resolves folder correctly
- [ ] Verify `list`/`search` with `folder_path` param works

🤖 Generated with [Claude Code](https://claude.com/claude-code)