### PR TITLE
docs(guardrails): add value tables to enum docstrings, remove MkDocs hook

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.55"
+version = "0.1.56"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_enums.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/_enums.py
@@ -19,8 +19,27 @@ class GuardrailExecutionStage(str, Enum):
 class PIIDetectionEntityType(str, Enum):
     """PII detection entity types supported by UiPath guardrails.
 
-    These entities match the available options from the UiPath guardrails service
-    backend. The enum values correspond to the exact strings expected by the API.
+    | Value |
+    |---|
+    | `PERSON` |
+    | `ADDRESS` |
+    | `DATE` |
+    | `PHONE_NUMBER` |
+    | `EUGPS_COORDINATES` |
+    | `EMAIL` |
+    | `CREDIT_CARD_NUMBER` |
+    | `INTERNATIONAL_BANKING_ACCOUNT_NUMBER` |
+    | `SWIFT_CODE` |
+    | `ABA_ROUTING_NUMBER` |
+    | `US_DRIVERS_LICENSE_NUMBER` |
+    | `UK_DRIVERS_LICENSE_NUMBER` |
+    | `US_INDIVIDUAL_TAXPAYER_IDENTIFICATION` |
+    | `UK_UNIQUE_TAXPAYER_NUMBER` |
+    | `US_BANK_ACCOUNT_NUMBER` |
+    | `US_SOCIAL_SECURITY_NUMBER` |
+    | `USUK_PASSPORT_NUMBER` |
+    | `URL` |
+    | `IP_ADDRESS` |
     """
 
     PERSON = "Person"
@@ -47,7 +66,12 @@ class PIIDetectionEntityType(str, Enum):
 class HarmfulContentEntityType(str, Enum):
     """Harmful content entity types supported by UiPath guardrails.
 
-    These entities correspond to the Azure Content Safety categories.
+    | Value |
+    |---|
+    | `HATE` |
+    | `SELF_HARM` |
+    | `SEXUAL` |
+    | `VIOLENCE` |
     """
 
     HATE = "Hate"
@@ -57,7 +81,13 @@ class HarmfulContentEntityType(str, Enum):
 
 
 class IntellectualPropertyEntityType(str, Enum):
-    """Intellectual property entity types supported by UiPath guardrails."""
+    """Intellectual property entity types supported by UiPath guardrails.
+
+    | Value |
+    |---|
+    | `TEXT` |
+    | `CODE` |
+    """
 
     TEXT = "Text"
     CODE = "Code"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-05-17T16:21:45.1868663Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.55"
+version = "0.1.56"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/mkdocs.yml
+++ b/packages/uipath/mkdocs.yml
@@ -6,9 +6,6 @@ repo_url: https://github.com/UiPath/uipath-python
 
 copyright: Copyright &copy; 2025 UiPath
 
-hooks:
-  - docs/langchain/hooks/enum_lists.py
-
 extra_css:
   - stylesheets/extra.css
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.55"
+version = "0.1.56"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What changed?

**`packages/uipath-platform/src/uipath/platform/guardrails/decorators/_enums.py`**
- Added markdown value tables to the docstrings of `PIIDetectionEntityType`, `HarmfulContentEntityType`, and `IntellectualPropertyEntityType`
- Values are now documented once, next to the enum definition, and rendered automatically by mkdocstrings wherever the class is referenced

**`packages/uipath/mkdocs.yml`**
- Removed the `hooks:` entry (`docs/langchain/hooks/enum_lists.py`) — the MkDocs build hook approach is not supported by the docs site

## How has this been tested?

Rendered locally via `mkdocs serve` from `packages/uipath/`. The three entity type sections in the LangChain guardrails page display correct value tables derived from the enum docstrings.

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations required
- [ ] API removals or changes
- [ ] Other