### PR TITLE
fix(connections): preserve filename and content type in multipart file uploads

### DIFF
--- a/packages/uipath-platform/src/uipath/platform/connections/_connections_service.py
+++ b/packages/uipath-platform/src/uipath/platform/connections/_connections_service.py
@@ -788,12 +788,22 @@ class ConnectionsService(BaseService):
                 # instead of making assumptions on whether or not it's present, we'll handle it defensively
                 if key == json_section:
                     continue
-                # files not supported yet supported so this will likely not work
-                files[key] = (
-                    key,
-                    val,
-                    None,
-                )  # probably needs to extract content type from val since IS metadata doesn't provide it
+                if isinstance(val, tuple):
+                    # Caller supplied httpx's (filename, content[, content_type])
+                    # shape — pass through verbatim. This is the recommended path
+                    # for file uploads so the multipart Content-Disposition gets
+                    # the real filename instead of the form-field name.
+                    files[key] = val
+                elif isinstance(val, (bytes, bytearray)) or hasattr(val, "read"):
+                    # Raw file content with no filename — fall back to the
+                    # form-field name (legacy behaviour). Backwards compatible
+                    # with callers that still pass bytes directly.
+                    files[key] = (key, val, "application/octet-stream")
+                else:
+                    # Scalar (string/number/etc.) — send as a plain multipart
+                    # form field, not a file part. The (None, value) shape tells
+                    # httpx to omit `filename=...` from the Content-Disposition.
+                    files[key] = (None, str(val))
 
             files[json_section] = (
                 "",

--- a/packages/uipath-platform/tests/services/test_connections_service.py
+++ b/packages/uipath-platform/tests/services/test_connections_service.py
@@ -2116,3 +2116,173 @@ class TestConnectorActivityInvocation:
         assert f"/element/instances/{original_connection_id}/" not in str(
             activity_request.url
         )
+
+
+def _multipart_part(body: bytes, boundary: str, name: str) -> str:
+    """Return the raw text of the multipart part with the given form-field name."""
+    text = body.decode("utf-8", errors="replace")
+    for part in text.split(f"--{boundary}"):
+        if f'name="{name}"' in part:
+            return part
+    raise AssertionError(f"part {name!r} not found in multipart body")
+
+
+class TestMultipartFileUpload:
+    """Regression tests for the multipart serializer that handles file uploads.
+
+    Before this fix, ``_build_activity_request_spec`` always built
+    ``files[key] = (key, val, None)``, using the form-field name as the
+    multipart filename and dropping the content type. Downstream services
+    (e.g. Coupa's ``add_attachment`` endpoint) ended up storing every
+    attachment with the literal name ``attachment[file]`` and no extension.
+
+    The serializer now branches on the value type:
+
+    * tuple  → passed through (caller controls filename + content type)
+    * bytes  → legacy fallback, key as filename, octet-stream content type
+    * scalar → plain multipart form field (no filename in Content-Disposition)
+    """
+
+    def test_invoke_activity_multipart_tuple_3_preserves_filename(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+        multipart_activity_metadata: ActivityMetadata,
+    ) -> None:
+        """3-tuple input is forwarded verbatim, so the real filename + content type land on the wire."""
+        connection_id = "test-connection-123"
+        activity_input = {
+            "file_param": ("invoice.pdf", b"%PDF-1.4 fake", "application/pdf"),
+            "description": "Test file upload",
+        }
+
+        httpx_mock.add_response(
+            method="GET",
+            status_code=200,
+            json={"id": connection_id, "name": "Test", "elementInstanceId": 1},
+        )
+        httpx_mock.add_response(method="POST", status_code=200, json={"ok": True})
+
+        _ = service.invoke_activity(
+            activity_metadata=multipart_activity_metadata,
+            connection_id=connection_id,
+            activity_input=activity_input,
+        )
+
+        sent_request = httpx_mock.get_requests()[1]
+        boundary = sent_request.headers["content-type"].split("boundary=")[1]
+        part = _multipart_part(sent_request.content, boundary, "file_param")
+
+        assert 'filename="invoice.pdf"' in part
+        assert "Content-Type: application/pdf" in part
+        assert b"%PDF-1.4 fake" in sent_request.content
+
+    def test_invoke_activity_multipart_tuple_2_preserves_filename(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+        multipart_activity_metadata: ActivityMetadata,
+    ) -> None:
+        """2-tuple (filename, content) shorthand: filename preserved, httpx infers the content type."""
+        connection_id = "test-connection-123"
+        activity_input = {
+            "file_param": ("invoice.pdf", b"%PDF-1.4 fake"),
+            "description": "Test file upload",
+        }
+
+        httpx_mock.add_response(
+            method="GET",
+            status_code=200,
+            json={"id": connection_id, "name": "Test", "elementInstanceId": 1},
+        )
+        httpx_mock.add_response(method="POST", status_code=200, json={"ok": True})
+
+        _ = service.invoke_activity(
+            activity_metadata=multipart_activity_metadata,
+            connection_id=connection_id,
+            activity_input=activity_input,
+        )
+
+        sent_request = httpx_mock.get_requests()[1]
+        boundary = sent_request.headers["content-type"].split("boundary=")[1]
+        part = _multipart_part(sent_request.content, boundary, "file_param")
+
+        assert 'filename="invoice.pdf"' in part
+        assert b"%PDF-1.4 fake" in sent_request.content
+
+    def test_invoke_activity_multipart_bytes_backwards_compatible(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+        multipart_activity_metadata: ActivityMetadata,
+    ) -> None:
+        """Existing callers passing raw bytes keep working — filename = form-field name (legacy)."""
+        connection_id = "test-connection-123"
+        activity_input = {
+            "file_param": b"raw bytes",
+            "description": "Test",
+        }
+
+        httpx_mock.add_response(
+            method="GET",
+            status_code=200,
+            json={"id": connection_id, "name": "Test", "elementInstanceId": 1},
+        )
+        httpx_mock.add_response(method="POST", status_code=200, json={"ok": True})
+
+        _ = service.invoke_activity(
+            activity_metadata=multipart_activity_metadata,
+            connection_id=connection_id,
+            activity_input=activity_input,
+        )
+
+        sent_request = httpx_mock.get_requests()[1]
+        boundary = sent_request.headers["content-type"].split("boundary=")[1]
+        part = _multipart_part(sent_request.content, boundary, "file_param")
+
+        # Legacy fallback: form-field name used as filename, octet-stream content type.
+        assert 'filename="file_param"' in part
+        assert "Content-Type: application/octet-stream" in part
+        assert b"raw bytes" in sent_request.content
+
+    def test_invoke_activity_multipart_scalar_is_plain_form_field(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+    ) -> None:
+        """Scalar multipart_params get sent as plain form fields (no bogus filename)."""
+        metadata = ActivityMetadata(
+            object_path="/elements/test-connector/upload",
+            method_name="POST",
+            content_type="multipart/form-data",
+            parameter_location_info=ActivityParameterLocationInfo(
+                multipart_params=["file_param", "payload"],
+                body_fields=[],
+            ),
+        )
+        connection_id = "test-connection-123"
+        activity_input = {
+            "file_param": ("doc.pdf", b"data", "application/pdf"),
+            "payload": "{}",
+        }
+
+        httpx_mock.add_response(
+            method="GET",
+            status_code=200,
+            json={"id": connection_id, "name": "Test", "elementInstanceId": 1},
+        )
+        httpx_mock.add_response(method="POST", status_code=200, json={"ok": True})
+
+        _ = service.invoke_activity(
+            activity_metadata=metadata,
+            connection_id=connection_id,
+            activity_input=activity_input,
+        )
+
+        sent_request = httpx_mock.get_requests()[1]
+        boundary = sent_request.headers["content-type"].split("boundary=")[1]
+        payload_part = _multipart_part(sent_request.content, boundary, "payload")
+
+        # Scalar payload must NOT carry a filename in Content-Disposition.
+        assert "filename=" not in payload_part
+        assert "{}" in payload_part


### PR DESCRIPTION
## Summary

`ConnectionsService._build_activity_request_spec` currently constructs
`files[key] = (key, val, None)` for every multipart parameter,
regardless of value type. Two consequences for any connector activity
that uploads a file:

1. **Filename is wrong.** `httpx` interprets the first element of a
   3-tuple as the filename for `Content-Disposition: form-data; name="…"; filename="…"`.
   Today every file is uploaded with the *form-field name* as its
   filename, e.g. `attachment[file]`. Downstream services that store
   attachments by name end up with literal `attachment_file_.` (Coupa
   sanitises `[`/`]`, then appends `.` because there's no extension).
2. **Content-Type is `None`.** httpx then defaults to `application/octet-stream`,
   so previewers / browsers cannot pick a sensible viewer.

The current source even flags the gap explicitly:

```python
# files not supported yet supported so this will likely not work
files[key] = (
    key,
    val,
    None,
)  # probably needs to extract content type from val since IS metadata doesn't provide it
```
[`packages/uipath-platform/src/uipath/platform/connections/_connections_service.py#L791-L796`](https://github.com/UiPath/uipath-python/blob/main/packages/uipath-platform/src/uipath/platform/connections/_connections_service.py#L791-L796)

A real-world manifestation: every Coupa attachment uploaded by an agent using `coupa.add_attachment` lands as `attachment_file_.` instead of the document's real filename.

## Fix

Branch on the value type to accept httpx's standard tuple shape, while keeping the existing bytes-only path working:

```python
if isinstance(val, tuple):
    # Caller supplied httpx's (filename, content[, content_type])
    # shape — pass through verbatim. This is the recommended path
    # for file uploads.
    files[key] = val
elif isinstance(val, (bytes, bytearray)) or hasattr(val, "read"):
    # Raw file content with no filename — fall back to the form-field
    # name (legacy behaviour). Backwards compatible with callers that
    # still pass bytes directly.
    files[key] = (key, val, "application/octet-stream")
else:
    # Scalar — send as a plain multipart form field, not a file part.
    # The (None, value) shape tells httpx to omit `filename=...` from
    # the Content-Disposition.
    files[key] = (None, str(val))
```

| Caller passes | Wire-level result |
|---|---|
| `("invoice.pdf", b"…", "application/pdf")` *(recommended)* | `Content-Disposition: form-data; name="attachment[file]"; filename="invoice.pdf"` + `Content-Type: application/pdf` |
| `("invoice.pdf", b"…")` *(2-tuple shorthand)* | filename preserved, httpx infers content type |
| `b"…"` *(legacy)* | unchanged behaviour: filename = form-field name |
| `"some string"` *(scalar)* | sent as plain form field — `filename=…` is **omitted** |

Backwards compatible: existing callers passing raw `bytes` keep working with no observable change on the wire.

## Tests

Added `TestMultipartFileUpload` in `packages/uipath-platform/tests/services/test_connections_service.py` with four cases that inspect the serialized multipart body:

- `test_invoke_activity_multipart_tuple_3_preserves_filename` — asserts `filename="invoice.pdf"` and `Content-Type: application/pdf` land in the wire body.
- `test_invoke_activity_multipart_tuple_2_preserves_filename` — 2-tuple shorthand preserves filename.
- `test_invoke_activity_multipart_bytes_backwards_compatible` — legacy raw-bytes callers keep behaviour: filename = form-field name, `application/octet-stream` content type.
- `test_invoke_activity_multipart_scalar_is_plain_form_field` — non-file params (e.g. `payload="{}"`) are emitted without a bogus `filename=` in `Content-Disposition`.

### Test results

Ran from `packages/uipath-platform/`:

- `uv run pytest tests/services/test_connections_service.py` → **57 passed** (53 pre-existing + 4 new).
- `uv run pytest tests/` → **1105 passed, 7 skipped** (the skipped ones are pre-existing LLM integration tests gated on real credentials).
- `uv run ruff check src/uipath/platform/connections/_connections_service.py` → clean.

### Verification that the new tests catch the bug

I `git stash`ed the fix and re-ran `pytest …::TestMultipartFileUpload` — 3 of the 4 new tests fail against the unpatched serializer (tuple_3, tuple_2, scalar). The bytes-backwards-compat test passes either way, because httpx defaults a `None` content type to `application/octet-stream` on the wire.

## End-to-end validation

The downstream change in our agent that motivated this — using the patched SDK to send the real document filename to Coupa via `add_attachment` — was verified end-to-end against the staging Coupa instance: same byte payload as before, but the attachment is now stored with the real filename (`invoice_<id>.pdf`) instead of `attachment_file_.`.