### PR TITLE
feat(platform): promote verbosityLevel attribute to top-level VerbosityLevel field

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.52"
+version = "0.1.53"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -87,6 +87,7 @@ class UiPathSpan:
     # Top-level fields for internal tracing schema
     execution_type: Optional[int] = None
     agent_version: Optional[str] = None
+    verbosity_level: Optional[int] = None
     attachments: Optional[List[SpanAttachment]] = None
 
     def to_dict(self, serialize_attributes: bool = True) -> Dict[str, Any]:
@@ -136,6 +137,7 @@ class UiPathSpan:
             "ReferenceId": self.reference_id,
             "ExecutionType": self.execution_type,
             "AgentVersion": self.agent_version,
+            "VerbosityLevel": self.verbosity_level,
             "Attachments": attachments_out,
         }
 
@@ -284,6 +286,7 @@ class _SpanUtils:
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
         reference_id = env.get("UIPATH_AGENT_ID") or attributes_dict.get("agentId")
+        verbosity_level = attributes_dict.get("verbosityLevel")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")
@@ -334,6 +337,7 @@ class _SpanUtils:
             span_type=span_type,
             execution_type=execution_type,
             agent_version=agent_version,
+            verbosity_level=verbosity_level,
             reference_id=reference_id,
             source=source,
             attachments=attachments,

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -125,7 +125,7 @@ class UiPathSpan:
                 for att in self.attachments
             ]
 
-        return {
+        result: Dict[str, Any] = {
             "Id": self.id,
             "TraceId": self.trace_id,
             "ParentId": self.parent_id,
@@ -147,9 +147,11 @@ class UiPathSpan:
             "ReferenceId": self.reference_id,
             "ExecutionType": self.execution_type,
             "AgentVersion": self.agent_version,
-            "VerbosityLevel": self.verbosity_level,
             "Attachments": attachments_out,
         }
+        if self.verbosity_level is not None:
+            result["VerbosityLevel"] = self.verbosity_level
+        return result
 
 
 class _SpanUtils:

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -29,6 +29,16 @@ class AttachmentDirection(IntEnum):
     OUT = 2
 
 
+class VerbosityLevel(IntEnum):
+    VERBOSE = 0
+    TRACE = 1
+    INFORMATION = 2
+    WARNING = 3
+    ERROR = 4
+    CRITICAL = 5
+    OFF = 6
+
+
 class SpanAttachment(BaseModel):
     """Represents an attachment in the UiPath tracing system."""
 

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -57,6 +57,37 @@ class TestOTelToUiPathSpan:
             assert getattr(uipath_span, span_field) == value, span_field
             assert span_dict[top_level_key] == value, top_level_key
 
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_verbosity_level_omitted_when_unset(self) -> None:
+        """Spans that don't set verbosityLevel must not carry the key on the wire.
+
+        Backwards compat: pre-existing spans never emitted VerbosityLevel; the
+        LLMOps backend applies its own default. Adding `"VerbosityLevel": null`
+        unconditionally would change the wire format for every existing span.
+        """
+        mock_span = Mock(spec=OTelSpan)
+        mock_context = SpanContext(
+            trace_id=0x123456789ABCDEF0123456789ABCDEF0,
+            span_id=0x0123456789ABCDEF,
+            is_remote=False,
+        )
+        mock_span.get_span_context.return_value = mock_context
+        mock_span.name = "legacy-span"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = {"someOtherAttr": "value"}
+        mock_span.events = []
+        mock_span.links = []
+        now_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = now_ns
+        mock_span.end_time = now_ns + 1_000_000
+
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        span_dict = uipath_span.to_dict()
+
+        assert uipath_span.verbosity_level is None
+        assert "VerbosityLevel" not in span_dict
+
 
 class TestNormalizeIds:
     """Tests for OTEL ID normalization functions."""

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -11,18 +11,49 @@ from uipath.platform.common import UiPathSpan, _SpanUtils
 
 
 class TestVerbosityLevel:
-    """VerbosityLevel enum mirrors the LLMOps backend enum."""
+    """Top-level UiPathSpan fields populated by attribute promotion.
 
-    def test_values_match_backend_enum(self) -> None:
-        from uipath.platform.common._span_utils import VerbosityLevel
+    `_SpanUtils.otel_span_to_uipath_span` promotes a small set of OTEL
+    attributes onto dedicated `UiPathSpan` fields surfaced under
+    `to_dict()`. This test documents that contract — adding a new row
+    means the attribute is newly promoted, removing one breaks
+    downstream consumers.
+    """
 
-        assert VerbosityLevel.VERBOSE == 0
-        assert VerbosityLevel.TRACE == 1
-        assert VerbosityLevel.INFORMATION == 2
-        assert VerbosityLevel.WARNING == 3
-        assert VerbosityLevel.ERROR == 4
-        assert VerbosityLevel.CRITICAL == 5
-        assert VerbosityLevel.OFF == 6
+    PROMOTIONS = [
+        ("executionType", "execution_type", "ExecutionType", 1),
+        ("agentVersion", "agent_version", "AgentVersion", "1.2.3"),
+        ("agentId", "reference_id", "ReferenceId", "ref-abc"),
+        ("verbosityLevel", "verbosity_level", "VerbosityLevel", 6),
+    ]
+
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_attributes_are_promoted_to_top_level_fields(self) -> None:
+        attrs = {otel_attr: value for otel_attr, _, _, value in self.PROMOTIONS}
+
+        mock_span = Mock(spec=OTelSpan)
+        mock_context = SpanContext(
+            trace_id=0x123456789ABCDEF0123456789ABCDEF0,
+            span_id=0x0123456789ABCDEF,
+            is_remote=False,
+        )
+        mock_span.get_span_context.return_value = mock_context
+        mock_span.name = "test-span"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = attrs
+        mock_span.events = []
+        mock_span.links = []
+        now_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = now_ns
+        mock_span.end_time = now_ns + 1_000_000
+
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        span_dict = uipath_span.to_dict()
+
+        for _, span_field, top_level_key, value in self.PROMOTIONS:
+            assert getattr(uipath_span, span_field) == value, span_field
+            assert span_dict[top_level_key] == value, top_level_key
 
 
 class TestNormalizeIds:
@@ -376,59 +407,6 @@ class TestSpanUtils:
 
         assert span_dict["ExecutionType"] is None
         assert span_dict["AgentVersion"] is None
-
-    def test_uipath_span_promotes_verbosity_level_attribute(self):
-        """Test that uipath.verbosity_level attribute promotes to top-level VerbosityLevel."""
-        mock_span = Mock(spec=OTelSpan)
-
-        trace_id = 0x123456789ABCDEF0123456789ABCDEF0
-        span_id = 0x0123456789ABCDEF
-        mock_context = SpanContext(trace_id=trace_id, span_id=span_id, is_remote=False)
-        mock_span.get_span_context.return_value = mock_context
-
-        mock_span.name = "AgentDefinition"
-        mock_span.parent = None
-        mock_span.status.status_code = StatusCode.OK
-        mock_span.attributes = {"verbosityLevel": 6}
-        mock_span.events = []
-        mock_span.links = []
-
-        current_time_ns = int(datetime.now().timestamp() * 1e9)
-        mock_span.start_time = current_time_ns
-        mock_span.end_time = current_time_ns + 1000000
-
-        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
-        span_dict = uipath_span.to_dict()
-
-        assert span_dict["VerbosityLevel"] == 6
-        assert uipath_span.verbosity_level == 6
-
-    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
-    def test_uipath_span_missing_verbosity_level_defaults_none(self):
-        """Test that absent uipath.verbosity_level leaves VerbosityLevel=None."""
-        mock_span = Mock(spec=OTelSpan)
-
-        trace_id = 0x123456789ABCDEF0123456789ABCDEF0
-        span_id = 0x0123456789ABCDEF
-        mock_context = SpanContext(trace_id=trace_id, span_id=span_id, is_remote=False)
-        mock_span.get_span_context.return_value = mock_context
-
-        mock_span.name = "Agent run"
-        mock_span.parent = None
-        mock_span.status.status_code = StatusCode.OK
-        mock_span.attributes = {"someOtherAttr": "value"}
-        mock_span.events = []
-        mock_span.links = []
-
-        current_time_ns = int(datetime.now().timestamp() * 1e9)
-        mock_span.start_time = current_time_ns
-        mock_span.end_time = current_time_ns + 1000000
-
-        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
-        span_dict = uipath_span.to_dict()
-
-        assert span_dict["VerbosityLevel"] is None
-        assert uipath_span.verbosity_level is None
 
     @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
     def test_uipath_span_source_defaults_to_coded_agents(self):

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -10,6 +10,21 @@ from opentelemetry.trace import SpanContext, StatusCode
 from uipath.platform.common import UiPathSpan, _SpanUtils
 
 
+class TestVerbosityLevel:
+    """VerbosityLevel enum mirrors the LLMOps backend enum."""
+
+    def test_values_match_backend_enum(self) -> None:
+        from uipath.platform.common._span_utils import VerbosityLevel
+
+        assert VerbosityLevel.VERBOSE == 0
+        assert VerbosityLevel.TRACE == 1
+        assert VerbosityLevel.INFORMATION == 2
+        assert VerbosityLevel.WARNING == 3
+        assert VerbosityLevel.ERROR == 4
+        assert VerbosityLevel.CRITICAL == 5
+        assert VerbosityLevel.OFF == 6
+
+
 class TestNormalizeIds:
     """Tests for OTEL ID normalization functions."""
 

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -10,8 +10,8 @@ from opentelemetry.trace import SpanContext, StatusCode
 from uipath.platform.common import UiPathSpan, _SpanUtils
 
 
-class TestVerbosityLevel:
-    """Top-level UiPathSpan fields populated by attribute promotion.
+class TestPromotedAttributes:
+    """OTEL attributes promoted to top-level UiPathSpan fields.
 
     `_SpanUtils.otel_span_to_uipath_span` promotes a small set of OTEL
     attributes onto dedicated `UiPathSpan` fields surfaced under

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -362,6 +362,59 @@ class TestSpanUtils:
         assert span_dict["ExecutionType"] is None
         assert span_dict["AgentVersion"] is None
 
+    def test_uipath_span_promotes_verbosity_level_attribute(self):
+        """Test that uipath.verbosity_level attribute promotes to top-level VerbosityLevel."""
+        mock_span = Mock(spec=OTelSpan)
+
+        trace_id = 0x123456789ABCDEF0123456789ABCDEF0
+        span_id = 0x0123456789ABCDEF
+        mock_context = SpanContext(trace_id=trace_id, span_id=span_id, is_remote=False)
+        mock_span.get_span_context.return_value = mock_context
+
+        mock_span.name = "AgentDefinition"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = {"verbosityLevel": 6}
+        mock_span.events = []
+        mock_span.links = []
+
+        current_time_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = current_time_ns
+        mock_span.end_time = current_time_ns + 1000000
+
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        span_dict = uipath_span.to_dict()
+
+        assert span_dict["VerbosityLevel"] == 6
+        assert uipath_span.verbosity_level == 6
+
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_uipath_span_missing_verbosity_level_defaults_none(self):
+        """Test that absent uipath.verbosity_level leaves VerbosityLevel=None."""
+        mock_span = Mock(spec=OTelSpan)
+
+        trace_id = 0x123456789ABCDEF0123456789ABCDEF0
+        span_id = 0x0123456789ABCDEF
+        mock_context = SpanContext(trace_id=trace_id, span_id=span_id, is_remote=False)
+        mock_span.get_span_context.return_value = mock_context
+
+        mock_span.name = "Agent run"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = {"someOtherAttr": "value"}
+        mock_span.events = []
+        mock_span.links = []
+
+        current_time_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = current_time_ns
+        mock_span.end_time = current_time_ns + 1000000
+
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        span_dict = uipath_span.to_dict()
+
+        assert span_dict["VerbosityLevel"] is None
+        assert uipath_span.verbosity_level is None
+
     @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
     def test_uipath_span_source_defaults_to_coded_agents(self):
         """Test that Source defaults to 10 (CodedAgents) and ignores attributes.source."""

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -10,17 +10,17 @@ from opentelemetry.trace import SpanContext, StatusCode
 from uipath.platform.common import UiPathSpan, _SpanUtils
 
 
-class TestPromotedAttributes:
-    """OTEL attributes promoted to top-level UiPathSpan fields.
+class TestOTelToUiPathSpan:
+    """OTEL attribute -> top-level UiPathSpan field mapping.
 
-    `_SpanUtils.otel_span_to_uipath_span` promotes a small set of OTEL
-    attributes onto dedicated `UiPathSpan` fields surfaced under
-    `to_dict()`. This test documents that contract — adding a new row
-    means the attribute is newly promoted, removing one breaks
+    `_SpanUtils.otel_span_to_uipath_span` lifts a small set of OTEL
+    span attributes onto dedicated `UiPathSpan` fields surfaced under
+    `to_dict()`. This test documents that mapping — adding a new row
+    means the attribute is newly mapped, removing one breaks
     downstream consumers.
     """
 
-    PROMOTIONS = [
+    ATTRIBUTE_FIELD_MAP = [
         ("executionType", "execution_type", "ExecutionType", 1),
         ("agentVersion", "agent_version", "AgentVersion", "1.2.3"),
         ("agentId", "reference_id", "ReferenceId", "ref-abc"),
@@ -28,8 +28,10 @@ class TestPromotedAttributes:
     ]
 
     @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
-    def test_attributes_are_promoted_to_top_level_fields(self) -> None:
-        attrs = {otel_attr: value for otel_attr, _, _, value in self.PROMOTIONS}
+    def test_attributes_map_to_top_level_fields(self) -> None:
+        attrs = {
+            otel_attr: value for otel_attr, _, _, value in self.ATTRIBUTE_FIELD_MAP
+        }
 
         mock_span = Mock(spec=OTelSpan)
         mock_context = SpanContext(
@@ -51,7 +53,7 @@ class TestPromotedAttributes:
         uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
         span_dict = uipath_span.to_dict()
 
-        for _, span_field, top_level_key, value in self.PROMOTIONS:
+        for _, span_field, top_level_key, value in self.ATTRIBUTE_FIELD_MAP:
             assert getattr(uipath_span, span_field) == value, span_field
             assert span_dict[top_level_key] == value, top_level_key
 

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.52"
+version = "0.1.53"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.10.66"
+version = "2.10.67"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.8, <0.6.0",
   "uipath-runtime>=0.10.1, <0.11.0",
-  "uipath-platform>=0.1.47, <0.2.0",
+  "uipath-platform>=0.1.53, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/tracing/__init__.py
+++ b/packages/uipath/src/uipath/tracing/__init__.py
@@ -5,6 +5,7 @@ from uipath.platform.common._span_utils import (
     AttachmentDirection,
     AttachmentProvider,
     SpanAttachment,
+    VerbosityLevel,
 )
 
 from ._live_tracking_processor import LiveTrackingSpanProcessor
@@ -23,4 +24,5 @@ __all__ = [
     "AttachmentDirection",
     "AttachmentProvider",
     "SpanAttachment",
+    "VerbosityLevel",
 ]

--- a/packages/uipath/tests/tracing/test_otel_exporters.py
+++ b/packages/uipath/tests/tracing/test_otel_exporters.py
@@ -810,5 +810,18 @@ class TestNilUuidProcessKey:
         assert payload["ProcessKey"] is None
 
 
+class TestVerbosityLevelReexport:
+    """VerbosityLevel from uipath-platform is re-exported via uipath.tracing."""
+
+    def test_uipath_tracing_reexports_verbosity_level(self) -> None:
+        from uipath.platform.common._span_utils import (
+            VerbosityLevel as _CommonVerbosity,
+        )
+        from uipath.tracing import VerbosityLevel as _TracingVerbosity
+
+        assert _TracingVerbosity is _CommonVerbosity
+        assert _TracingVerbosity.OFF == 6
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.66"
+version = "2.10.63"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.52"
+version = "0.1.49"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.63"
+version = "2.10.67"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.49"
+version = "0.1.53"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

   
  - Adds verbosity_level: Optional[int] field to UiPathSpan. The wire representation is deliberately different from ExecutionType / AgentVersion: when verbosity_level is None, the "VerbosityLevel" key is omitted entirely from to_dict() rather than emitted as null. This guarantees that
  spans which don't opt in produce byte-identical JSON to pre-change, so the LLMOps backend keeps applying its existing default (Information=2) untouched — required for 100% backwards compat with existing agents.
  - _SpanUtils.otel_span_to_uipath_span promotes the verbosityLevel OTEL span attribute to the new top-level field — same call-site shape as executionType / agentVersion / referenceId, but the omit-on-None behavior described above means the wire format only changes for spans that
  explicitly opt in.
  - New VerbosityLevel IntEnum (Verbose=0, Trace=1, Information=2, Warning=3, Error=4, Critical=5, Off=6) mirroring the C# UiPath.LLMOps.DataAccess.Models.VerbosityLevelEnum. Defined in uipath.platform.common._span_utils, re-exported via uipath.tracing (same pattern as AttachmentDirection
  / AttachmentProvider / SpanAttachment).
  - Enables producers to tag a span as internal-only (e.g. VerbosityLevel.OFF) so LLMOps can filter it out of user-facing trace UIs.
  - Bumps uipath-platform → 0.1.53, uipath → 2.10.67 (tightens uipath-platform>=0.1.53).

  Backwards compatibility

  The wire format change is intentionally asymmetric:
  
  ```
┌────────────────────────────────────────────────────────────────┬─────────────────────────────┬─────────────────────────────────────────────────────┐
  │                            Scenario                            │         Wire output         │                  Backend behavior                   │
  ├────────────────────────────────────────────────────────────────┼─────────────────────────────┼─────────────────────────────────────────────────────┤
  │ Existing span, no opt-in                                       │ "VerbosityLevel" key absent │ Applies its default (Information=2) — same as today │
  ├────────────────────────────────────────────────────────────────┼─────────────────────────────┼─────────────────────────────────────────────────────┤
  │ New opt-in span (e.g. AgentDefinition with VerbosityLevel.OFF) │ "VerbosityLevel": 6         │ Stores 6                                            │
  └────────────────────────────────────────────────────────────────┴─────────────────────────────┴─────────────────────────────────────────────────────┘
```

  This is intentionally NOT consistent with ExecutionType / AgentVersion, which still emit null unconditionally. The asymmetry is documented inline in to_dict() and locked by test_verbosity_level_omitted_when_unset (assert "VerbosityLevel" not in span_dict). Existing agents see
  byte-for-byte identical JSON.
  - Bumps uipath-platform → 0.1.53, uipath → 2.10.67 (tightens uipath-platform>=0.1.53).

  Test plan

  - pytest packages/uipath-platform/tests/services/test_span_utils.py — 20 passed, includes:
    - TestOTelToUiPathSpan::test_attributes_map_to_top_level_fields — single table-driven test enumerating the OTEL attributes that map to top-level fields (executionType, agentVersion, agentId, verbosityLevel).
    - TestOTelToUiPathSpan::test_verbosity_level_omitted_when_unset — locks the omit-on-None contract.
  - pytest packages/uipath/tests/tracing/test_otel_exporters.py — 26 passed, no regression; includes TestVerbosityLevelReexport for the uipath.tracing re-export.
  - No change to the wire format for spans that don't set verbosityLevel — verified by test_verbosity_level_omitted_when_unset.

  ---
  Key changes from the old description that address the reviewer's comment:
  - Removed the incorrect "consistent with ExecutionType / AgentVersion" claim.
  - Made the omit-on-None behavior explicit and called it out as intentional/different.
  - Added a backwards-compat table with the actual wire shape on both sides.
  - Pointed at the specific test (test_verbosity_level_omitted_when_unset, assert "VerbosityLevel" not in span_dict) that locks it.