### PR TITLE
fix: serialize datetime fields when creating queue items (#670)

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.40"
+version = "0.1.41"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_queues_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_queues_service.py
@@ -454,7 +454,9 @@ class QueuesService(FolderContext, BaseService):
         elif isinstance(item, QueueItem):
             queue_item = item
 
-        item_data = queue_item.model_dump(exclude_unset=True, by_alias=True)
+        item_data = queue_item.model_dump(
+            mode="json", exclude_unset=True, by_alias=True
+        )
         resolved_name = queue_name or item_data.get("Name")
         if resolved_name is None:
             raise ValueError(
@@ -493,9 +495,11 @@ class QueuesService(FolderContext, BaseService):
                 "queueName": queue_name,
                 "commitType": commit_type.value,
                 "queueItems": [
-                    item.model_dump(exclude_unset=True, by_alias=True)
+                    item.model_dump(mode="json", exclude_unset=True, by_alias=True)
                     if isinstance(item, QueueItem)
-                    else QueueItem(**item).model_dump(exclude_unset=True, by_alias=True)
+                    else QueueItem(**item).model_dump(
+                        mode="json", exclude_unset=True, by_alias=True
+                    )
                     for item in items
                 ],
             },
@@ -519,7 +523,7 @@ class QueuesService(FolderContext, BaseService):
             transaction_item = item
 
         transaction_data = transaction_item.model_dump(
-            exclude_unset=True, by_alias=True
+            mode="json", exclude_unset=True, by_alias=True
         )
         resolved_name = queue_name or transaction_data.get("Name")
         if resolved_name is None:
@@ -580,7 +584,7 @@ class QueuesService(FolderContext, BaseService):
             ),
             json={
                 "transactionResult": transaction_result.model_dump(
-                    exclude_unset=True, by_alias=True
+                    mode="json", exclude_unset=True, by_alias=True
                 )
             },
             headers={

--- a/packages/uipath-platform/tests/services/test_queues_service.py
+++ b/packages/uipath-platform/tests/services/test_queues_service.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -517,6 +518,39 @@ class TestQueuesService:
             sent_request.headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.QueuesService.create_item_async/{version}"
         )
+
+    def test_create_item_with_datetime_fields(
+        self,
+        httpx_mock: HTTPXMock,
+        service: QueuesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        defer = datetime(2026, 5, 1, 9, 0, 0, tzinfo=timezone.utc)
+        due = datetime(2026, 5, 2, 17, 30, 0, tzinfo=timezone.utc)
+        risk = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+        queue_item = QueueItem(
+            priority=QueueItemPriority.NORMAL,
+            specific_content={"key": "value"},
+            defer_date=defer,
+            due_date=due,
+            risk_sla_date=risk,
+        )
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Queues/UiPathODataSvc.AddQueueItem",
+            status_code=200,
+            json={"Id": 1},
+        )
+
+        service.create_item(queue_item, queue_name="test-queue")
+
+        sent_request = httpx_mock.get_request()
+        assert sent_request is not None
+        body = json.loads(sent_request.content.decode())
+        assert body["itemData"]["DeferDate"] == defer.isoformat()
+        assert body["itemData"]["DueDate"] == due.isoformat()
+        assert body["itemData"]["RiskSlaDate"] == risk.isoformat()
 
     def test_create_transaction_item(
         self,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.40"
+version = "0.1.41"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.8, <0.6.0",
   "uipath-runtime>=0.10.1, <0.11.0",
-  "uipath-platform>=0.1.39, <0.2.0",
+  "uipath-platform>=0.1.41, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.40"
+version = "0.1.41"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- queue items with `defer_date`, `due_date`, or `risk_sla_date` no longer raise `TypeError: Object of type datetime is not JSON serializable`
- applies to `create_item`, `create_items`, `start_transaction_item`, and `complete_transaction_item`

## Why

Fixes #670

`model_dump` was called without `mode="json"`, so the `field_serializer` configured to convert datetime to ISO 8601 never fired and httpx received raw datetime objects it could not encode.

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version:
  "uipath==2.10.60.dev1016076290",

  # Any version from PR
  "uipath>=2.10.60.dev1016070000,<2.10.60.dev1016080000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-platform==0.1.41.dev1016076290",

  # Any version from PR
  "uipath-platform>=0.1.41.dev1016070000,<0.1.41.dev1016080000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```