### PR TITLE
feat: introduce ToolsConfiguration on AgentMcpResourceConfig

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.67"
+version = "2.10.68"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -446,11 +446,46 @@ class AgentMcpTool(BaseCfg):
 
 
 class DynamicToolsMode(str, CaseInsensitiveEnum):
-    """Dynamic tools mode enumeration."""
+    """Dynamic tools mode enumeration.
+
+    Deprecated: kept for backwards compatibility with older ``agent.json`` files
+    that still serialize the ``dynamicTools`` field. New code should use
+    :class:`ToolsConfiguration` (see ``AgentMcpResourceConfig.tools_configuration``).
+    """
 
     NONE = "none"
     SCHEMA = "schema"
     ALL = "all"
+
+
+class CachedToolsConfig(BaseCfg):
+    """Cached tools configuration: use the tools saved in the agent definition snapshot."""
+
+    type: Literal["cached"] = Field(default="cached", frozen=True)
+
+
+class DynamicToolsConfig(BaseCfg):
+    """Dynamic tools configuration: fetch the tool list from the MCP server at runtime.
+
+    When ``allow_all`` is true, every tool the server exposes is forwarded
+    to the agent. When false, the live list is filtered by the snapshot's
+    ``available_tools`` allowlist (live schemas, curated tool set).
+    """
+
+    type: Literal["dynamic"] = Field(default="dynamic", frozen=True)
+    allow_all: bool = Field(alias="allowAll")
+
+
+DiscoveryMode = Annotated[
+    Union[CachedToolsConfig, DynamicToolsConfig],
+    Field(discriminator="type"),
+]
+
+
+class ToolsConfiguration(BaseCfg):
+    """Configuration describing how tools are sourced for an MCP resource."""
+
+    discovery_mode: DiscoveryMode = Field(alias="discoveryMode")
 
 
 class AgentMcpResourceConfig(BaseAgentResourceConfig):
@@ -462,8 +497,8 @@ class AgentMcpResourceConfig(BaseAgentResourceConfig):
     folder_path: str = Field(alias="folderPath")
     slug: str = Field(..., alias="slug")
     available_tools: List[AgentMcpTool] = Field(..., alias="availableTools")
-    dynamic_tools: DynamicToolsMode = Field(
-        default=DynamicToolsMode.NONE, alias="dynamicTools"
+    tools_configuration: Optional[ToolsConfiguration] = Field(
+        default=None, alias="toolsConfiguration"
     )
 
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-05-17T16:21:47.0725551Z"
+exclude-newer = "2026-05-17T17:25:34.9197064Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.67"
+version = "2.10.68"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

Introduces a new `tools_configuration: Optional[ToolsConfiguration]` field on `AgentMcpResourceConfig`, replacing the legacy `dynamic_tools` enum.

`ToolsConfiguration.discovery_mode` is a discriminated union of:

- **`CachedToolsConfig`** (`type: "cached"`) — use the tools saved in the agent definition snapshot. No runtime discovery; lazy MCP connection.
- **`DynamicToolsConfig`** (`type: "dynamic"`, with `allow_all: bool`) — fetch the live tool list from the MCP server at runtime.
  - `allow_all=True` → forward every tool the server exposes.
  - `allow_all=False` → filter the live list against the snapshot's `availableTools` (curated subset, live schemas).

The legacy `DynamicToolsMode` enum stays exported as a deprecated alias. The `dynamic_tools` field is removed from the model, but old `agent.json` files that still serialize `dynamicTools` continue to validate because `BaseCfg` keeps `extra="allow"`.

Patch version bumped: `2.10.67` → `2.10.68`.

## Related PRs (must land together)

- uipath-langchain consumer: https://github.com/UiPath/uipath-langchain-python/pull/861
- uipath-agents-python dep bump: https://github.com/UiPath/uipath-agents-python/pull/499
- Agents frontend (UI rename + storage schema): https://github.com/UiPath/Agents/pull/5290

## Test plan

- [x] `packages/uipath/tests/agent/models/test_agent.py` — 65 tests passing.
- [x] `ruff format --check` / `ruff check` / `mypy` clean on the package.
- [x] Downstream consumer (uipath-langchain) tests pass against editable install of this branch.