### PR TITLE
fix(ci): run sonarcloud scan on push to main too

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -301,7 +301,7 @@ jobs:
     name: SonarCloud
     needs: [test-uipath-core, test-uipath-platform, test-uipath]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && always() && needs.test-uipath-core.result != 'failure' && needs.test-uipath-platform.result != 'failure' && needs.test-uipath.result != 'failure'
+    if: always() && needs.test-uipath-core.result != 'failure' && needs.test-uipath-platform.result != 'failure' && needs.test-uipath.result != 'failure'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- removes the `github.event_name == ''pull_request''` gate from the sonarcloud job so it also runs on push to main

## Why

so coverage baseline gets recomputed on every merge