### PR TITLE
chore: enforce 2 days min age for third parties

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -120,6 +120,9 @@ exclude_lines = [
   "@(abc\\.)?abstractmethod",
 ]
 
+[tool.uv]
+exclude-newer = "2 days"
+
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -126,6 +126,12 @@ exclude_lines = [
   "@(abc\\.)?abstractmethod",
 ]
 
+[tool.uv]
+exclude-newer = "2 days"
+
+[tool.uv.exclude-newer-package]
+uipath-core = false
+
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }
 

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+uipath-core = false
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -162,6 +162,14 @@ exclude_lines = [
   "@(abc\\.)?abstractmethod",
 ]
 
+[tool.uv]
+exclude-newer = "2 days"
+
+[tool.uv.exclude-newer-package]
+uipath-core = false
+uipath-runtime = false
+uipath-platform = false
+
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }
 uipath-platform = { path = "../uipath-platform", editable = true }

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2,6 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+uipath-runtime = false
+uipath-platform = false
+uipath-core = false
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
Given the recent npm supply chain attacks, it would be prudent to enforce a min package age here as well.