### PR TITLE
fix(platform): gate x-uipath-traceparent-id behind EnableTraceContextHeaders

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.39"
+version = "0.1.40"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_base_service.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_base_service.py
@@ -69,15 +69,26 @@ _TRACE_PARENT_HEADER = "x-uipath-traceparent-id"
 def _inject_trace_context(headers: dict[str, str]) -> None:
     """Inject UiPath trace context header.
 
+    Gated by the ``EnableTraceContextHeaders`` feature flag: callers opt in
+    once they want server-side spans (e.g. LLM Gateway, agentsruntime) to be
+    parented under the current LLMOps span. Sending the header unconditionally
+    causes backends that emit traces from it (helix-v2 / agentsruntime
+    guardrails validate, etc.) to attach restricted spans to internal LLMOps
+    parents the viewer isn't authorized to read — see AL-441.
+
     Trace ID: uses the agent trace ID from UIPATH_TRACE_ID env var (same
     remapping the LLMOps exporter applies), falling back to the OTEL trace ID.
     Span ID: uses the LLMOps tool span (via external span provider) so the
     span ID matches what's visible in the LLMOps trace UI.
     """
+    from uipath.core.feature_flags import FeatureFlags
     from uipath.core.tracing.span_utils import UiPathSpanUtils
 
     from ._config import UiPathConfig
     from ._span_utils import _SpanUtils
+
+    if not FeatureFlags.is_flag_enabled("EnableTraceContextHeaders"):
+        return
 
     llmops_span = UiPathSpanUtils.get_external_current_span()
     span = llmops_span or trace.get_current_span()

--- a/packages/uipath-platform/tests/services/test_base_service.py
+++ b/packages/uipath-platform/tests/services/test_base_service.py
@@ -1,5 +1,8 @@
 import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
 from pytest_httpx import HTTPXMock
+from uipath.core.feature_flags import FeatureFlags
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common._base_service import BaseService
@@ -350,6 +353,94 @@ class TestServiceUrlOverride:
             == f"{base_url}{org}{tenant}/orchestrator_/odata/Buckets"
         )
         assert response.status_code == 200
+
+
+_TRACE_PARENT_HEADER = "x-uipath-traceparent-id"
+
+
+class TestTraceContextHeader:
+    """`x-uipath-traceparent-id` must stay off the wire unless explicitly opted in.
+
+    When the header is present, downstream services (LLM Gateway,
+    /agentsruntime_/guardrails/validate, etc.) emit child spans tied to the
+    propagated parent. That backend behavior pre-existed but only became
+    user-visible once this header started shipping on every BaseService call —
+    see AL-441, where helix-v2 emits permission-restricted child spans under
+    LLMOps guardrail-evaluation parents.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tracer_provider(self) -> None:
+        # Default OTel ProxyTracer hands back NonRecording spans, which makes
+        # the trace context inert. Install a real SDK provider so any span we
+        # would propagate is observable on the wire.
+        otel_trace.set_tracer_provider(TracerProvider())
+
+    @pytest.fixture(autouse=True)
+    def _reset_flags(self) -> None:
+        FeatureFlags.reset_flags()
+        yield
+        FeatureFlags.reset_flags()
+
+    def test_header_not_sent_when_flag_off(
+        self,
+        httpx_mock: HTTPXMock,
+        service: BaseService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/endpoint", status_code=200, json={}
+        )
+        tracer = otel_trace.get_tracer(__name__)
+        with tracer.start_as_current_span("client-span"):
+            service.request("GET", "/endpoint")
+
+        sent = httpx_mock.get_request()
+        assert sent is not None
+        assert _TRACE_PARENT_HEADER not in sent.headers
+
+    def test_header_sent_when_flag_on(
+        self,
+        httpx_mock: HTTPXMock,
+        service: BaseService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        FeatureFlags.configure_flags({"EnableTraceContextHeaders": True})
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/endpoint", status_code=200, json={}
+        )
+        tracer = otel_trace.get_tracer(__name__)
+        with tracer.start_as_current_span("client-span"):
+            service.request("GET", "/endpoint")
+
+        sent = httpx_mock.get_request()
+        assert sent is not None
+        assert _TRACE_PARENT_HEADER in sent.headers
+        assert sent.headers[_TRACE_PARENT_HEADER].startswith("00-")
+
+    @pytest.mark.anyio
+    async def test_header_not_sent_when_flag_off_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: BaseService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/endpoint", status_code=200, json={}
+        )
+        tracer = otel_trace.get_tracer(__name__)
+        with tracer.start_as_current_span("client-span"):
+            await service.request_async("GET", "/endpoint")
+
+        sent = httpx_mock.get_request()
+        assert sent is not None
+        assert _TRACE_PARENT_HEADER not in sent.headers
 
 
 class TestServiceUrlOverrideAsync:

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1088,7 +1088,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.39"
+version = "0.1.40"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

`_inject_trace_context` in `BaseService.request` / `request_async` has been shipping the `x-uipath-traceparent-id` header on every outbound call since #1535. Backends that emit traces from that header (notably helix-v2's `/agentsruntime_/api/execution/guardrails/validate`) tie their server-side spans to the LLMOps span the header points to. When the viewer doesn't hold the trace producer's permissions, the LLMOps UI renders the resulting helix-v2 spans as permission-restricted **N/A** children — see [AL-441](https://uipath.atlassian.net/browse/AL-441):

```json
{ "Id": "f12ade93fcf8b5c1", "ParentId": "d1e00cb14a74e382",
  "Name": null, "Attributes": null, "Status": 4, "VerbosityLevel": 2, ... }
```

The LLM Gateway path already gates the same header behind `EnableTraceContextHeaders` (see `build_trace_context_headers` in `uipath/platform/chat/llm_trace_context.py`). This PR aligns `_inject_trace_context` with that contract so the header only ships when the flag is explicitly enabled — matching the design intent that backend span propagation is opt-in.

## Changes
- `_inject_trace_context` short-circuits when `EnableTraceContextHeaders` is off.
- Three new tests in `TestTraceContextHeader` covering: off (sync + async) and on.
- Version bump `uipath-platform` 0.1.39 → 0.1.40.

## Test plan
- [x] `pytest packages/uipath-platform/tests/services/test_base_service.py` — 28 passed
- [x] `ruff check` clean
- [ ] Verify in a downstream agents run (with the flag off) that helix-v2 no longer emits N/A child spans under guardrail evaluations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AL-441]: https://uipath.atlassian.net/browse/AL-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ