### PR TITLE
docs(cli): clarify `uipath new` docstring

### DIFF
--- a/packages/uipath/src/uipath/_cli/cli_new.py
+++ b/packages/uipath/src/uipath/_cli/cli_new.py
@@ -49,7 +49,7 @@ def generate_uipath_json(target_directory):
 @click.argument("name", type=str, default="")
 @track_command("new")
 def new(name: str):
-    """Generate a quick-start project."""
+    """Generate a quick-start project scaffold in the current directory."""
     directory = os.getcwd()
 
     if not name:


### PR DESCRIPTION
## Summary
- Minor docstring tweak for the `uipath new` CLI command to clarify that it scaffolds into the current directory.

> Note: this PR is intentionally tiny — opened to validate the newly activated Copilot GitHub ruleset on this repository.

## Test plan
- [ ] CI checks pass
- [ ] Copilot ruleset triggers as expected