### PR TITLE
fix(jobs): allow null folder_key on Job model

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.50"
+version = "0.1.51"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/job.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/job.py
@@ -79,5 +79,5 @@ class Job(BaseModel):
     has_errors: Optional[bool] = Field(default=None, alias="HasErrors")
     has_warnings: Optional[bool] = Field(default=None, alias="HasWarnings")
     job_error: Optional[JobErrorInfo] = Field(default=None, alias="JobError")
-    folder_key: str = Field(alias="FolderKey")
+    folder_key: Optional[str] = Field(default=None, alias="FolderKey")
     id: int = Field(alias="Id")

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.50"
+version = "0.1.51"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.50"
+version = "0.1.51"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- mark `Job.folder_key` as `Optional[str]` so `sdk.jobs.list()` no longer raises a pydantic ValidationError when orchestrator returns `FolderKey: null`

## Why

orchestrator's odata `/Jobs` endpoint declares `FolderKey` as `nullable`