### PR TITLE
feat(tasks): add QuickForm task creation SDK + agent.json model

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.59"
+version = "0.1.60"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
@@ -676,25 +676,56 @@ class TasksService(FolderContext, BaseService):
         task_schema_key: str,
         schema: Dict[str, Any],
         data: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        *,
+        folder_path: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        assignee: Optional[str] = None,
+        recipient: Optional[TaskRecipient] = None,
+        priority: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+        is_actionable_message_enabled: Optional[bool] = None,
+        actionable_message_metadata: Optional[Dict[str, Any]] = None,
+        creator_job_key: Optional[str] = None,
+        source_name: str = "Agent",
     ) -> Task:
         """Create a new QuickForm task synchronously.
 
-        Thin ``asyncio.run`` wrapper over :meth:`create_quickform_async`. All
-        keyword arguments (``folder_path``, ``folder_key``, ``assignee``,
-        ``recipient``, ``priority``, ``labels``, ``is_actionable_message_enabled``,
-        ``actionable_message_metadata``, ``creator_job_key``, ``source_name``)
-        are forwarded as-is. See that method for parameter docs.
+        See :meth:`create_quickform_async` for parameter docs.
         """
-        return asyncio.run(
-            self.create_quickform_async(
-                title=title,
-                task_schema_key=task_schema_key,
-                schema=schema,
-                data=data,
-                **kwargs,
-            )
+        spec = _create_quickform_spec(
+            title=title,
+            data=data,
+            task_schema_key=task_schema_key,
+            schema=schema,
+            creator_job_key=creator_job_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+            priority=priority,
+            labels=labels,
+            is_actionable_message_enabled=is_actionable_message_enabled,
+            actionable_message_metadata=actionable_message_metadata,
+            source_name=source_name,
         )
+
+        response = self.request(
+            spec.method,
+            spec.endpoint,
+            json=spec.json,
+            content=spec.content,
+            headers=spec.headers,
+        )
+        json_response = response.json()
+        if assignee or recipient:
+            assign_spec = asyncio.run(
+                _assign_task_spec(self, json_response["id"], assignee, recipient)
+            )
+            self.request(
+                assign_spec.method,
+                assign_spec.endpoint,
+                json=assign_spec.json,
+                content=assign_spec.content,
+            )
+        return Task.model_validate(json_response)
 
     @resource_override(
         resource_type="app",

--- a/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
@@ -212,7 +212,6 @@ def _normalize_priority(priority: str | None) -> str | None:
     return normalized
 
 
-# TaskType.QuickFormTask value, matching the Orchestrator enum (UiPath.Orchestrator.DataContracts.TaskType).
 _TASK_TYPE_QUICKFORM = 6
 
 

--- a/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
@@ -118,10 +118,34 @@ def _create_spec(
         ),
     }
 
+    _apply_priority_labels_and_actionable_toggle(
+        json_payload, priority, labels, is_actionable_message_enabled
+    )
+    _apply_task_source(json_payload, source_name)
+
+    return RequestSpec(
+        method="POST",
+        endpoint=Endpoint("/orchestrator_/tasks/AppTasks/CreateAppTask"),
+        json=json_payload,
+        headers=header_folder(app_folder_key, app_folder_path),
+    )
+
+
+def _apply_priority_labels_and_actionable_toggle(
+    payload: Dict[str, Any],
+    priority: Optional[str],
+    labels: Optional[List[str]],
+    is_actionable_message_enabled: Optional[bool],
+) -> None:
+    """Apply priority / tags / isActionableMessageEnabled to ``payload`` in-place.
+
+    Shared between AppTask and QuickForm spec builders — they handle these three
+    optional fields identically.
+    """
     if priority and (normalized_priority := _normalize_priority(priority)):
-        json_payload["priority"] = normalized_priority
+        payload["priority"] = normalized_priority
     if labels is not None:
-        json_payload["tags"] = [
+        payload["tags"] = [
             {
                 "name": label,
                 "displayName": label,
@@ -131,37 +155,29 @@ def _create_spec(
             for label in labels
         ]
     if is_actionable_message_enabled is not None:
-        json_payload["isActionableMessageEnabled"] = is_actionable_message_enabled
+        payload["isActionableMessageEnabled"] = is_actionable_message_enabled
 
+
+def _apply_task_source(payload: Dict[str, Any], source_name: str) -> None:
+    """Populate ``payload["taskSource"]`` when UiPathConfig has project_id + trace_id.
+
+    Shared between AppTask and QuickForm spec builders — the taskSource block is
+    identical for both task types.
+    """
     project_id = UiPathConfig.project_id
     trace_id = UiPathConfig.trace_id
-
-    if project_id and trace_id:
-        folder_key = UiPathConfig.folder_key
-        job_key = UiPathConfig.job_key
-        process_key = UiPathConfig.process_uuid
-
-        task_source_metadata: Dict[str, Any] = {
+    if not (project_id and trace_id):
+        return
+    payload["taskSource"] = {
+        "sourceName": source_name,
+        "sourceId": project_id,
+        "taskSourceMetadata": {
             "InstanceId": trace_id,
-            "FolderKey": folder_key,
-            "JobKey": job_key,
-            "ProcessKey": process_key,
-        }
-
-        task_source = {
-            "sourceName": source_name,
-            "sourceId": project_id,
-            "taskSourceMetadata": task_source_metadata,
-        }
-
-        json_payload["taskSource"] = task_source
-
-    return RequestSpec(
-        method="POST",
-        endpoint=Endpoint("/orchestrator_/tasks/AppTasks/CreateAppTask"),
-        json=json_payload,
-        headers=header_folder(app_folder_key, app_folder_path),
-    )
+            "FolderKey": UiPathConfig.folder_key,
+            "JobKey": UiPathConfig.job_key,
+            "ProcessKey": UiPathConfig.process_uuid,
+        },
+    }
 
 
 def _normalize_priority(priority: str | None) -> str | None:
@@ -194,6 +210,63 @@ def _normalize_priority(priority: str | None) -> str | None:
         )
 
     return normalized
+
+
+# TaskType.QuickFormTask value, matching the Orchestrator enum (UiPath.Orchestrator.DataContracts.TaskType).
+_TASK_TYPE_QUICKFORM = 6
+
+
+def _create_quickform_spec(
+    data: Optional[Dict[str, Any]],
+    title: str,
+    task_schema_key: str,
+    schema: Dict[str, Any],
+    creator_job_key: Optional[str] = None,
+    folder_key: Optional[str] = None,
+    folder_path: Optional[str] = None,
+    priority: Optional[str] = None,
+    labels: Optional[List[str]] = None,
+    is_actionable_message_enabled: Optional[bool] = None,
+    actionable_message_metadata: Optional[Dict[str, Any]] = None,
+    source_name: str = "Agent",
+) -> RequestSpec:
+    """Build the RequestSpec for Orchestrator's GenericTasks/CreateTask endpoint.
+
+    Sets TaskType=QuickFormTask. Mirrors _create_spec but skips the AppTask-specific
+    shape (no appId, no action-schema-derived fieldSet/actionSet) and instead sends
+    taskSchemaKey + inline schema together.
+
+    Both taskSchemaKey AND schema are sent on every call: the Agents runtime has no
+    Action Center package.uploaded subscriber populating the TaskSchemas table, so
+    Orchestrator upserts the schema (keyed by taskSchemaKey) and then creates the task
+    in the same call.
+
+    Wire contract: UiPath/Orchestrator/src/Core/Application/Dto/Tasks/TaskCreateRequest.cs.
+    """
+    json_payload: Dict[str, Any] = {
+        "type": _TASK_TYPE_QUICKFORM,
+        "taskSchemaKey": task_schema_key,
+        "schema": schema,
+        "title": title,
+        "data": data if data is not None else {},
+    }
+
+    if creator_job_key is not None:
+        json_payload["creatorJobKey"] = creator_job_key
+
+    _apply_priority_labels_and_actionable_toggle(
+        json_payload, priority, labels, is_actionable_message_enabled
+    )
+    if actionable_message_metadata is not None:
+        json_payload["actionableMessageMetaData"] = actionable_message_metadata
+    _apply_task_source(json_payload, source_name)
+
+    return RequestSpec(
+        method="POST",
+        endpoint=Endpoint("/orchestrator_/tasks/GenericTasks/CreateTask"),
+        json=json_payload,
+        headers=header_folder(folder_key, folder_path),
+    )
 
 
 def _retrieve_action_spec(
@@ -505,6 +578,123 @@ class TasksService(FolderContext, BaseService):
                 spec.method, spec.endpoint, json=spec.json, content=spec.content
             )
         return Task.model_validate(json_response)
+
+    @traced(name="tasks_create_quickform", run_type="uipath")
+    async def create_quickform_async(
+        self,
+        title: str,
+        task_schema_key: str,
+        schema: Dict[str, Any],
+        data: Optional[Dict[str, Any]] = None,
+        *,
+        folder_path: Optional[str] = None,
+        folder_key: Optional[str] = None,
+        assignee: Optional[str] = None,
+        recipient: Optional[TaskRecipient] = None,
+        priority: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+        is_actionable_message_enabled: Optional[bool] = None,
+        actionable_message_metadata: Optional[Dict[str, Any]] = None,
+        creator_job_key: Optional[str] = None,
+        source_name: str = "Agent",
+    ) -> Task:
+        """Creates a new QuickForm task asynchronously.
+
+        QuickForm tasks are schema-first HITL tasks rendered by FormLib in Action
+        Center. Both task_schema_key AND schema are required: the Agents runtime
+        does not pre-populate TaskSchemas via a package.uploaded subscriber, so
+        Orchestrator upserts the schema (keyed by task_schema_key) and creates
+        the task in the same call.
+
+        Args:
+            title: The title of the task.
+            task_schema_key: UUID key of the schema. Used as the key under which
+                Orchestrator stores/looks up the schema in TaskSchemas.
+            schema: The HITL schema body to register/upsert. Sent inline on every
+                call.
+            data: Optional dictionary containing input data for the task.
+            folder_path: Optional folder path for the task. Required by the
+                Orchestrator controller (RequireOrganizationUnit) unless
+                folder_key is provided.
+            folder_key: Optional folder key, alternative to folder_path.
+            assignee: Optional username or email to assign the task to.
+            recipient: Optional structured recipient (user id / group id /
+                email). Resolved via identity service before assignment.
+            priority: Optional priority. Low / Medium / High / Critical.
+            labels: Optional list of labels for the task.
+            is_actionable_message_enabled: Whether actionable notifications are
+                enabled for this task.
+            actionable_message_metadata: Optional metadata override. For
+                QuickForm, when null, Orchestrator derives it from the
+                referenced TaskSchema.
+            creator_job_key: Optional. Identifies the job that triggered the
+                inline schema creation/upsert.
+            source_name: Source name on TaskSource. Defaults to 'Agent'.
+
+        Returns:
+            Task: The created task object.
+        """
+        spec = _create_quickform_spec(
+            title=title,
+            data=data,
+            task_schema_key=task_schema_key,
+            schema=schema,
+            creator_job_key=creator_job_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+            priority=priority,
+            labels=labels,
+            is_actionable_message_enabled=is_actionable_message_enabled,
+            actionable_message_metadata=actionable_message_metadata,
+            source_name=source_name,
+        )
+
+        response = await self.request_async(
+            spec.method,
+            spec.endpoint,
+            json=spec.json,
+            content=spec.content,
+            headers=spec.headers,
+        )
+        json_response = response.json()
+        if assignee or recipient:
+            assign_spec = await _assign_task_spec(
+                self, json_response["id"], assignee, recipient
+            )
+            await self.request_async(
+                assign_spec.method,
+                assign_spec.endpoint,
+                json=assign_spec.json,
+                content=assign_spec.content,
+            )
+        return Task.model_validate(json_response)
+
+    @traced(name="tasks_create_quickform", run_type="uipath")
+    def create_quickform(
+        self,
+        title: str,
+        task_schema_key: str,
+        schema: Dict[str, Any],
+        data: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Task:
+        """Create a new QuickForm task synchronously.
+
+        Thin ``asyncio.run`` wrapper over :meth:`create_quickform_async`. All
+        keyword arguments (``folder_path``, ``folder_key``, ``assignee``,
+        ``recipient``, ``priority``, ``labels``, ``is_actionable_message_enabled``,
+        ``actionable_message_metadata``, ``creator_job_key``, ``source_name``)
+        are forwarded as-is. See that method for parameter docs.
+        """
+        return asyncio.run(
+            self.create_quickform_async(
+                title=title,
+                task_schema_key=task_schema_key,
+                schema=schema,
+                data=data,
+                **kwargs,
+            )
+        )
 
     @resource_override(
         resource_type="app",

--- a/packages/uipath-platform/tests/services/test_actions_service.py
+++ b/packages/uipath-platform/tests/services/test_actions_service.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -593,11 +594,9 @@ def qf_assign_url(base_url: str, org: str, tenant: str) -> str:
 
 
 def _posted_body(httpx_mock: HTTPXMock, url: str) -> dict[str, Any]:
-    import json as _json
-
     for req in httpx_mock.get_requests():
         if str(req.url) == url:
-            return _json.loads(req.content)
+            return json.loads(req.content)
     raise AssertionError(f"no request was POSTed to {url}")
 
 

--- a/packages/uipath-platform/tests/services/test_actions_service.py
+++ b/packages/uipath-platform/tests/services/test_actions_service.py
@@ -555,3 +555,149 @@ class TestCreateFiltersByFolder:
                 app_name="my-app",
                 app_folder_path=None,
             )
+
+
+# ---------------------------------------------------------------------------
+# QuickForm task tests
+# ---------------------------------------------------------------------------
+
+_QF_SCHEMA: dict[str, Any] = {
+    "id": "7ebef452-fee9-45df-8fc2-01f1d0248540",
+    "fields": [
+        {"id": "f1", "type": "text", "label": "F1", "direction": "input"},
+        {"id": "f2", "type": "text", "label": "F2", "direction": "output"},
+    ],
+    "outcomes": [
+        {"id": "approve", "name": "Approve", "type": "string", "isPrimary": True},
+    ],
+}
+_QF_DEFAULTS = {
+    "title": "QF task",
+    "task_schema_key": _QF_SCHEMA["id"],
+    "schema": _QF_SCHEMA,
+}
+_QF_CREATE_RESPONSE = {"id": 42, "title": _QF_DEFAULTS["title"]}
+
+
+@pytest.fixture
+def qf_create_url(base_url: str, org: str, tenant: str) -> str:
+    return f"{base_url}{org}{tenant}/orchestrator_/tasks/GenericTasks/CreateTask"
+
+
+@pytest.fixture
+def qf_assign_url(base_url: str, org: str, tenant: str) -> str:
+    return (
+        f"{base_url}{org}{tenant}"
+        "/orchestrator_/odata/Tasks/UiPath.Server.Configuration.OData.AssignTasks"
+    )
+
+
+def _posted_body(httpx_mock: HTTPXMock, url: str) -> dict[str, Any]:
+    import json as _json
+
+    for req in httpx_mock.get_requests():
+        if str(req.url) == url:
+            return _json.loads(req.content)
+    raise AssertionError(f"no request was POSTed to {url}")
+
+
+@pytest.fixture
+def qf_runner(httpx_mock: HTTPXMock, service: TasksService, qf_create_url: str) -> Any:
+    """Factory: stub the QF endpoint, call create_quickform with overrides,
+    return (task, posted_body). One call per test eliminates setup duplication.
+    """
+    httpx_mock.add_response(
+        url=qf_create_url, status_code=200, json=_QF_CREATE_RESPONSE
+    )
+
+    def _run(**overrides: Any) -> tuple[Task, dict[str, Any]]:
+        task = service.create_quickform(**{**_QF_DEFAULTS, **overrides})
+        return task, _posted_body(httpx_mock, qf_create_url)
+
+    return _run
+
+
+@pytest.fixture
+def qf_runner_async(
+    httpx_mock: HTTPXMock, service: TasksService, qf_create_url: str
+) -> Any:
+    """Async variant of qf_runner."""
+    httpx_mock.add_response(
+        url=qf_create_url, status_code=200, json=_QF_CREATE_RESPONSE
+    )
+
+    async def _run(**overrides: Any) -> tuple[Task, dict[str, Any]]:
+        task = await service.create_quickform_async(**{**_QF_DEFAULTS, **overrides})
+        return task, _posted_body(httpx_mock, qf_create_url)
+
+    return _run
+
+
+def test_create_quickform_baseline_payload(qf_runner: Any) -> None:
+    task, body = qf_runner()
+    assert body == {
+        "type": 6,
+        "taskSchemaKey": _QF_DEFAULTS["task_schema_key"],
+        "schema": _QF_SCHEMA,
+        "title": _QF_DEFAULTS["title"],
+        "data": {},
+    }
+    assert isinstance(task, Task)
+    assert task.id == 42
+
+
+def test_create_quickform_data_passthrough(qf_runner: Any) -> None:
+    _, body = qf_runner(data={"x": 1})
+    assert body["data"] == {"x": 1}
+
+
+def test_create_quickform_includes_optional_fields_when_set(qf_runner: Any) -> None:
+    _, body = qf_runner(
+        priority="High",
+        labels=["a", "b"],
+        is_actionable_message_enabled=True,
+        actionable_message_metadata={"fieldSet": {}, "actionSet": {}},
+        creator_job_key="3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    )
+    assert body["priority"] == "High"
+    assert {tag["name"] for tag in body["tags"]} == {"a", "b"}
+    assert body["isActionableMessageEnabled"] is True
+    assert body["actionableMessageMetaData"] == {"fieldSet": {}, "actionSet": {}}
+    assert body["creatorJobKey"] == "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+
+def test_create_quickform_omits_optional_fields_when_unset(qf_runner: Any) -> None:
+    _, body = qf_runner()
+    for omitted in (
+        "creatorJobKey",
+        "priority",
+        "tags",
+        "isActionableMessageEnabled",
+        "actionableMessageMetaData",
+    ):
+        assert omitted not in body
+
+
+async def test_create_quickform_async_baseline_payload(qf_runner_async: Any) -> None:
+    task, body = await qf_runner_async()
+    assert body["type"] == 6
+    assert body["taskSchemaKey"] == _QF_DEFAULTS["task_schema_key"]
+    assert task.id == 42
+
+
+def test_create_quickform_with_assignee_triggers_assign_call(
+    httpx_mock: HTTPXMock, qf_runner: Any, qf_assign_url: str
+) -> None:
+    httpx_mock.add_response(url=qf_assign_url, status_code=200, json={})
+    qf_runner(assignee="user@example.com")
+    body = _posted_body(httpx_mock, qf_assign_url)
+    assert body["taskAssignments"][0]["UserNameOrEmail"] == "user@example.com"
+
+
+async def test_create_quickform_async_with_assignee_triggers_assign_call(
+    httpx_mock: HTTPXMock, qf_runner_async: Any, qf_assign_url: str
+) -> None:
+    httpx_mock.add_response(url=qf_assign_url, status_code=200, json={})
+    await qf_runner_async(assignee="user@example.com")
+    body = _posted_body(httpx_mock, qf_assign_url)
+    assert body["taskAssignments"][0]["UserNameOrEmail"] == "user@example.com"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.59"
+version = "0.1.60"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.10.75"
+version = "2.10.76"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.17, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.59, <0.2.0",
+  "uipath-platform>=0.1.60, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -726,12 +726,7 @@ class AgentEscalationChannel(BaseCfg):
     )
     priority: Optional[str] = None
     labels: List[str] = Field(default_factory=list)
-    # QuickForm fields — set only on channels backed by a .hitl.json schema.
-    # schema_id is the UUID key under which the schema is registered in Orchestrator's
-    # TaskSchemas table. schema_body is the inline schema body, sent on every task creation
-    # so Orchestrator can upsert it (the Agents runtime has no separate registration step).
-    # The Python attribute is schema_body (not schema) to avoid shadowing
-    # pydantic.BaseModel.schema(); the JSON alias is "schema" to match the wire format.
+    # schema_body avoids shadowing pydantic.BaseModel.schema(); JSON alias stays "schema".
     schema_id: Optional[str] = Field(None, alias="schemaId")
     schema_body: Optional[Dict[str, Any]] = Field(None, alias="schema")
 

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -726,6 +726,14 @@ class AgentEscalationChannel(BaseCfg):
     )
     priority: Optional[str] = None
     labels: List[str] = Field(default_factory=list)
+    # QuickForm fields — set only on channels backed by a .hitl.json schema.
+    # schema_id is the UUID key under which the schema is registered in Orchestrator's
+    # TaskSchemas table. schema_body is the inline schema body, sent on every task creation
+    # so Orchestrator can upsert it (the Agents runtime has no separate registration step).
+    # The Python attribute is schema_body (not schema) to avoid shadowing
+    # pydantic.BaseModel.schema(); the JSON alias is "schema" to match the wire format.
+    schema_id: Optional[str] = Field(None, alias="schemaId")
+    schema_body: Optional[Dict[str, Any]] = Field(None, alias="schema")
 
     @model_validator(mode="before")
     @classmethod
@@ -767,6 +775,23 @@ class AgentIxpVsEscalationResourceConfig(BaseAgentResourceConfig):
     vs_escalation_properties: AgentIxpVsEscalationProperties = Field(
         ..., alias="vsEscalationProperties"
     )
+
+
+class AgentQuickFormEscalationResourceConfig(BaseAgentResourceConfig):
+    """Quick Form Agent escalation resource configuration model (escalationType=2).
+
+    Quick Form escalations render a schema-first HITL task in Action Center via FormLib.
+    The schema (and its key) live on the channel (see AgentEscalationChannel.schema_id /
+    schema) and are sent inline to Orchestrator's GenericTasks/CreateTask endpoint.
+    """
+
+    id: Optional[str] = Field(None, alias="id")
+    resource_type: Literal[AgentResourceType.ESCALATION] = Field(
+        alias="$resourceType", default=AgentResourceType.ESCALATION, frozen=True
+    )
+    channels: List[AgentEscalationChannel] = Field(alias="channels")
+    is_agent_memory_enabled: bool = Field(default=False, alias="isAgentMemoryEnabled")
+    escalation_type: Literal[2] = Field(default=2, alias="escalationType")
 
 
 class BaseAgentToolResourceConfig(BaseAgentResourceConfig):
@@ -978,6 +1003,7 @@ EscalationResourceConfig = Annotated[
     Union[
         Annotated[AgentEscalationResourceConfig, Tag(0)],
         Annotated[AgentIxpVsEscalationResourceConfig, Tag(1)],
+        Annotated[AgentQuickFormEscalationResourceConfig, Tag(2)],
     ],
     Discriminator(lambda v: v.get("escalation_type") or v.get("escalationType") or 0),
 ]

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.75"
+version = "2.10.76"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.59"
+version = "0.1.60"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

  - `TasksService.create_quickform_async` / `create_quickform` — POSTs to `/orchestrator_/tasks/GenericTasks/CreateTask` with `type=6 (QuickFormTask)`, `taskSchemaKey`, inline `schema`, plus standard `data` / `priority` / `labels` / `actionableMessageMetaData` / `taskSource`. Mirrors `create_async` including the `OData.AssignTasks` follow-up call.
  - `AgentEscalationChannel` — new optional `schema_id` / `schema` fields for QF channels in `agent.json`.
  - `AgentQuickFormEscalationResourceConfig`, new resource config for `escalationType=2`, mirroring the existing IXP pattern. Wired into the `EscalationResourceConfig` discriminated union via `Tag(2)`.
  
## Testing
Validated against the alpha Orchestrator by calling the new SDK method directly with a schema.

<img width="1732" height="1487" alt="image" src="https://github.com/user-attachments/assets/27499d93-e7e5-44aa-b948-2b28eeebcc1e" />
<img width="3835" height="1930" alt="image" src="https://github.com/user-attachments/assets/818a2397-53db-42bd-b2c8-a5e5cac21f8d" />
