### PR TITLE
fix(tracing): use agentId as span reference_id

### DIFF
--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -283,7 +283,7 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = attributes_dict.get("referenceId")
+        reference_id = attributes_dict.get("agentId")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")


### PR DESCRIPTION
## Summary
- Set `UiPathSpan.reference_id` from the `agentId` attribute (sourced from the `PROJECT_KEY` env var) instead of the unset `referenceId` attribute, so coded-agent spans carry a meaningful reference back to their agent.

Supersedes #1634 / #1628 — scope narrowed to only the `_span_utils.py` change (the workflow changes have been dropped from this PR).

## Test plan
- [ ] Verify emitted spans include `ReferenceId` matching the project/agent id