### PR TITLE
chore: update pyproject template version to current minor interval

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.57"
+version = "2.10.58"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_new.py
+++ b/packages/uipath/src/uipath/_cli/cli_new.py
@@ -28,7 +28,7 @@ version = "0.0.1"
 description = "{project_name}"
 authors = [{{ name = "John Doe", email = "john.doe@myemail.com" }}]
 dependencies = [
-    "uipath>=2.2.0, <2.3.0"
+    "uipath>=2.10.0, <2.11.0"
 ]
 requires-python = ">=3.11"
 """

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.57"
+version = "2.10.58"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Bump uipath package version to 2.10.58 and update the cli new template to generate projects pinned to the current minor interval (>=2.10.0, <2.11.0).