### PR TITLE
ci: scope sonarcloud job permissions to contents:read

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -302,6 +302,8 @@ jobs:
     needs: [test-uipath-core, test-uipath-platform, test-uipath]
     runs-on: ubuntu-latest
     if: always() && needs.test-uipath-core.result != 'failure' && needs.test-uipath-platform.result != 'failure' && needs.test-uipath.result != 'failure'
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- adds explicit `permissions: contents: read` on the sonarcloud job
- follows least-privilege; sonarcloud bot posts via its own github app, so no `pull-requests: write` needed