### PR TITLE
fix(eval): trim legacy trajectory span history

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.65"
+version = "2.10.66"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
@@ -12,13 +12,13 @@ from uipath.platform.chat.llm_gateway import RequiredToolChoice
 
 from ..._utils.constants import COMMUNITY_agents_SUFFIX
 from .._execution_context import eval_set_run_id_context
+from .._helpers.evaluators_helpers import trace_to_str
 from .._helpers.helpers import is_empty_value
 from ..models import EvaluationResult
 from ..models.models import (
     AgentExecution,
     LLMResponse,
     NumericEvaluationResult,
-    TrajectoryEvaluationTrace,
     UiPathEvaluationError,
     UiPathEvaluationErrorCategory,
 )
@@ -140,10 +140,7 @@ class LegacyTrajectoryEvaluator(BaseLegacyEvaluator[LegacyTrajectoryEvaluatorCon
             and agent_run_history
             and isinstance(agent_run_history[0], ReadableSpan)
         ):
-            trajectory_trace = TrajectoryEvaluationTrace.from_readable_spans(
-                agent_run_history
-            )
-            agent_run_history = str(trajectory_trace.spans)
+            agent_run_history = trace_to_str(agent_run_history)
         else:
             agent_run_history = str(agent_run_history)
 

--- a/packages/uipath/tests/evaluators/test_legacy_trajectory_evaluator.py
+++ b/packages/uipath/tests/evaluators/test_legacy_trajectory_evaluator.py
@@ -1,0 +1,64 @@
+import uuid
+
+from opentelemetry.sdk.trace import ReadableSpan
+
+from uipath.eval.evaluators import LegacyTrajectoryEvaluator
+from uipath.eval.evaluators.base_legacy_evaluator import LegacyEvaluationCriteria
+from uipath.eval.evaluators.legacy_trajectory_evaluator import (
+    LegacyTrajectoryEvaluatorConfig,
+)
+from uipath.eval.models.models import LegacyEvaluatorCategory, LegacyEvaluatorType
+
+
+def _legacy_trajectory_evaluator() -> LegacyTrajectoryEvaluator:
+    return LegacyTrajectoryEvaluator(
+        id=str(uuid.uuid4()),
+        name="Legacy trajectory",
+        config_type=LegacyTrajectoryEvaluatorConfig,
+        evaluation_criteria_type=LegacyEvaluationCriteria,
+        justification_type=str,
+        category=LegacyEvaluatorCategory.Trajectory,
+        type=LegacyEvaluatorType.Trajectory,
+        prompt="History:\n{{AgentRunHistory}}\nExpected:\n{{ExpectedAgentBehavior}}",
+        createdAt="2026-05-14T00:00:00Z",
+        updatedAt="2026-05-14T00:00:00Z",
+    )
+
+
+def test_legacy_trajectory_prompt_uses_compact_tool_history() -> None:
+    long_prompt = "SYSTEM_PROMPT_" + ("x" * 10_000)
+    spans = [
+        ReadableSpan(
+            name="agent_llm_call",
+            start_time=0,
+            end_time=1,
+            attributes={
+                "openinference.span.kind": "LLM",
+                "input.value": f'{{"messages": [{{"role": "system", "content": "{long_prompt}"}}]}}',
+                "output.value": '{"generations": []}',
+            },
+        ),
+        ReadableSpan(
+            name="search_profiles",
+            start_time=1,
+            end_time=2,
+            attributes={
+                "openinference.span.kind": "TOOL",
+                "tool.name": "search_profiles",
+                "input.value": '{"query": "mentor"}',
+                "output.value": '{"content": "found mentor profile"}',
+                "metadata": f'{{"agent_prompt": "{long_prompt}"}}',
+            },
+        ),
+    ]
+
+    prompt = _legacy_trajectory_evaluator()._create_evaluation_prompt(
+        expected_agent_behavior="The agent should search matching profiles.",
+        agent_run_history=spans,
+    )
+
+    assert "SYSTEM_PROMPT_" not in prompt
+    assert "Tool: search_profiles" in prompt
+    assert '{"query": "mentor"}' in prompt
+    assert "found mentor profile" in prompt
+    assert "agent_llm_call" not in prompt

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.65"
+version = "2.10.66"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Replacement for #1630 because the original branch cannot be updated cleanly from this account: direct push is blocked by repository rules, gh pr update-branch --rebase returns a GitHub GraphQL error, merge commits are disabled, and the branch now conflicts with main's uipath version bump.\n\nChanges:\n- use trace_to_str for legacy trajectory ReadableSpan history to avoid carrying long LLM/system prompt payloads into the evaluator prompt\n- add a regression test for compact tool history\n- pass explicit LegacyTrajectoryEvaluator type metadata in the test so mypy passes\n- bump packages/uipath to 2.10.66 because 2.10.65 is now on main and already published\n\nLocal validation:\n- GITHUB_EVENT_NAME=pull_request BASE_SHA=origin/main HEAD_SHA=HEAD python .github/scripts/check_version_uniqueness.py\n- cd packages/uipath && uv run mypy --config-file pyproject.toml .\n- cd packages/uipath && uv run ruff check .\n- cd packages/uipath && uv run ruff format --check .\n- cd packages/uipath && uv run pytest tests/evaluators/test_legacy_trajectory_evaluator.py\n- cd packages/uipath && uv run pytest