### PR TITLE
Fix PR 1630 lint and version checks

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.63"
+version = "2.10.66"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/tests/evaluators/test_legacy_trajectory_evaluator.py
+++ b/packages/uipath/tests/evaluators/test_legacy_trajectory_evaluator.py
@@ -3,6 +3,10 @@ import uuid
 from opentelemetry.sdk.trace import ReadableSpan
 
 from uipath.eval.evaluators import LegacyTrajectoryEvaluator
+from uipath.eval.evaluators.base_legacy_evaluator import LegacyEvaluationCriteria
+from uipath.eval.evaluators.legacy_trajectory_evaluator import (
+    LegacyTrajectoryEvaluatorConfig,
+)
 from uipath.eval.models.models import LegacyEvaluatorCategory, LegacyEvaluatorType
 
 
@@ -10,6 +14,9 @@ def _legacy_trajectory_evaluator() -> LegacyTrajectoryEvaluator:
     return LegacyTrajectoryEvaluator(
         id=str(uuid.uuid4()),
         name="Legacy trajectory",
+        config_type=LegacyTrajectoryEvaluatorConfig,
+        evaluation_criteria_type=LegacyEvaluationCriteria,
+        justification_type=str,
         category=LegacyEvaluatorCategory.Trajectory,
         type=LegacyEvaluatorType.Trajectory,
         prompt="History:\n{{AgentRunHistory}}\nExpected:\n{{ExpectedAgentBehavior}}",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.63"
+version = "2.10.66"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Updates #1630's head branch through the repository-required PR path.\n\nFixes:\n- adds explicit LegacyTrajectoryEvaluator type metadata in the new test so mypy passes\n- bumps packages/uipath from 2.10.63 to 2.10.66 because 2.10.64 and 2.10.65 are already published\n\nLocal validation against current main:\n- GITHUB_EVENT_NAME=pull_request BASE_SHA=origin/main HEAD_SHA=HEAD python .github/scripts/check_version_uniqueness.py\n- cd packages/uipath && uv run mypy --config-file pyproject.toml .\n- cd packages/uipath && uv run ruff check .\n- cd packages/uipath && uv run ruff format --check .