### PR TITLE
fix(automation-ops): handle empty deployed-policy response

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.52"
+version = "0.1.53"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/automation_ops/_automation_ops_service.py
+++ b/packages/uipath-platform/src/uipath/platform/automation_ops/_automation_ops_service.py
@@ -30,7 +30,8 @@ class AutomationOpsService(BaseService):
         """Retrieve the deployed policy.
 
         Returns:
-            The deployed policy response as a dictionary.
+            The deployed policy response as a dictionary. Returns an empty
+            dict when no policy is deployed (empty 200 response body).
         """
         spec = self._deployed_policy_spec()
         response = self.request(
@@ -39,6 +40,8 @@ class AutomationOpsService(BaseService):
             headers=spec.headers,
             scoped="tenant",
         )
+        if not response.content:
+            return {}
         return response.json()
 
     @traced(name="automation_ops_get_deployed_policy", run_type="uipath")
@@ -46,7 +49,8 @@ class AutomationOpsService(BaseService):
         """Retrieve the deployed policy (async).
 
         Returns:
-            The deployed policy response as a dictionary.
+            The deployed policy response as a dictionary. Returns an empty
+            dict when no policy is deployed (empty 200 response body).
         """
         spec = self._deployed_policy_spec()
         response = await self.request_async(
@@ -55,6 +59,8 @@ class AutomationOpsService(BaseService):
             headers=spec.headers,
             scoped="tenant",
         )
+        if not response.content:
+            return {}
         return response.json()
 
     def _deployed_policy_spec(self) -> RequestSpec:

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -283,7 +283,7 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = attributes_dict.get("agentId")
+        reference_id = env.get("UIPATH_AGENT_ID") or attributes_dict.get("agentId")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE
         uipath_source = attributes_dict.get("uipath.source")

--- a/packages/uipath-platform/tests/services/test_automation_ops_service.py
+++ b/packages/uipath-platform/tests/services/test_automation_ops_service.py
@@ -49,6 +49,24 @@ class TestAutomationOpsService:
 
             assert result == expected_policy
 
+        def test_returns_empty_dict_when_no_policy_deployed(
+            self,
+            httpx_mock: HTTPXMock,
+            service: AutomationOpsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ) -> None:
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/agenthub_/api/policies/deployed-policy",
+                status_code=200,
+                content=b"",
+            )
+
+            result = service.get_deployed_policy()
+
+            assert result == {}
+
         def test_uses_post_method(
             self,
             httpx_mock: HTTPXMock,
@@ -101,6 +119,24 @@ class TestAutomationOpsService:
             result = await service.get_deployed_policy_async()
 
             assert result == expected_policy
+
+        async def test_returns_empty_dict_when_no_policy_deployed(
+            self,
+            httpx_mock: HTTPXMock,
+            service: AutomationOpsService,
+            base_url: str,
+            org: str,
+            tenant: str,
+        ) -> None:
+            httpx_mock.add_response(
+                url=f"{base_url}{org}{tenant}/agenthub_/api/policies/deployed-policy",
+                status_code=200,
+                content=b"",
+            )
+
+            result = await service.get_deployed_policy_async()
+
+            assert result == {}
 
         async def test_url_is_tenant_scoped(
             self,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.52"
+version = "0.1.53"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.52"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.64"
+version = "2.10.65"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_publish.py
+++ b/packages/uipath/src/uipath/_cli/cli_publish.py
@@ -191,7 +191,12 @@ def publish(feed, folder):
                 files = {
                     "file": (package_to_publish_path, f, "application/octet-stream")
                 }
-                response = client.post(url, headers=headers, files=files)
+                response = client.post(
+                    url,
+                    headers=headers,
+                    files=files,
+                    timeout=httpx.Timeout(600.0),
+                )
 
                 if response.status_code == 200:
                     console.success("Package published successfully!")
@@ -228,3 +233,5 @@ def publish(feed, folder):
                     console.error(
                         f"Failed to publish package. Status code: {response.status_code} {response.text}"
                     )
+                    console.error(f"Request URL: {response.request.method} {response.request.url}")
+                    console.error(f"Response headers: {dict(response.headers)}")

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.64"
+version = "2.10.65"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2682,7 +2682,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.51"
+version = "0.1.53"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
`automation_ops.get_deployed_policy[_async]` raised `JSONDecodeError` when the `agenthub_/api/policies/deployed-policy` endpoint returned 200 with an empty body (no policy deployed). This broke the `analyze_files_tool` in `uipath-langchain`. Returns `{}` when the response body is empty so callers see "no policy" cleanly.

Bumps `uipath-platform` to `0.1.53`.

Supersedes #1642 (couldn't resolve merge conflicts in place due to the branch protection ruleset blocking pushes).

## Test plan
- [x] Added unit tests for the empty-body case in sync and async paths (`test_automation_ops_service.py`).
- [x] `pytest tests/services/test_automation_ops_service.py` — 7 passed.
- [x] `uv sync --locked --all-extras` resolves cleanly in `packages/uipath` and `packages/uipath-platform`.
- [ ] Verify in a downstream agent that an environment with no deployed policy no longer logs the traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)