### PR TITLE
fix(tracing): set Traces source to CodedAgents

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.48"
+version = "0.1.49"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -15,8 +15,8 @@ from uipath.core.serialization import serialize_json
 
 logger = logging.getLogger(__name__)
 
-# SourceEnum.Robots = 4 (default for Python SDK / coded agents)
-DEFAULT_SOURCE = 4
+# SourceEnum.CodedAgents = 10 (default for Python SDK / coded agents)
+DEFAULT_SOURCE = 10
 
 
 class AttachmentProvider(IntEnum):

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -363,8 +363,8 @@ class TestSpanUtils:
         assert span_dict["AgentVersion"] is None
 
     @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
-    def test_uipath_span_source_defaults_to_robots(self):
-        """Test that Source defaults to 4 (Robots) and ignores attributes.source."""
+    def test_uipath_span_source_defaults_to_coded_agents(self):
+        """Test that Source defaults to 10 (CodedAgents) and ignores attributes.source."""
         mock_span = Mock(spec=OTelSpan)
 
         trace_id = 0x123456789ABCDEF0123456789ABCDEF0
@@ -387,9 +387,9 @@ class TestSpanUtils:
         uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
         span_dict = uipath_span.to_dict()
 
-        # Top-level Source should be 4 (Robots), string "runtime" is ignored
-        assert uipath_span.source == 4
-        assert span_dict["Source"] == 4
+        # Top-level Source should be 10 (CodedAgents), string "runtime" is ignored
+        assert uipath_span.source == 10
+        assert span_dict["Source"] == 10
 
         # attributes.source string should still be in Attributes JSON
         attrs = json.loads(span_dict["Attributes"])
@@ -408,7 +408,7 @@ class TestSpanUtils:
         mock_span.name = "test-span"
         mock_span.parent = None
         mock_span.status.status_code = StatusCode.OK
-        # uipath.source=1 (Agents) overrides default of 4 (Robots)
+        # uipath.source=1 (Agents) overrides default of 10 (CodedAgents)
         mock_span.attributes = {"uipath.source": 1, "source": "runtime"}
         mock_span.events = []
         mock_span.links = []

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.48"
+version = "0.1.49"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.63"
+version = "2.10.64"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/tracing/_otel_exporters.py
+++ b/packages/uipath/src/uipath/tracing/_otel_exporters.py
@@ -389,7 +389,7 @@ class LlmOpsHttpExporter(SpanExporter):
     def _build_url(self, span_list: list[Dict[str, Any]]) -> str:
         """Construct the URL for the API request."""
         trace_id = str(span_list[0]["TraceId"])
-        return f"{self.base_url}/api/Traces/spans?traceId={trace_id}&source=Robots"
+        return f"{self.base_url}/api/Traces/spans?traceId={trace_id}&source=CodedAgents"
 
     def _send_with_retries(
         self, url: str, payload: list[Dict[str, Any]], max_retries: int = 4

--- a/packages/uipath/tests/tracing/test_otel_exporters.py
+++ b/packages/uipath/tests/tracing/test_otel_exporters.py
@@ -54,7 +54,7 @@ def exporter(mock_env_vars):
         exporter = LlmOpsHttpExporter()
         # Mock _build_url to include query parameters as in the actual implementation
         exporter._build_url = MagicMock(  # type: ignore
-            return_value="https://test.uipath.com/org/tenant/llmopstenant_/api/Traces/spans?traceId=test-trace-id&source=Robots"
+            return_value="https://test.uipath.com/org/tenant/llmopstenant_/api/Traces/spans?traceId=test-trace-id&source=CodedAgents"
         )
         yield exporter
 
@@ -107,7 +107,7 @@ def test_export_success(exporter, mock_span):
             [{"span": "data", "TraceId": "test-trace-id"}]
         )
         exporter.http_client.post.assert_called_once_with(
-            "https://test.uipath.com/org/tenant/llmopstenant_/api/Traces/spans?traceId=test-trace-id&source=Robots",
+            "https://test.uipath.com/org/tenant/llmopstenant_/api/Traces/spans?traceId=test-trace-id&source=CodedAgents",
             json=[{"span": "data", "TraceId": "test-trace-id"}],
         )
 
@@ -685,7 +685,7 @@ class TestUpsertSpan:
         with patch("uipath.tracing._otel_exporters.httpx.Client"):
             exporter = LlmOpsHttpExporter()
             exporter._build_url = MagicMock(  # type: ignore
-                return_value="https://test.uipath.com/org/tenant/llmopstenant_/api/Traces/spans?traceId=test-trace-id&source=Robots"
+                return_value="https://test.uipath.com/org/tenant/llmopstenant_/api/Traces/spans?traceId=test-trace-id&source=CodedAgents"
             )
             yield exporter
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.63"
+version = "2.10.64"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.48"
+version = "0.1.49"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Change `source=Robots` to `source=CodedAgents` in the `/api/Traces/spans` URL built by `LlmOpsHttpExporter`
- Align `DEFAULT_SOURCE` model-side value with the query-path change
- Update related tests
- Bump `uipath` to 2.10.64 and `uipath-platform` to 0.1.49

Supersedes #1626 (that branch could not be force-pushed past the latest main due to repo ruleset blocking direct pushes; this PR is rebased onto current main).

## Test plan
- [ ] `pytest packages/uipath/tests/tracing/test_otel_exporters.py`
- [ ] `pytest packages/uipath-platform/tests/services/test_span_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)