### PR TITLE
fix: restore interrupt event compat shims in uipath-core (#1599)

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.13"
+version = "0.5.14"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/chat/__init__.py
+++ b/packages/uipath-core/src/uipath/core/chat/__init__.py
@@ -77,6 +77,20 @@ from .exchange import (
     UiPathConversationExchangeEvent,
     UiPathConversationExchangeStartEvent,
 )
+from .interrupt import (
+    InterruptTypeEnum,
+    UiPathConversationGenericInterruptEndEvent,
+    UiPathConversationGenericInterruptStartEvent,
+    UiPathConversationInterrupt,
+    UiPathConversationInterruptData,
+    UiPathConversationInterruptEndEvent,
+    UiPathConversationInterruptEvent,
+    UiPathConversationInterruptStartEvent,
+    UiPathConversationToolCallConfirmationEndValue,
+    UiPathConversationToolCallConfirmationInterruptEndEvent,
+    UiPathConversationToolCallConfirmationInterruptStartEvent,
+    UiPathConversationToolCallConfirmationValue,
+)
 from .message import (
     UiPathConversationMessage,
     UiPathConversationMessageData,
@@ -177,4 +191,17 @@ __all__ = [
     "UiPathVoiceToolCallRequest",
     "UiPathVoiceToolCallMessage",
     "UiPathVoiceToolCallResult",
+    # Interrupt (compat shims — deprecated, see interrupt.py)
+    "InterruptTypeEnum",
+    "UiPathConversationInterruptStartEvent",
+    "UiPathConversationInterruptEndEvent",
+    "UiPathConversationInterruptEvent",
+    "UiPathConversationInterruptData",
+    "UiPathConversationInterrupt",
+    "UiPathConversationGenericInterruptStartEvent",
+    "UiPathConversationGenericInterruptEndEvent",
+    "UiPathConversationToolCallConfirmationValue",
+    "UiPathConversationToolCallConfirmationEndValue",
+    "UiPathConversationToolCallConfirmationInterruptStartEvent",
+    "UiPathConversationToolCallConfirmationInterruptEndEvent",
 ]

--- a/packages/uipath-core/src/uipath/core/chat/interrupt.py
+++ b/packages/uipath-core/src/uipath/core/chat/interrupt.py
@@ -1,0 +1,122 @@
+"""Compatibility shims for legacy interrupt event types.
+
+The interrupt-based tool-call confirmation flow was replaced by `confirmToolCall`
+on the tool call event itself (see PR #1558). The original `interrupt.py` was
+removed in `uipath-core` 0.5.13, but published `uipath-runtime` versions still
+import these names at module load time, breaking installs that pull the new
+`uipath-core` alongside an older runtime.
+
+These shims keep those imports working. They are not used by current code paths
+and should be removed in the next minor bump of `uipath-core`.
+"""
+
+from enum import Enum
+from typing import Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class InterruptTypeEnum(str, Enum):
+    """Enum of known interrupt types."""
+
+    TOOL_CALL_CONFIRMATION = "uipath_cas_tool_call_confirmation"
+
+
+class UiPathConversationToolCallConfirmationValue(BaseModel):
+    """Schema for tool call confirmation interrupt value."""
+
+    tool_call_id: str = Field(..., alias="toolCallId")
+    tool_name: str = Field(..., alias="toolName")
+    input_schema: Any = Field(..., alias="inputSchema")
+    input_value: Any | None = Field(None, alias="inputValue")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationToolCallConfirmationInterruptStartEvent(BaseModel):
+    """Tool call confirmation interrupt start event with strong typing."""
+
+    type: Literal["uipath_cas_tool_call_confirmation"]
+    value: UiPathConversationToolCallConfirmationValue
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationGenericInterruptStartEvent(BaseModel):
+    """Generic interrupt start event for custom interrupt types."""
+
+    type: str
+    value: Any
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+UiPathConversationInterruptStartEvent = Union[
+    UiPathConversationToolCallConfirmationInterruptStartEvent,
+    UiPathConversationGenericInterruptStartEvent,
+]
+
+
+class UiPathConversationToolCallConfirmationEndValue(BaseModel):
+    """Schema for tool call confirmation end value."""
+
+    approved: bool
+    input: Any | None = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationToolCallConfirmationInterruptEndEvent(BaseModel):
+    """Tool call confirmation interrupt end event with strong typing."""
+
+    type: Literal["uipath_cas_tool_call_confirmation"]
+    value: UiPathConversationToolCallConfirmationEndValue
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationGenericInterruptEndEvent(BaseModel):
+    """Generic interrupt end event for custom interrupt types."""
+
+    type: str
+    value: Any
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+UiPathConversationInterruptEndEvent = Union[
+    UiPathConversationToolCallConfirmationInterruptEndEvent,
+    UiPathConversationGenericInterruptEndEvent,
+]
+
+
+class UiPathConversationInterruptEvent(BaseModel):
+    """Encapsulates interrupt-related events within a message."""
+
+    interrupt_id: str = Field(..., alias="interruptId")
+    start: UiPathConversationInterruptStartEvent | None = Field(
+        None, alias="startInterrupt"
+    )
+    end: UiPathConversationInterruptEndEvent | None = Field(None, alias="endInterrupt")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationInterruptData(BaseModel):
+    """Core data of an interrupt within a message."""
+
+    type: str
+    interrupt_value: Any = Field(..., alias="interruptValue")
+    end_value: Any | None = Field(None, alias="endValue")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class UiPathConversationInterrupt(UiPathConversationInterruptData):
+    """An interrupt within a message — a pause point where the agent needs external input."""
+
+    interrupt_id: str = Field(..., alias="interruptId")
+    created_at: str = Field(..., alias="createdAt")
+    updated_at: str = Field(..., alias="updatedAt")
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.13"
+version = "0.5.14"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1056,7 +1056,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.13"
+version = "0.5.14"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2650,7 +2650,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.13"
+version = "0.5.14"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },


### PR DESCRIPTION
## Summary
- restore `UiPathConversationInterrupt*` names in `uipath.core.chat` as deprecation shims
- unblocks installs where old `uipath-runtime` resolves alongside new `uipath-core`

## Why

Fixes #1599

#1558 removed the interrupt event types from `uipath.core.chat` in a patch release. Published `uipath-runtime` 0.9.x still imports those names at module load, so any install pulling the new core (e.g. via `uipath-openai-agents`) hits an `ImportError` before the agent can start. Restoring the symbols keeps old runtimes loadable while the new `confirmToolCall` flow remains the active path.