### PR TITLE
ci: add coverage report on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -18,6 +21,9 @@ jobs:
 
   test:
     uses: ./.github/workflows/test-packages.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   check-versions:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/check-version-availability.yml

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -2,6 +2,9 @@ name: Test Packages
 
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -77,9 +80,30 @@ jobs:
         run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')
         working-directory: packages/uipath-core
         run: uv run pytest
+
+      - name: Run tests with coverage
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        working-directory: packages/uipath-core
+        run: uv run pytest --cov-report=xml --cov-report=html --tb=short
+
+      - name: Upload coverage HTML report
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-uipath-core
+          path: packages/uipath-core/htmlcov/
+          retention-days: 30
+
+      - name: Upload coverage XML report
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-uipath-core
+          path: packages/uipath-core/coverage.xml
+          retention-days: 30
 
   test-uipath-platform:
     name: Test (uipath-platform, ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -126,9 +150,30 @@ jobs:
         run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')
         working-directory: packages/uipath-platform
         run: uv run pytest
+
+      - name: Run tests with coverage
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        working-directory: packages/uipath-platform
+        run: uv run pytest --cov-report=xml --cov-report=html --tb=short
+
+      - name: Upload coverage HTML report
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-uipath-platform
+          path: packages/uipath-platform/htmlcov/
+          retention-days: 30
+
+      - name: Upload coverage XML report
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-uipath-platform
+          path: packages/uipath-platform/coverage.xml
+          retention-days: 30
 
   e2e-uipath-platform:
     name: E2E (uipath-platform, memory)
@@ -225,11 +270,75 @@ jobs:
         run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')
         working-directory: packages/uipath
         run: uv run pytest
 
+      - name: Run tests with coverage
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        working-directory: packages/uipath
+        run: uv run pytest --cov-report=xml --cov-report=html --tb=short
+
+      - name: Upload coverage HTML report
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-uipath
+          path: packages/uipath/htmlcov/
+          retention-days: 30
+
+      - name: Upload coverage XML report
+        if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-uipath
+          path: packages/uipath/coverage.xml
+          retention-days: 30
+
     continue-on-error: true
+
+  sonarcloud:
+    name: SonarCloud
+    needs: [test-uipath-core, test-uipath-platform, test-uipath]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && always() && needs.test-uipath-core.result != 'failure' && needs.test-uipath-platform.result != 'failure' && needs.test-uipath.result != 'failure'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download uipath-core coverage
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-xml-uipath-core
+          path: packages/uipath-core
+
+      - name: Download uipath-platform coverage
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-xml-uipath-platform
+          path: packages/uipath-platform
+
+      - name: Download uipath coverage
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-xml-uipath
+          path: packages/uipath
+
+      - name: Rewrite coverage XML <source> to repo-relative paths
+        run: |
+          sed -i 's|<source>src</source>|<source>packages/uipath-core/src</source>|g' packages/uipath-core/coverage.xml || true
+          sed -i 's|<source>src</source>|<source>packages/uipath-platform/src</source>|g' packages/uipath-platform/coverage.xml || true
+          sed -i 's|<source>src</source>|<source>packages/uipath/src</source>|g' packages/uipath/coverage.xml || true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   test-gate:
     name: Test

--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -95,15 +95,30 @@ warn_required_dynamic_aliases = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
-addopts = "-ra -q --cov=src/uipath --cov-report=term-missing"
+addopts = "-ra -q --cov=src --cov-report=term-missing"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 
-[tool.coverage.report]
-show_missing = true
-
 [tool.coverage.run]
 source = ["src"]
+relative_files = true
+omit = [
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/site-packages/*",
+  "*/conftest.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "raise NotImplementedError",
+  "if TYPE_CHECKING:",
+  "@(abc\\.)?abstractmethod",
+]
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -98,18 +98,33 @@ warn_required_dynamic_aliases = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
-addopts = "-ra -q --cov=src/uipath --cov-report=term-missing -m 'not e2e'"
+addopts = "-ra -q --cov=src --cov-report=term-missing -m 'not e2e'"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 markers = [
     "e2e: end-to-end tests against real ECS/LLMOps (requires UIPATH_URL, UIPATH_ACCESS_TOKEN, UIPATH_FOLDER_KEY)",
 ]
 
-[tool.coverage.report]
-show_missing = true
-
 [tool.coverage.run]
 source = ["src"]
+relative_files = true
+omit = [
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/site-packages/*",
+  "*/conftest.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "raise NotImplementedError",
+  "if TYPE_CHECKING:",
+  "@(abc\\.)?abstractmethod",
+]
 
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -137,15 +137,30 @@ warn_required_dynamic_aliases = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
-addopts = "-ra -q --cov"
+addopts = "-ra -q --cov=src --cov-report=term-missing"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 
-[tool.coverage.report]
-show_missing = true
-
 [tool.coverage.run]
 source = ["src"]
+relative_files = true
+omit = [
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/site-packages/*",
+  "*/conftest.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "raise NotImplementedError",
+  "if TYPE_CHECKING:",
+  "@(abc\\.)?abstractmethod",
+]
 
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=UiPath_uipath-python
+sonar.organization=ui
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=packages/uipath/src,packages/uipath-core/src,packages/uipath-platform/src
+sonar.tests=packages/uipath/tests,packages/uipath-core/tests,packages/uipath-platform/tests
+
+sonar.python.version=3.11,3.12,3.13
+sonar.python.coverage.reportPaths=packages/uipath/coverage.xml,packages/uipath-core/coverage.xml,packages/uipath-platform/coverage.xml
+
+sonar.exclusions=**/samples/**,**/testcases/**,**/template/**,**/_resources/**
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- per-package coverage artifacts on PRs (uipath, uipath-core, uipath-platform)
- coverage runs only on the ubuntu/3.13 matrix cell, no duplicate test runs
- also runs on push to main so sonarcloud has a baseline for new-code comparisons