### PR TITLE
docs: add LangChain guardrails nav entry and remove deprecated PromptInjection [AL-437]

### DIFF
--- a/packages/uipath/docs/core/guardrails.md
+++ b/packages/uipath/docs/core/guardrails.md
@@ -1,6 +1,6 @@
 # Guardrails
 
-Guardrails are safeguards applied before and/or after execution to inspect inputs and outputs for policy violations — PII, harmful content, intellectual property, and custom rules — and respond by logging, blocking, or modifying the data.
+Guardrails are safeguards applied before and/or after execution to inspect inputs and outputs for policy violations — PII, harmful content, prompt attacks, intellectual property, and custom rules — and respond by logging, blocking, or modifying the data.
 
 They can be applied at three scopes:
 

--- a/packages/uipath/docs/core/guardrails.md
+++ b/packages/uipath/docs/core/guardrails.md
@@ -1,6 +1,6 @@
 # Guardrails
 
-Guardrails are safeguards applied before and/or after execution to inspect inputs and outputs for policy violations — PII, harmful content, prompt injection, intellectual property, and custom rules — and respond by logging, blocking, or modifying the data.
+Guardrails are safeguards applied before and/or after execution to inspect inputs and outputs for policy violations — PII, harmful content, intellectual property, and custom rules — and respond by logging, blocking, or modifying the data.
 
 They can be applied at three scopes:
 
@@ -44,9 +44,11 @@ When using LangChain's `@tool`, `@guardrail` must be placed **above** `@tool`:
 from langchain_core.tools import tool
 
 @guardrail(
-    validator=PromptInjectionValidator(threshold=0.5),
+    validator=PIIValidator(
+        entities=[PIIDetectionEntity(PIIDetectionEntityType.EMAIL, threshold=0.5)]
+    ),
     action=BlockAction(),
-    name="No prompt injection",
+    name="No PII in tool input",
     stage=GuardrailExecutionStage.PRE,
 )
 @tool  # @guardrail wraps the already-decorated tool object
@@ -58,9 +60,9 @@ def analyze_joke(joke: str) -> str:
 
 ```python
 @guardrail(
-    validator=PromptInjectionValidator(threshold=0.5),
+    validator=UserPromptAttacksValidator(),
     action=BlockAction(),
-    name="LLM Prompt Injection Detection",
+    name="LLM User Prompt Attacks Detection",
     stage=GuardrailExecutionStage.PRE,
 )
 def create_llm():
@@ -92,7 +94,7 @@ The `stage` parameter controls when the guardrail evaluates. Not all validators 
 | Stage | When evaluated | Supported by |
 |-------|---------------|--------------|
 | `PRE` | Before the function runs | All validators |
-| `POST` | After the function runs | All except `PromptInjectionValidator`, `UserPromptAttacksValidator` |
+| `POST` | After the function runs | All except `UserPromptAttacksValidator` |
 | `PRE_AND_POST` | Both before and after | `PIIValidator`, `HarmfulContentValidator`, `CustomValidator` |
 
 ## Built-in Validators
@@ -153,28 +155,6 @@ from uipath.platform.guardrails import (
     name="Safe content only",
 )
 def generate_response(prompt: str) -> str:
-    ...
-```
-
-### Prompt Injection
-
-Detects prompt injection attacks in user input. Restricted to `PRE` stage only — this is an input concern.
-
-```python
-from uipath.platform.guardrails import (
-    BlockAction,
-    GuardrailExecutionStage,
-    PromptInjectionValidator,
-    guardrail,
-)
-
-@guardrail(
-    validator=PromptInjectionValidator(threshold=0.5),
-    action=BlockAction(),
-    name="No prompt injection",
-    stage=GuardrailExecutionStage.PRE,
-)
-def run_agent_step(user_input: str) -> str:
     ...
 ```
 
@@ -337,9 +317,9 @@ Multiple `@guardrail` decorators can be stacked on the same function. Each is ev
 
 ```python
 @guardrail(
-    validator=PromptInjectionValidator(),
+    validator=UserPromptAttacksValidator(),
     action=BlockAction(),
-    name="No injection",
+    name="No prompt attacks",
     stage=GuardrailExecutionStage.PRE,
 )
 @guardrail(
@@ -447,11 +427,6 @@ print(result.result, result.reason)
     options:
       members:
         - HarmfulContentValidator
-
-::: uipath.platform.guardrails.decorators.validators.prompt_injection
-    options:
-      members:
-        - PromptInjectionValidator
 
 ::: uipath.platform.guardrails.decorators.validators.intellectual_property
     options:

--- a/packages/uipath/docs/langchain
+++ b/packages/uipath/docs/langchain
@@ -1,0 +1,1 @@
+/Users/apetraru/Projects/agents-python-workspace/uipath-langchain-python/docs

--- a/packages/uipath/docs/langchain
+++ b/packages/uipath/docs/langchain
@@ -1,1 +1,0 @@
-/Users/apetraru/Projects/agents-python-workspace/uipath-langchain-python/docs

--- a/packages/uipath/mkdocs.yml
+++ b/packages/uipath/mkdocs.yml
@@ -6,6 +6,9 @@ repo_url: https://github.com/UiPath/uipath-python
 
 copyright: Copyright &copy; 2025 UiPath
 
+hooks:
+  - docs/langchain/hooks/enum_lists.py
+
 extra_css:
   - stylesheets/extra.css
 

--- a/packages/uipath/mkdocs.yml
+++ b/packages/uipath/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Getting Started: langchain/quick_start.md
       - Chat Models: langchain/chat_models.md
       - Context Grounding: langchain/context_grounding.md
+      - Guardrails: langchain/guardrails.md
       - Human In The Loop: langchain/human_in_the_loop.md
       - Sample Agents: https://github.com/UiPath/uipath-langchain-python/tree/main/samples
   - UiPath LlamaIndex SDK:


### PR DESCRIPTION
## What changed?

Three documentation updates:

**`packages/uipath/mkdocs.yml`**
- Added `Guardrails: langchain/guardrails.md` nav entry under the UiPath LangChain SDK section
- Registered the `docs/langchain/hooks/enum_lists.py` MkDocs hook (symlinked from `uipath-langchain-python` at build time) — expands `<!-- ENUM dotted.path.ClassName -->` placeholders into markdown tables derived from the installed package

**`packages/uipath/docs/core/guardrails.md`**
- Added "prompt attacks" to the intro violations list (covers `UserPromptAttacksValidator`)
- Replaced `PromptInjectionValidator` in all usage examples with `PIIValidator` / `UserPromptAttacksValidator`
- Removed the dedicated "Prompt Injection" section and its API reference block
- Updated the execution-stages table to remove the `PromptInjectionValidator` POST exception

## How has this been tested?

Rendered locally via `mkdocs serve` from `packages/uipath/`. The new Guardrails nav entry appears correctly under UiPath LangChain SDK and all core guardrails page content is correct with no remaining `PromptInjectionValidator` references.

> **Note:** The symlink `docs/langchain` is created by CI at build time (`publish-docs.yml` clones `uipath-langchain-python` and symlinks `docs/` to `docs/langchain`). No symlink is committed to this repo.

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations required
- [ ] API removals or changes
- [ ] Other