### PR TITLE
fix(platform): use LLMOps external span in trace context headers

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.44"
+version = "0.1.45"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/chat/llm_trace_context.py
+++ b/packages/uipath-platform/src/uipath/platform/chat/llm_trace_context.py
@@ -2,6 +2,7 @@
 
 from opentelemetry import trace
 from uipath.core.feature_flags import FeatureFlags
+from uipath.core.tracing.span_utils import UiPathSpanUtils
 
 from ..common._config import UiPathConfig
 
@@ -22,7 +23,8 @@ def build_trace_context_headers(
         return {}
 
     headers: dict[str, str] = {}
-    span = trace.get_current_span()
+    llmops_span = UiPathSpanUtils.get_external_current_span()
+    span = llmops_span or trace.get_current_span()
     ctx = span.get_span_context()
     if ctx and ctx.trace_id and ctx.span_id:
         trace_id = format(ctx.trace_id, "032x")

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.44"
+version = "0.1.45"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.8, <0.6.0",
   "uipath-runtime>=0.10.1, <0.11.0",
-  "uipath-platform>=0.1.43, <0.2.0",
+  "uipath-platform>=0.1.45, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.44"
+version = "0.1.45"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Use `UiPathSpanUtils.get_external_current_span()` in `build_trace_context_headers()` so the traceparent header reflects the LLMOps span visible in the trace UI (same pattern as `_base_service.py`)
- Bump `uipath-platform` to `0.1.45`

## Test plan
- [x] Existing `test_llm_trace_context.py` tests pass (11/11)
- [x] mypy clean
- [ ] Verify traceparent header matches LLMOps trace UI in an end-to-end run

🤖 Generated with [Claude Code](https://claude.com/claude-code)