### PR TITLE
feat(agent): add Flow tool type for Maestro Flow processes

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.68"
+version = "2.10.69"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -112,6 +112,7 @@ class AgentToolType(str, CaseInsensitiveEnum):
     PROCESS = "Process"
     API = "Api"
     PROCESS_ORCHESTRATION = "ProcessOrchestration"
+    FLOW = "Flow"
     INTEGRATION = "Integration"
     INTERNAL = "Internal"
     IXP = "Ixp"
@@ -779,6 +780,7 @@ class AgentProcessToolResourceConfig(BaseAgentToolResourceConfig):
         AgentToolType.PROCESS,
         AgentToolType.API,
         AgentToolType.PROCESS_ORCHESTRATION,
+        AgentToolType.FLOW,
     ]
     output_schema: Dict[str, Any] = Field(EMPTY_SCHEMA, alias="outputSchema")
     properties: AgentProcessToolProperties
@@ -1322,6 +1324,7 @@ class AgentDefinition(BaseModel):
             "process": "Process",
             "api": "Api",
             "processorchestration": "ProcessOrchestration",
+            "flow": "Flow",
             "integration": "Integration",
             "internal": "Internal",
             "ixp": "Ixp",

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -3558,6 +3558,75 @@ class TestAgentBuilderConfigResources:
         assert isinstance(tool_resource, AgentProcessToolResourceConfig)
         assert tool_resource.output_schema == {"type": "object", "properties": {}}
 
+    def test_flow_tool_type_enum_value(self):
+        """AgentToolType.FLOW exists with the wire value 'Flow' and is case-insensitive."""
+        assert AgentToolType.FLOW.value == "Flow"
+        assert AgentToolType("flow") is AgentToolType.FLOW
+        assert AgentToolType("FLOW") is AgentToolType.FLOW
+
+    def test_flow_tool_resource_deserialization(self):
+        """A resource with type='Flow' is parsed as AgentProcessToolResourceConfig."""
+        resources = [
+            {
+                "$resourceType": "tool",
+                "type": "Flow",
+                "id": "flow-tool-1",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                },
+                "outputSchema": {"type": "object", "properties": {}},
+                "arguments": {},
+                "settings": {"timeout": 0, "maxAttempts": 0, "retryDelay": 0},
+                "properties": {
+                    "processName": "MyFlow",
+                    "folderPath": "/Shared/Flows",
+                },
+                "name": "Flow Tool",
+                "description": "Test Flow tool",
+            }
+        ]
+
+        json_data = self._agent_dict_with_resources(resources)
+        config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
+            json_data
+        )
+
+        tool_resource = config.resources[0]
+        assert isinstance(tool_resource, AgentProcessToolResourceConfig)
+        assert tool_resource.type == AgentToolType.FLOW
+        assert tool_resource.properties.process_name == "MyFlow"
+        assert tool_resource.properties.folder_path == "/Shared/Flows"
+
+    def test_flow_tool_resource_case_insensitive(self):
+        """A resource with lowercase type='flow' also deserializes via CaseInsensitiveEnum."""
+        resources = [
+            {
+                "$resourceType": "tool",
+                "type": "flow",
+                "id": "flow-tool-2",
+                "inputSchema": {"type": "object", "properties": {}},
+                "outputSchema": {"type": "object", "properties": {}},
+                "arguments": {},
+                "settings": {"timeout": 0, "maxAttempts": 0, "retryDelay": 0},
+                "properties": {
+                    "processName": "MyFlow",
+                    "folderPath": "/Shared/Flows",
+                },
+                "name": "Flow Tool",
+                "description": "Test Flow tool",
+            }
+        ]
+
+        json_data = self._agent_dict_with_resources(resources)
+        config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
+            json_data
+        )
+
+        tool_resource = config.resources[0]
+        assert isinstance(tool_resource, AgentProcessToolResourceConfig)
+        assert tool_resource.type == AgentToolType.FLOW
+
     def test_escalation_missing_escalation_type_defaults_to_zero(self):
         """Test that missing escalationType defaults to 0."""
         resources = [

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-05-17T17:25:34.9197064Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.68"
+version = "2.10.69"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Extend AgentToolType with a FLOW value so that agent.json resources declared as "type": "Flow" deserialize into AgentProcessToolResourceConfig and invoke through the existing ProcessesService.invoke_async() path (Orchestrator resolves the ProcessType server-side from the release). Also update the parent normalizer's TOOL_MAP so the new value isn't silently downgraded to Unknown.