### PR TITLE
fix(tracing): fall back to referenceId attribute when agentId is missing

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.54"
+version = "0.1.55"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -297,7 +297,11 @@ class _SpanUtils:
         # Top-level fields for internal tracing schema
         execution_type = attributes_dict.get("executionType")
         agent_version = attributes_dict.get("agentVersion")
-        reference_id = env.get("UIPATH_AGENT_ID") or attributes_dict.get("agentId")
+        reference_id = (
+            env.get("UIPATH_AGENT_ID")
+            or attributes_dict.get("agentId")
+            or attributes_dict.get("referenceId")
+        )
         verbosity_level = attributes_dict.get("verbosityLevel")
 
         # Source: override via uipath.source attribute, else DEFAULT_SOURCE

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -89,6 +89,83 @@ class TestOTelToUiPathSpan:
         assert "VerbosityLevel" not in span_dict
 
 
+class TestReferenceIdResolution:
+    """`reference_id` resolution chain.
+
+    Priority: `UIPATH_AGENT_ID` env var > `agentId` attribute > `referenceId`
+    attribute. Falsy values (missing / empty string) at each step fall through
+    to the next source. The `referenceId` fallback exists for backwards
+    compatibility with older producers that only emit that attribute.
+    """
+
+    @pytest.mark.parametrize(
+        ("env_value", "attributes", "expected"),
+        [
+            pytest.param(
+                "env-agent",
+                {"agentId": "attr-agent", "referenceId": "attr-ref"},
+                "env-agent",
+                id="env-var-wins",
+            ),
+            pytest.param(
+                None,
+                {"agentId": "attr-agent", "referenceId": "attr-ref"},
+                "attr-agent",
+                id="agent-id-attr-when-env-unset",
+            ),
+            pytest.param(
+                None,
+                {"referenceId": "attr-ref"},
+                "attr-ref",
+                id="reference-id-fallback-when-agent-id-missing",
+            ),
+            pytest.param(
+                None,
+                {"agentId": "", "referenceId": "attr-ref"},
+                "attr-ref",
+                id="reference-id-fallback-when-agent-id-empty",
+            ),
+            pytest.param(
+                None,
+                {},
+                None,
+                id="none-when-all-sources-missing",
+            ),
+        ],
+    )
+    def test_reference_id_chain(
+        self,
+        env_value: str | None,
+        attributes: dict[str, object],
+        expected: str | None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if env_value is None:
+            monkeypatch.delenv("UIPATH_AGENT_ID", raising=False)
+        else:
+            monkeypatch.setenv("UIPATH_AGENT_ID", env_value)
+
+        mock_span = Mock(spec=OTelSpan)
+        mock_context = SpanContext(
+            trace_id=0x123456789ABCDEF0123456789ABCDEF0,
+            span_id=0x0123456789ABCDEF,
+            is_remote=False,
+        )
+        mock_span.get_span_context.return_value = mock_context
+        mock_span.name = "test-span"
+        mock_span.parent = None
+        mock_span.status.status_code = StatusCode.OK
+        mock_span.attributes = attributes
+        mock_span.events = []
+        mock_span.links = []
+        now_ns = int(datetime.now().timestamp() * 1e9)
+        mock_span.start_time = now_ns
+        mock_span.end_time = now_ns + 1_000_000
+
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        assert uipath_span.reference_id == expected
+
+
 class TestNormalizeIds:
     """Tests for OTEL ID normalization functions."""
 

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.54"
+version = "0.1.55"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.54"
+version = "0.1.55"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- `reference_id` now falls back to the older `referenceId` span attribute when `UIPATH_AGENT_ID` env var and the `agentId` span attribute are both absent or empty.
- Preserves the priority introduced in #1643 (env var → `agentId` attribute) and adds a final legacy fallback for backwards compatibility with older trace producers.
- Bumps `uipath-platform` to `0.1.55`.

## Test plan

- [ ] Local agent run with `UIPATH_AGENT_ID` set → `ReferenceId` matches the env var.
- [ ] Deployed run without env var but with `agentId` span attribute → `ReferenceId` matches `agentId`.
- [ ] Producer that only emits the legacy `referenceId` attribute → `ReferenceId` is populated from it instead of being null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)