### PR TITLE
fix(tracing): use agentId as span reference_id

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,6 +3,14 @@ name: uipath - Integration Tests
 on:
   pull_request:
     branches: [ main ]
+  # pull_request_target runs in the base-branch context and exposes secrets,
+  # which is required for Dependabot PRs (regular pull_request events do not
+  # receive repository secrets when triggered by Dependabot). The actor gate
+  # below restricts this trigger to Dependabot to avoid handing secrets to
+  # arbitrary fork PRs.
+  pull_request_target:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -11,6 +19,9 @@ permissions:
 
 jobs:
   detect-changed-packages:
+    if: |
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
@@ -19,6 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Python
@@ -44,6 +56,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Discover testcases
       id: discover
@@ -85,17 +99,37 @@ jobs:
       fail-fast: false
       matrix:
         testcase: ${{ fromJson(needs.discover-testcases.outputs.testcases) }}
-        environment: [alpha, cloud, staging]
+        # Dependabot runs are restricted to alpha to minimize blast radius of
+        # exposing credentials to dependency-bump PRs.
+        environment: ${{ github.event_name == 'pull_request_target' && fromJson('["alpha"]') || fromJson('["alpha", "cloud", "staging"]') }}
 
     name: "${{ matrix.testcase.testcase }} / ${{ matrix.environment }}"
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install dependencies
       working-directory: packages/${{ matrix.testcase.package }}
       run: uv sync
+
+    - name: Check secrets availability
+      env:
+        CLIENT_ID:      ${{ matrix.environment == 'alpha' && secrets.ALPHA_TEST_CLIENT_ID || matrix.environment == 'staging' && secrets.STAGING_TEST_CLIENT_ID || matrix.environment == 'cloud' && secrets.CLOUD_TEST_CLIENT_ID }}
+        CLIENT_SECRET:  ${{ matrix.environment == 'alpha' && secrets.ALPHA_TEST_CLIENT_SECRET || matrix.environment == 'staging' && secrets.STAGING_TEST_CLIENT_SECRET || matrix.environment == 'cloud' && secrets.CLOUD_TEST_CLIENT_SECRET }}
+        BASE_URL:       ${{ matrix.environment == 'alpha' && secrets.ALPHA_BASE_URL || matrix.environment == 'staging' && secrets.STAGING_BASE_URL || matrix.environment == 'cloud' && secrets.CLOUD_BASE_URL }}
+        PR_ACTOR: ${{ github.event.pull_request.user.login }}
+      run: |
+        missing=()
+        [ -z "$CLIENT_ID" ] && missing+=("CLIENT_ID")
+        [ -z "$CLIENT_SECRET" ] && missing+=("CLIENT_SECRET")
+        [ -z "$BASE_URL" ] && missing+=("BASE_URL")
+
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::warning::Missing or empty secrets for ${{ matrix.environment }}: ${missing[*]}. PRs from forks or Dependabot do not receive repository secrets — workflows triggered by '$PR_ACTOR' must have the corresponding values configured in Settings → Secrets and variables → Dependabot (or be re-run by a maintainer from a branch in this repo). The testcase will fail with a misleading auth error downstream."
+        fi
 
     - name: Run testcase
       env:
@@ -105,10 +139,10 @@ jobs:
 
         USE_AZURE_CHAT: ${{ matrix.use_azure_chat }}
 
-        # App Insights for telemetry testing
-        TELEMETRY_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
-        APP_INSIGHTS_APP_ID: ${{ secrets.APP_INSIGHTS_APP_ID }}
-        APP_INSIGHTS_API_KEY: ${{ secrets.APP_INSIGHTS_API_KEY }}
+        # App Insights for telemetry testing — omitted for Dependabot runs.
+        TELEMETRY_CONNECTION_STRING: ${{ github.event_name == 'pull_request_target' && '' || secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+        APP_INSIGHTS_APP_ID:         ${{ github.event_name == 'pull_request_target' && '' || secrets.APP_INSIGHTS_APP_ID }}
+        APP_INSIGHTS_API_KEY:        ${{ github.event_name == 'pull_request_target' && '' || secrets.APP_INSIGHTS_API_KEY }}
       working-directory: packages/${{ matrix.testcase.package }}/testcases/${{ matrix.testcase.testcase }}
       run: |
         # If any errors occur execution will stop with exit code
@@ -126,7 +160,11 @@ jobs:
   summarize-results:
     needs: [detect-changed-packages, discover-testcases, integration-tests]
     runs-on: ubuntu-latest
-    if: always()
+    if: |
+      always() && (
+        (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+        (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+      )
     steps:
       - name: Check integration tests status
         run: |

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -283,7 +283,7 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = attributes_dict.get("referenceId")
+        reference_id = attributes_dict.get("agentId")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")


### PR DESCRIPTION
## Summary

### Tracing
- Set `UiPathSpan.reference_id` from the `agentId` attribute (sourced from the `PROJECT_KEY` env var) instead of the unset `referenceId` attribute, so coded-agent spans carry a meaningful reference back to their agent.

### Integration tests workflow
Make Dependabot PRs actually able to run integration tests, without exposing the full secret blast radius to arbitrary fork PRs:

- Add `pull_request_target` trigger alongside the existing `pull_request`, gated by actor so it fires only for `dependabot[bot]`. Regular PRs continue to use `pull_request` exactly as before. No double-runs.
- Set `actions/checkout` to `ref: ${{ github.event.pull_request.head.sha }}` so the PR's code is tested in both event contexts (default for `pull_request_target` is base).
- Restrict the Dependabot matrix to the `alpha` environment only (skip `cloud` and `staging`) to minimize credential exposure for dependency-bump PRs.
- Omit App Insights / telemetry secrets for Dependabot runs.
- Add a `Check secrets availability` step that emits a `::warning::` annotation when any of `CLIENT_ID`/`CLIENT_SECRET`/`BASE_URL` is empty, so the previously-misleading downstream `UIPATH_ACCESS_TOKEN is not set` failure now has clear context (useful for non-Dependabot fork PRs).

Supersedes #1628 — rebased onto current main (the original branch could not be force-pushed past the latest main due to the repo ruleset blocking direct pushes).

## Test plan
- [ ] CI green on this PR (non-Dependabot path)
- [ ] Verify emitted spans include `ReferenceId` matching the project/agent id
- [ ] Confirm next Dependabot PR runs integration tests against alpha only and passes