### PR TITLE
fix: remove SearchMode.AUTO from context grounding

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.47"
+version = "0.1.48"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -1556,7 +1556,7 @@ class ContextGroundingService(FolderContext, BaseService):
         self,
         name: str,
         query: str,
-        search_mode: SearchMode = SearchMode.AUTO,
+        search_mode: SearchMode = SearchMode.SEMANTIC,
         number_of_results: int = 10,
         threshold: float = 0.0,
         scope: Optional[UnifiedSearchScope] = None,
@@ -1572,7 +1572,7 @@ class ContextGroundingService(FolderContext, BaseService):
         Args:
             name (str): The name of the context index to search in.
             query (str): The search query in natural language.
-            search_mode (SearchMode): The search mode to use. Defaults to AUTO.
+            search_mode (SearchMode): The search mode to use. Defaults to SEMANTIC.
             number_of_results (int): Maximum number of results to return. Defaults to 10.
             threshold (float): Minimum similarity threshold. Defaults to 0.0.
             scope (Optional[UnifiedSearchScope]): Optional search scope (folder, extension).
@@ -1620,7 +1620,7 @@ class ContextGroundingService(FolderContext, BaseService):
         self,
         name: str,
         query: str,
-        search_mode: SearchMode = SearchMode.AUTO,
+        search_mode: SearchMode = SearchMode.SEMANTIC,
         number_of_results: int = 10,
         threshold: float = 0.0,
         scope: Optional[UnifiedSearchScope] = None,
@@ -1636,7 +1636,7 @@ class ContextGroundingService(FolderContext, BaseService):
         Args:
             name (str): The name of the context index to search in.
             query (str): The search query in natural language.
-            search_mode (SearchMode): The search mode to use. Defaults to AUTO.
+            search_mode (SearchMode): The search mode to use. Defaults to SEMANTIC.
             number_of_results (int): Maximum number of results to return. Defaults to 10.
             threshold (float): Minimum similarity threshold. Defaults to 0.0.
             scope (Optional[UnifiedSearchScope]): Optional search scope (folder, extension).
@@ -2306,7 +2306,7 @@ class ContextGroundingService(FolderContext, BaseService):
         self,
         index_id: str,
         query: str,
-        search_mode: SearchMode = SearchMode.AUTO,
+        search_mode: SearchMode = SearchMode.SEMANTIC,
         number_of_results: int = 10,
         threshold: float = 0.0,
         scope: Optional[UnifiedSearchScope] = None,

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/context_grounding.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/context_grounding.py
@@ -239,7 +239,6 @@ class ContextGroundingSearchResultItem(BaseModel):
 class SearchMode(str, Enum):
     """Enum representing possible unified search modes."""
 
-    AUTO = "Auto"
     SEMANTIC = "Semantic"
 
 

--- a/packages/uipath-platform/tests/services/test_context_grounding_service.py
+++ b/packages/uipath-platform/tests/services/test_context_grounding_service.py
@@ -3700,7 +3700,7 @@ class TestContextGroundingService:
         response = await service.unified_search_async(
             name="test-index",
             query="test query",
-            search_mode=SearchMode.AUTO,
+            search_mode=SearchMode.SEMANTIC,
         )
 
         assert isinstance(response, UnifiedQueryResult)

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.47"
+version = "0.1.48"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.61"
+version = "2.10.62"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/services/cli_context_grounding.py
+++ b/packages/uipath/src/uipath/_cli/services/cli_context_grounding.py
@@ -460,9 +460,9 @@ def ingest_index(
 )
 @click.option(
     "--search-mode",
-    type=click.Choice(["Auto", "Semantic"]),
-    default="Auto",
-    help="Search mode (default: Auto)",
+    type=click.Choice(["Semantic"]),
+    default="Semantic",
+    help="Search mode (default: Semantic)",
 )
 @common_service_options
 @service_command

--- a/packages/uipath/src/uipath/_resources/CLI_REFERENCE.md
+++ b/packages/uipath/src/uipath/_resources/CLI_REFERENCE.md
@@ -923,7 +923,7 @@ Options:
 - `--query`: Search query in natural language (default: `Sentinel.UNSET`)
 - `--limit`: Maximum number of results (default: 10) (default: `10`)
 - `--threshold`: Minimum similarity threshold (default: 0.0) (default: `0.0`)
-- `--search-mode`: Search mode (default: Auto) (default: `Auto`)
+- `--search-mode`: Search mode (default: Semantic) (default: `Semantic`)
 - `--folder-path`: Folder path (e.g., "Shared"). Can also be set via UIPATH_FOLDER_PATH environment variable. (default: `Sentinel.UNSET`)
 - `--folder-key`: Folder key (UUID) (default: `Sentinel.UNSET`)
 - `--format`: Output format (overrides global) (default: `Sentinel.UNSET`)

--- a/packages/uipath/src/uipath/_resources/SDK_REFERENCE.md
+++ b/packages/uipath/src/uipath/_resources/SDK_REFERENCE.md
@@ -386,10 +386,10 @@ sdk.context_grounding.start_deep_rag_ephemeral(name: str, prompt: Annotated[str,
 sdk.context_grounding.start_deep_rag_ephemeral_async(name: str, prompt: Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=250000)])], glob_pattern: Annotated[str, FieldInfo(annotation=NoneType, required=False, default='*', metadata=[MaxLen(max_length=512)])]="**", citation_mode: <enum 'CitationMode="CitationMode.SKIP", index_id: Optional[Annotated[str, FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=512)])]]=None) -> uipath.platform.context_grounding.context_grounding.DeepRagCreationResponse
 
 # Perform a unified search on a context grounding index.
-sdk.context_grounding.unified_search(name: str, query: str, search_mode: <enum 'SearchMode="SearchMode.AUTO", number_of_results: int=10, threshold: float=0.0, scope: Optional[uipath.platform.context_grounding.context_grounding.UnifiedSearchScope]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding.UnifiedQueryResult
+sdk.context_grounding.unified_search(name: str, query: str, search_mode: <enum 'SearchMode="SearchMode.SEMANTIC", number_of_results: int=10, threshold: float=0.0, scope: Optional[uipath.platform.context_grounding.context_grounding.UnifiedSearchScope]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding.UnifiedQueryResult
 
 # Asynchronously perform a unified search on a context grounding index.
-sdk.context_grounding.unified_search_async(name: str, query: str, search_mode: <enum 'SearchMode="SearchMode.AUTO", number_of_results: int=10, threshold: float=0.0, scope: Optional[uipath.platform.context_grounding.context_grounding.UnifiedSearchScope]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding.UnifiedQueryResult
+sdk.context_grounding.unified_search_async(name: str, query: str, search_mode: <enum 'SearchMode="SearchMode.SEMANTIC", number_of_results: int=10, threshold: float=0.0, scope: Optional[uipath.platform.context_grounding.context_grounding.UnifiedSearchScope]=None, folder_key: Optional[str]=None, folder_path: Optional[str]=None) -> uipath.platform.context_grounding.context_grounding.UnifiedQueryResult
 
 ```
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.61"
+version = "2.10.62"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.47"
+version = "0.1.48"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Removes the `AUTO` variant from the context grounding `SearchMode` enum (server no longer supports it).
- Updates the broken `SearchMode.AUTO` reference in `test_context_grounding_service.py` to `SearchMode.SEMANTIC`.
- Updates two stale docstrings in `_context_grounding_service.py` ("Defaults to AUTO" → "Defaults to SEMANTIC").
- Bumps `uipath-platform` to `0.1.48`.

## Test plan
- [ ] `pytest packages/uipath-platform/tests/services/test_context_grounding_service.py`
- [ ] `ruff check packages/uipath-platform`
- [ ] `mypy packages/uipath-platform/src packages/uipath-platform/tests`