### PR TITLE
feat(agent): add tool-output and V2 escalation recipient types [ACTN-10480]

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.67"
+version = "0.1.68"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
@@ -305,6 +305,34 @@ async def _assign_task_spec(
                     }
                 ]
             }
+        elif task_recipient.type == TaskRecipientType.WORKLOAD:
+            # This branch covers BOTH agent-side Workload criteria (single
+            # group, distributed by workload) AND agent-side CustomAssignees
+            # criteria (explicit email list — already resolved into
+            # `task_recipient.values` upstream). Both submit to the Action
+            # Center API as a "Workload" assignment; the difference is whether
+            # `values` carries one group or N emails.
+            request_spec.json = {
+                "taskAssignments": [
+                    {
+                        "taskId": task_key,
+                        "assignmentCriteria": "Workload",
+                        "assigneeNamesOrEmails": task_recipient.values
+                        or [recipient_value],
+                    }
+                ]
+            }
+        elif task_recipient.type == TaskRecipientType.ROUND_ROBIN:
+            request_spec.json = {
+                "taskAssignments": [
+                    {
+                        "taskId": task_key,
+                        "assignmentCriteria": "RoundRobin",
+                        "assigneeNamesOrEmails": task_recipient.values
+                        or [recipient_value],
+                    }
+                ]
+            }
         else:
             request_spec.json = {
                 "taskAssignments": [

--- a/packages/uipath-platform/src/uipath/platform/action_center/tasks.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/tasks.py
@@ -22,18 +22,35 @@ class TaskRecipientType(str, enum.Enum):
     GROUP_ID = "GroupId"
     EMAIL = "UserEmail"
     GROUP_NAME = "GroupName"
+    WORKLOAD = "Workload"
+    ROUND_ROBIN = "RoundRobin"
 
 
 class TaskRecipient(BaseModel):
-    """Model representing a task recipient."""
+    """Model representing a task recipient.
+
+    `value` is the single identifier (group name, group id, user id, email, …).
+    `values` is the multi-assignee form used by Workload-with-custom-emails
+    assignments; when set it takes precedence over `value` for the
+    `assigneeNamesOrEmails` payload.
+
+    Note: there is no CustomAssignees member here on purpose. The agent-side
+    CustomAssignees criteria (AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
+    type 11) is resolved to a Workload assignment with the explicit email list
+    in `values` before reaching this layer, so the Action Center
+    AssignTasks API only ever sees the existing literal types.
+    """
 
     type: Literal[
         TaskRecipientType.USER_ID,
         TaskRecipientType.GROUP_ID,
         TaskRecipientType.EMAIL,
         TaskRecipientType.GROUP_NAME,
+        TaskRecipientType.WORKLOAD,
+        TaskRecipientType.ROUND_ROBIN,
     ] = Field(..., alias="type")
     value: str = Field(..., alias="value")
+    values: Optional[List[str]] = Field(default=None, alias="values")
     display_name: Optional[str] = Field(default=None, alias="displayName")
 
 

--- a/packages/uipath-platform/tests/services/test_actions_service.py
+++ b/packages/uipath-platform/tests/services/test_actions_service.py
@@ -7,6 +7,7 @@ from pytest_httpx import HTTPXMock
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.action_center import Task
 from uipath.platform.action_center._tasks_service import TasksService
+from uipath.platform.action_center.tasks import TaskRecipient, TaskRecipientType
 from uipath.platform.common.constants import HEADER_USER_AGENT
 
 
@@ -184,6 +185,167 @@ class TestTasksService:
         assert isinstance(action, Task)
         assert action.id == 1
         assert action.title == "Test Action"
+
+
+def _mock_app_lookup_and_create(
+    httpx_mock: HTTPXMock,
+    base_url: str,
+    org: str,
+    tenant: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Common httpx mock setup for app lookup + task creation + assign."""
+    monkeypatch.setenv("UIPATH_TENANT_ID", "test-tenant-id")
+    httpx_mock.add_response(
+        url=f"{base_url}{org}/apps_/default/api/v1/default/deployed-action-apps-schemas?search=test-app&filterByDeploymentTitle=true",
+        status_code=200,
+        json={
+            "deployed": [
+                {
+                    "systemName": "test-app",
+                    "deploymentTitle": "test-app",
+                    "actionSchema": {
+                        "key": "test-key",
+                        "inputs": [],
+                        "outputs": [],
+                        "inOuts": [],
+                        "outcomes": [],
+                    },
+                    "deploymentFolder": {
+                        "fullyQualifiedName": "test-folder-path",
+                        "key": "test-folder-key",
+                    },
+                }
+            ]
+        },
+    )
+    httpx_mock.add_response(
+        url=f"{base_url}{org}{tenant}/orchestrator_/tasks/AppTasks/CreateAppTask",
+        status_code=200,
+        json={"id": 1, "title": "Test Action"},
+    )
+    httpx_mock.add_response(
+        url=f"{base_url}{org}{tenant}/orchestrator_/odata/Tasks/UiPath.Server.Configuration.OData.AssignTasks",
+        status_code=200,
+        json={},
+    )
+
+
+def _assign_request_payload(httpx_mock: HTTPXMock) -> dict[str, Any]:
+    """Return the parsed JSON body of the last AssignTasks request captured by the mock."""
+    assign_request = next(
+        req
+        for req in reversed(httpx_mock.get_requests())
+        if "AssignTasks" in str(req.url)
+    )
+    return json.loads(assign_request.content)
+
+
+class TestAssignTaskSpec:
+    """Tests for the task-assignment payload built by `_assign_task_spec`."""
+
+    def test_assign_workload_recipient_uses_workload_criteria_with_group(
+        self,
+        httpx_mock: HTTPXMock,
+        service: TasksService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_app_lookup_and_create(httpx_mock, base_url, org, tenant, monkeypatch)
+
+        service.create(
+            title="Test Action",
+            app_name="test-app",
+            data={"x": 1},
+            recipient=TaskRecipient(
+                type=TaskRecipientType.WORKLOAD,
+                value="Support Team",
+                displayName="Support Team",
+            ),
+        )
+
+        payload = _assign_request_payload(httpx_mock)
+        assert payload == {
+            "taskAssignments": [
+                {
+                    "taskId": 1,
+                    "assignmentCriteria": "Workload",
+                    "assigneeNamesOrEmails": ["Support Team"],
+                }
+            ]
+        }
+
+    def test_assign_round_robin_recipient_uses_round_robin_criteria(
+        self,
+        httpx_mock: HTTPXMock,
+        service: TasksService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _mock_app_lookup_and_create(httpx_mock, base_url, org, tenant, monkeypatch)
+
+        service.create(
+            title="Test Action",
+            app_name="test-app",
+            data={"x": 1},
+            recipient=TaskRecipient(
+                type=TaskRecipientType.ROUND_ROBIN,
+                value="Support Team",
+                displayName="Support Team",
+            ),
+        )
+
+        payload = _assign_request_payload(httpx_mock)
+        assert payload == {
+            "taskAssignments": [
+                {
+                    "taskId": 1,
+                    "assignmentCriteria": "RoundRobin",
+                    "assigneeNamesOrEmails": ["Support Team"],
+                }
+            ]
+        }
+
+    def test_assign_workload_with_multiple_emails_uses_values_list(
+        self,
+        httpx_mock: HTTPXMock,
+        service: TasksService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Custom-assignees path: Workload criteria with a list of emails."""
+        _mock_app_lookup_and_create(httpx_mock, base_url, org, tenant, monkeypatch)
+
+        service.create(
+            title="Test Action",
+            app_name="test-app",
+            data={"x": 1},
+            recipient=TaskRecipient(
+                type=TaskRecipientType.WORKLOAD,
+                value="alice@example.com",
+                values=["alice@example.com", "bob@example.com"],
+            ),
+        )
+
+        payload = _assign_request_payload(httpx_mock)
+        assert payload == {
+            "taskAssignments": [
+                {
+                    "taskId": 1,
+                    "assignmentCriteria": "Workload",
+                    "assigneeNamesOrEmails": [
+                        "alice@example.com",
+                        "bob@example.com",
+                    ],
+                }
+            ]
+        }
 
 
 def _make_deployed_app(

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.67"
+version = "0.1.68"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.11.0"
+version = "2.11.1"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.17, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.67, <0.2.0",
+  "uipath-platform>=0.1.68, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -140,6 +140,9 @@ class AgentEscalationRecipientType(str, CaseInsensitiveEnum):
     ASSET_GROUP_NAME = "AssetGroupName"
     ARGUMENT_EMAIL = "ArgumentEmail"
     ARGUMENT_GROUP_NAME = "ArgumentGroupName"
+    WORKLOAD = "Workload"
+    ROUND_ROBIN = "RoundRobin"
+    CUSTOM_ASSIGNEES = "CustomAssignees"
 
 
 class AgentEscalationChannelType(str, CaseInsensitiveEnum):
@@ -547,6 +550,9 @@ _RECIPIENT_TYPE_NORMALIZED_MAP: Mapping[int | str, AgentEscalationRecipientType]
     6: AgentEscalationRecipientType.ASSET_GROUP_NAME,
     7: AgentEscalationRecipientType.ARGUMENT_EMAIL,
     8: AgentEscalationRecipientType.ARGUMENT_GROUP_NAME,
+    9: AgentEscalationRecipientType.WORKLOAD,
+    10: AgentEscalationRecipientType.ROUND_ROBIN,
+    11: AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
 }
 
 
@@ -626,14 +632,105 @@ class ArgumentGroupNameRecipient(BaseEscalationRecipient):
     argument_path: str = Field(..., alias="argumentName")
 
 
+class WorkloadRecipient(BaseEscalationRecipient):
+    """Workload-based group assignment.
+
+    The Action Center distributes tasks to the group member with the lightest workload.
+    """
+
+    type: Literal[AgentEscalationRecipientType.WORKLOAD,] = Field(..., alias="type")
+    value: str = Field(..., alias="value")
+    display_name: str = Field(..., alias="displayName")
+
+
+class RoundRobinRecipient(BaseEscalationRecipient):
+    """Round-robin group assignment.
+
+    The Action Center cycles through group members in order on each new task.
+    """
+
+    type: Literal[AgentEscalationRecipientType.ROUND_ROBIN,] = Field(..., alias="type")
+    value: str = Field(..., alias="value")
+    display_name: str = Field(..., alias="displayName")
+
+
+class CustomAssigneesRecipient(BaseEscalationRecipient):
+    """Custom multi-user assignment.
+
+    A channel can carry multiple instances, one per assignee email. All are passed
+    to Action Center together using a Workload assignment criteria.
+    """
+
+    type: Literal[AgentEscalationRecipientType.CUSTOM_ASSIGNEES,] = Field(
+        ..., alias="type"
+    )
+    value: str = Field(..., alias="value")
+    display_name: Optional[str] = Field(default=None, alias="displayName")
+
+
+class ToolOutputRecipient(BaseEscalationRecipient):
+    """Recipient whose value is resolved at runtime from a named tool's output.
+
+    Instead of a literal value entered at design time, this binding points at a
+    field within a named tool's output. The runtime walks the agent's message
+    history, finds the most recent ToolMessage matching `tool_name`, parses its
+    content as JSON, and extracts `output_path` (a top-level field for v1).
+
+    Only the assignment-criteria recipient types that accept a runtime-computed
+    value are supported: USER_ID, GROUP_ID, WORKLOAD, ROUND_ROBIN,
+    CUSTOM_ASSIGNEES. The asset/static/argument types do not participate in
+    tool-output binding (they have their own design-time resolution rules).
+    """
+
+    type: Literal[
+        AgentEscalationRecipientType.USER_ID,
+        AgentEscalationRecipientType.GROUP_ID,
+        AgentEscalationRecipientType.WORKLOAD,
+        AgentEscalationRecipientType.ROUND_ROBIN,
+        AgentEscalationRecipientType.CUSTOM_ASSIGNEES,
+    ] = Field(..., alias="type")
+    source: Literal["toolOutput"] = Field(..., alias="source")
+    tool_name: str = Field(..., alias="toolName")
+    output_path: str = Field(..., alias="outputPath")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# AgentEscalationRecipient — Union ordering & invariants
+# ──────────────────────────────────────────────────────────────────────────────
+# Pydantic evaluates Union members left-to-right and stops at the first
+# successful match, so member order determines which class a payload resolves
+# to when multiple members share the same `type` value (e.g. WORKLOAD is valid
+# on both WorkloadRecipient and ToolOutputRecipient).
+#
+# How dispatching works:
+#   - Payload with `source: "toolOutput"` → matches ToolOutputRecipient
+#     (it is the only class declaring `source` as a required Literal field).
+#   - Payload without `source` → ToolOutputRecipient validation fails
+#     (`source` missing), so it falls through to the literal class below
+#     that owns its `type`.
+#
+# Why we don't use `Field(discriminator="type")`:
+#   The `type` values are NOT unique across the Union — both WorkloadRecipient
+#   and ToolOutputRecipient declare `type=WORKLOAD`, same for the other
+#   tool-output-capable criteria. A typed discriminator requires unique
+#   discriminator values across members, which this union violates by design.
+#
+# Critical invariants (any of these breaking causes silent mis-typing):
+#   1. ToolOutputRecipient remains the FIRST member of the Union.
+#   2. ToolOutputRecipient.source remains a required `Literal["toolOutput"]`
+#      (NOT `Optional`, NOT a default value).
+#   3. No literal class below it gains an optional `source` field.
 AgentEscalationRecipient = Annotated[
     Union[
+        ToolOutputRecipient,
         StandardRecipient,
         AssetRecipient,
         ArgumentEmailRecipient,
         ArgumentGroupNameRecipient,
+        WorkloadRecipient,
+        RoundRobinRecipient,
+        CustomAssigneesRecipient,
     ],
-    Field(discriminator="type"),
     BeforeValidator(_normalize_recipient_type),
 ]
 

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -51,12 +51,16 @@ from uipath.agent.models.agent import (
     BatchTransformFileExtension,
     BatchTransformWebSearchGrounding,
     CitationMode,
+    CustomAssigneesRecipient,
     DeepRagFileExtension,
+    RoundRobinRecipient,
     StandardRecipient,
     TaskTitleType,
     TextBuilderTaskTitle,
     TextToken,
     TextTokenType,
+    ToolOutputRecipient,
+    WorkloadRecipient,
 )
 from uipath.platform.guardrails import (
     EnumListParameterValue,
@@ -4368,3 +4372,184 @@ class TestArgumentRecipientDeserialization:
         assert tool.output_schema["type"] == "object"
         assert "imageBase64" in tool.output_schema["properties"]
         assert tool.output_schema["required"] == ["imageBase64"]
+
+
+class TestCustomAssignmentRecipientDeserialization:
+    def test_workload_recipient_by_type_int(self):
+        payload = {"type": 9, "value": "group-1", "displayName": "Support Team"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, WorkloadRecipient)
+        assert recipient.value == "group-1"
+        assert recipient.display_name == "Support Team"
+        assert recipient.type == AgentEscalationRecipientType.WORKLOAD
+
+    def test_workload_recipient_by_type_string(self):
+        payload = {
+            "type": "Workload",
+            "value": "group-1",
+            "displayName": "Support Team",
+        }
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, WorkloadRecipient)
+        assert recipient.value == "group-1"
+        assert recipient.display_name == "Support Team"
+
+    def test_round_robin_recipient_by_type_int(self):
+        payload = {"type": 10, "value": "group-1", "displayName": "Support Team"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, RoundRobinRecipient)
+        assert recipient.value == "group-1"
+        assert recipient.display_name == "Support Team"
+        assert recipient.type == AgentEscalationRecipientType.ROUND_ROBIN
+
+    def test_round_robin_recipient_by_type_string(self):
+        payload = {
+            "type": "RoundRobin",
+            "value": "group-1",
+            "displayName": "Support Team",
+        }
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, RoundRobinRecipient)
+
+    def test_custom_assignees_recipient_by_type_int(self):
+        payload = {
+            "type": 11,
+            "value": "alice@example.com",
+            "displayName": "Alice",
+        }
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, CustomAssigneesRecipient)
+        assert recipient.value == "alice@example.com"
+        assert recipient.display_name == "Alice"
+        assert recipient.type == AgentEscalationRecipientType.CUSTOM_ASSIGNEES
+
+    def test_custom_assignees_recipient_by_type_string(self):
+        payload = {"type": "CustomAssignees", "value": "alice@example.com"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, CustomAssigneesRecipient)
+        assert recipient.value == "alice@example.com"
+        assert recipient.display_name is None
+
+    def test_custom_assignees_recipient_accepts_empty_value_sentinel(self):
+        payload = {"type": 11, "value": ""}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, CustomAssigneesRecipient)
+        assert recipient.value == ""
+
+    def test_workload_recipient_missing_value_raises(self):
+        payload = {"type": 9, "displayName": "Support Team"}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_workload_recipient_missing_display_name_raises(self):
+        payload = {"type": 9, "value": "group-1"}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_round_robin_recipient_missing_value_raises(self):
+        payload = {"type": 10, "displayName": "Support Team"}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_custom_assignees_recipient_missing_value_raises(self):
+        payload = {"type": 11}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+
+class TestToolOutputRecipientDeserialization:
+    @pytest.mark.parametrize(
+        "recipient_type",
+        [1, 2, 9, 10, 11],
+    )
+    def test_tool_output_recipient_by_type_int_for_supported_types(
+        self, recipient_type
+    ):
+        payload = {
+            "type": recipient_type,
+            "source": "toolOutput",
+            "toolName": "API workflow A",
+            "outputPath": "includeEmails",
+        }
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, ToolOutputRecipient)
+        assert recipient.tool_name == "API workflow A"
+        assert recipient.output_path == "includeEmails"
+        assert recipient.source == "toolOutput"
+
+    def test_tool_output_recipient_for_custom_assignees_by_type_string(self):
+        payload = {
+            "type": "CustomAssignees",
+            "source": "toolOutput",
+            "toolName": "API workflow A",
+            "outputPath": "includeEmails",
+        }
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, ToolOutputRecipient)
+        assert recipient.type == AgentEscalationRecipientType.CUSTOM_ASSIGNEES
+
+    def test_tool_output_recipient_missing_tool_name_raises(self):
+        payload = {"type": 11, "source": "toolOutput", "outputPath": "emails"}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_tool_output_recipient_missing_output_path_raises(self):
+        payload = {"type": 11, "source": "toolOutput", "toolName": "A"}
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_tool_output_recipient_unknown_source_raises(self):
+        payload = {
+            "type": 11,
+            "source": "magicBox",
+            "toolName": "A",
+            "outputPath": "emails",
+        }
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    @pytest.mark.parametrize(
+        "recipient_type",
+        [3, 4, 5, 6, 7, 8],
+    )
+    def test_tool_output_recipient_not_allowed_for_static_asset_argument_types(
+        self, recipient_type
+    ):
+        # Static/asset/argument types (3, 4, 5, 6, 7, 8) are not supported
+        # for tool-output binding because they have their own design-time
+        # resolution rules.
+        payload = {
+            "type": recipient_type,
+            "source": "toolOutput",
+            "toolName": "A",
+            "outputPath": "emails",
+        }
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationRecipient).validate_python(payload)
+
+    def test_literal_recipient_without_source_still_parses_to_literal_class(self):
+        # Backward compat: a payload without `source` still matches the literal class.
+        payload = {"type": 11, "value": "alice@example.com", "displayName": "Alice"}
+        recipient: AgentEscalationRecipient = TypeAdapter(
+            AgentEscalationRecipient
+        ).validate_python(payload)
+        assert isinstance(recipient, CustomAssigneesRecipient)
+        assert not isinstance(recipient, ToolOutputRecipient)

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.0"
+version = "2.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.67"
+version = "0.1.68"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Adds the agent + platform models needed for the V2 HITL escalation recipient flow consumed by the langchain runtime.

uipath/agent/models:
- New literal recipient classes for Workload (9), RoundRobin (10), and CustomAssignees (11) matching the storage schema v50 surface.
- New ToolOutputRecipient class accepting types USER_ID/GROUP_ID/WORKLOAD/ ROUND_ROBIN/CUSTOM_ASSIGNEES with source="toolOutput", toolName, outputPath fields for runtime-resolved assignees.
- ToolOutputRecipient listed first in the recipient Union so payloads carrying `source` match before falling through to literal variants.

uipath/platform/action_center:
- TaskRecipientType gains Workload and RoundRobin members.
- TaskRecipient gains an optional `values` list field for the multi-assignee assigneeNamesOrEmails payload.
- _tasks_service updated to forward the new fields when present.

Backwards-compatible: existing payloads without source/values parse and serialize identically.