### PR TITLE
refactor(agent): replace metadata.is_case_manager with metadata.variant

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.59"
+version = "2.10.60"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -165,6 +165,12 @@ class AgentMessageRole(str, CaseInsensitiveEnum):
     USER = "user"
 
 
+class AgentVariant(str, CaseInsensitiveEnum):
+    """Agent variant enumeration."""
+
+    CASE_MANAGER = "caseManager"
+
+
 class AgentGuardrailActionType(str, CaseInsensitiveEnum):
     """Agent guardrail action type enumeration."""
 
@@ -1156,7 +1162,7 @@ class AgentMetadata(BaseCfg):
     """Agent metadata model."""
 
     is_conversational: bool = Field(alias="isConversational")
-    is_case_manager: bool = Field(default=False, alias="isCaseManager")
+    variant: Optional[AgentVariant] = Field(default=None, alias="variant")
     storage_version: str = Field(alias="storageVersion")
 
 
@@ -1220,7 +1226,9 @@ class AgentDefinition(BaseModel):
     @property
     def is_case_manager(self) -> bool:
         """Checks if the agent is a case manager agent."""
-        return self.metadata.is_case_manager if self.metadata else False
+        if not self.metadata:
+            return False
+        return self.metadata.variant == AgentVariant.CASE_MANAGER
 
     @staticmethod
     def _normalize_guardrails(v: Dict[str, Any]) -> None:

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -3286,15 +3286,15 @@ class TestAgentDefinitionIsConversational:
 class TestAgentDefinitionIsCaseManager:
     """Tests for AgentDefinition.is_case_manager property."""
 
-    def test_is_case_manager_true_when_metadata_set(self):
-        """Returns True when metadata.is_case_manager is True."""
+    def test_is_case_manager_true_when_variant_is_case_manager(self):
+        """Returns True when metadata.variant is "caseManager"."""
         json_data = {
             "id": "test-case-manager",
             "name": "Case Manager Agent",
             "version": "1.0.0",
             "metadata": {
                 "isConversational": False,
-                "isCaseManager": True,
+                "variant": "caseManager",
                 "storageVersion": "1.0.0",
             },
             "settings": {
@@ -3317,15 +3317,15 @@ class TestAgentDefinitionIsCaseManager:
 
         assert config.is_case_manager is True
 
-    def test_is_case_manager_false_when_metadata_set_false(self):
-        """Returns False when metadata.is_case_manager is False."""
+    def test_is_case_manager_false_when_variant_is_none(self):
+        """Returns False when metadata.variant is None."""
         json_data = {
             "id": "test-non-case-manager",
             "name": "Regular Agent",
             "version": "1.0.0",
             "metadata": {
                 "isConversational": False,
-                "isCaseManager": False,
+                "variant": None,
                 "storageVersion": "1.0.0",
             },
             "settings": {
@@ -3346,11 +3346,11 @@ class TestAgentDefinitionIsCaseManager:
 
         assert config.is_case_manager is False
 
-    def test_is_case_manager_false_when_not_in_metadata(self):
-        """Returns False when isCaseManager is not present in metadata."""
+    def test_is_case_manager_false_when_variant_not_in_metadata(self):
+        """Returns False when variant is not present in metadata."""
         json_data = {
-            "id": "test-no-case-manager-field",
-            "name": "Agent Without CM Field",
+            "id": "test-no-variant-field",
+            "name": "Agent Without Variant Field",
             "version": "1.0.0",
             "metadata": {"isConversational": False, "storageVersion": "1.0.0"},
             "settings": {

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.59"
+version = "2.10.60"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## What changed                                                                                                                                                                                                                                          
  - Added AgentVariant enum (CaseInsensitiveEnum) with CASE_MANAGER = "caseManager"
  - Replaced is_case_manager: bool field in AgentMetadata with variant: Optional[AgentVariant] = None
  - Updated the AgentDefinition.is_case_manager property to derive from metadata.variant — public API unchanged, still returns bool                                                                                                     
  - Updated test fixtures from isCaseManager: true/false to variant: "caseManager" / absent

**Notes**           
 - variant is Optional[AgentVariant] because regular agents have no variant set. There is no "no variant" enum value - that state is None. The boolean is_case_manager property hides this from SDK consumers.