### PR TITLE
chore: add agentservice source on job invocation

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.38"
+version = "0.1.39"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_processes_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_processes_service.py
@@ -321,7 +321,11 @@ class ProcessesService(FolderContext, BaseService):
         parent_operation_id: Optional[str] = None,
         run_as_me: Optional[bool] = None,
     ) -> RequestSpec:
-        payload: Dict[str, Any] = {"ReleaseName": name, **(input_data or {})}
+        payload: Dict[str, Any] = {
+            "ReleaseName": name,
+            **(input_data or {}),
+            "Source": "AgentService",
+        }
         self._add_tracing(payload, UiPathConfig.trace_id, parent_span_id)
 
         if parent_operation_id:

--- a/packages/uipath-platform/tests/services/test_processes_service.py
+++ b/packages/uipath-platform/tests/services/test_processes_service.py
@@ -79,6 +79,7 @@ class TestProcessesService:
                 "startInfo": {
                     "ReleaseName": process_name,
                     "InputArguments": json.dumps(input_arguments),
+                    "Source": "AgentService",
                 }
             },
             separators=(",", ":"),
@@ -139,6 +140,7 @@ class TestProcessesService:
                 "startInfo": {
                     "ReleaseName": process_name,
                     "InputArguments": "{}",
+                    "Source": "AgentService",
                 }
             },
             separators=(",", ":"),
@@ -300,6 +302,7 @@ class TestProcessesService:
                 "startInfo": {
                     "ReleaseName": process_name,
                     "InputArguments": json.dumps(input_arguments),
+                    "Source": "AgentService",
                 }
             },
             separators=(",", ":"),
@@ -361,6 +364,7 @@ class TestProcessesService:
                 "startInfo": {
                     "ReleaseName": process_name,
                     "InputArguments": "{}",
+                    "Source": "AgentService",
                 }
             },
             separators=(",", ":"),

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.38"
+version = "0.1.39"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.8, <0.6.0",
   "uipath-runtime>=0.10.1, <0.11.0",
-  "uipath-platform>=0.1.13, <0.2.0",
+  "uipath-platform>=0.1.39, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.38"
+version = "0.1.39"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- add agentservice source on job invocation

## Why?

marks the source of the child jobs started by a coded agent 
<img width="1151" height="150" alt="image" src="https://github.com/user-attachments/assets/5ec1c183-df32-4967-b23f-b568c57ec79a" />


## Development Packages

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-platform==0.1.39.dev1015936262",

  # Any version from PR
  "uipath-platform>=0.1.39.dev1015930000,<0.1.39.dev1015940000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.58.dev1015936262",

  # Any version from PR
  "uipath>=2.10.58.dev1015930000,<2.10.58.dev1015940000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```