### PR TITLE
fix(tracing): use UIPATH_AGENT_ID for reference_id instead of PROJECT_KEY

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -283,7 +283,7 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = attributes_dict.get("agentId") or env.get("TRACE_REFERENCE_ID")
+        reference_id = env.get("UIPATH_AGENT_ID") or attributes_dict.get("agentId")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -283,7 +283,7 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = attributes_dict.get("agentId")
+        reference_id = attributes_dict.get("agentId") or env.get("TRACE_REFERENCE_ID")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.64"
+version = "2.10.65"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.64"
+version = "2.10.65"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- In local workspaces, `PROJECT_KEY` holds the debug project ID, not the agent ID
- `reference_id` was being set from `agentId` attribute, which was populated by mapping `PROJECT_KEY` → `agentId` in the env var loop
- Fix prioritizes `UIPATH_AGENT_ID` env var when computing `reference_id`, and removes the `TRACE_REFERENCE_ID` fallback (not always required)

## Test plan

- [ ] Run an agent locally and verify `ReferenceId` in traces matches `UIPATH_AGENT_ID`, not the debug project ID
- [ ] Verify non-local deployments still populate `reference_id` correctly via `agentId` span attribute fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)