### PR TITLE
fix(tracing): fall back to TRACE_REFERENCE_ID for local workspace spans

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -283,7 +283,7 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = attributes_dict.get("agentId")
+        reference_id = attributes_dict.get("agentId") or env.get("TRACE_REFERENCE_ID")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.64"
+version = "2.10.65"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.64"
+version = "2.10.65"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- For local workspace (design-time) runs, `PROJECT_KEY` is not set since there is no deployed process, so `agentId` was never added to `attributes_dict`
- This caused `reference_id` to be `None`, bypassing the `default_factory` on `UiPathSpan.reference_id` (default_factory only fires when the field is omitted entirely, not when `None` is passed explicitly)
- Spans were stored with `ReferenceId = NULL`, breaking feedback lookup (`QueryTraceSpanIdsByReferenceId`) and trace association in LLMOps for design-time runs
- Fix: fall back to `env.get("TRACE_REFERENCE_ID")` (set by Orchestrator to `logicalAgentId` for local workspace runs) when `agentId` is not present

## Test plan

- [ ] Run an agent via a local workspace in Orchestrator
- [ ] Verify spans are stored with `ReferenceId` = `logicalAgentId` (not `NULL`)
- [ ] Verify feedback is correctly fetched for subsequent local workspace runs
- [ ] Verify production job runs (where `PROJECT_KEY` is set) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)