### PR TITLE
feat(agent): QuickForm escalation channel models

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.78"
+version = "2.10.79"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -755,8 +755,8 @@ class BaseAgentEscalationChannel(BaseCfg):
         return _resolve_task_title(v)
 
 
-class AgentActionCenterEscalationChannel(BaseAgentEscalationChannel):
-    """Action Center app-task escalation channel."""
+class AgentEscalationChannel(BaseAgentEscalationChannel):
+    """Action Center app-task escalation channel (channel type ``actionCenter``)."""
 
     type: Literal[AgentEscalationChannelType.ACTION_CENTER] = Field(
         default=AgentEscalationChannelType.ACTION_CENTER, alias="type"
@@ -773,9 +773,9 @@ class AgentQuickFormEscalationChannel(BaseAgentEscalationChannel):
     properties: AgentQuickFormChannelProperties = Field(..., alias="properties")
 
 
-AgentEscalationChannel = Annotated[
+EscalationChannel = Annotated[
     Union[
-        AgentActionCenterEscalationChannel,
+        AgentEscalationChannel,
         AgentQuickFormEscalationChannel,
     ],
     Field(discriminator="type"),
@@ -790,7 +790,7 @@ class AgentEscalationResourceConfig(BaseAgentResourceConfig):
     resource_type: Literal[AgentResourceType.ESCALATION] = Field(
         alias="$resourceType", default=AgentResourceType.ESCALATION, frozen=True
     )
-    channels: List[AgentEscalationChannel] = Field(alias="channels")
+    channels: List[EscalationChannel] = Field(alias="channels")
     is_agent_memory_enabled: bool = Field(default=False, alias="isAgentMemoryEnabled")
     escalation_type: Literal[0] = Field(default=0, alias="escalationType")
 
@@ -810,7 +810,7 @@ class AgentIxpVsEscalationResourceConfig(BaseAgentResourceConfig):
     resource_type: Literal[AgentResourceType.ESCALATION] = Field(
         alias="$resourceType", default=AgentResourceType.ESCALATION, frozen=True
     )
-    channels: List[AgentEscalationChannel] = Field(alias="channels")
+    channels: List[EscalationChannel] = Field(alias="channels")
     is_agent_memory_enabled: bool = Field(default=False, alias="isAgentMemoryEnabled")
     escalation_type: Literal[1] = Field(default=1, alias="escalationType")
     vs_escalation_properties: AgentIxpVsEscalationProperties = Field(

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -147,7 +147,6 @@ class AgentEscalationChannelType(str, CaseInsensitiveEnum):
 
     ACTION_CENTER = "actionCenter"
     ACTION_CENTER_QUICK_FORM = "actionCenterQuickForm"
-    UNKNOWN = "unknown"  # fallback branch discriminator
 
 
 class AgentContextRetrievalMode(str, CaseInsensitiveEnum):
@@ -722,12 +721,12 @@ class AgentEscalationChannelProperties(BaseEscalationChannelProperties):
 class AgentQuickFormChannelProperties(BaseEscalationChannelProperties):
     """Quick Form channel properties (channel type ``actionCenterQuickForm``)."""
 
-    schema: Dict[str, Any] = Field(...)  # type: ignore[assignment]
+    form_schema: Dict[str, Any] = Field(..., alias="schema")
 
     @property
     def schema_id(self) -> str | None:
-        """Return the schema id nested inside schema."""
-        return self.schema.get("schemaId")
+        """Return the schema id nested inside the form schema body."""
+        return self.form_schema.get("schemaId")
 
 
 class BaseAgentEscalationChannel(BaseCfg):
@@ -766,7 +765,7 @@ class AgentActionCenterEscalationChannel(BaseAgentEscalationChannel):
 
 
 class AgentQuickFormEscalationChannel(BaseAgentEscalationChannel):
-    """Quick Form escalation channel; FormLib schema lives in ``properties.schema``."""
+    """Quick Form escalation channel; FormLib schema lives in ``properties.form_schema``."""
 
     type: Literal[AgentEscalationChannelType.ACTION_CENTER_QUICK_FORM] = Field(
         default=AgentEscalationChannelType.ACTION_CENTER_QUICK_FORM, alias="type"
@@ -774,22 +773,10 @@ class AgentQuickFormEscalationChannel(BaseAgentEscalationChannel):
     properties: AgentQuickFormChannelProperties = Field(..., alias="properties")
 
 
-class AgentUnknownEscalationChannel(BaseAgentEscalationChannel):
-    """Fallback for unknown or future escalation channel types."""
-
-    type: Literal[AgentEscalationChannelType.UNKNOWN] = Field(
-        default=AgentEscalationChannelType.UNKNOWN, alias="type"
-    )
-    properties: BaseEscalationChannelProperties = Field(
-        default_factory=BaseEscalationChannelProperties, alias="properties"
-    )
-
-
 AgentEscalationChannel = Annotated[
     Union[
         AgentActionCenterEscalationChannel,
         AgentQuickFormEscalationChannel,
-        AgentUnknownEscalationChannel,
     ],
     Field(discriminator="type"),
     _case_insensitive_enum_validator("type", AgentEscalationChannelType),

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -142,6 +142,14 @@ class AgentEscalationRecipientType(str, CaseInsensitiveEnum):
     ARGUMENT_GROUP_NAME = "ArgumentGroupName"
 
 
+class AgentEscalationChannelType(str, CaseInsensitiveEnum):
+    """Agent escalation channel type enumeration."""
+
+    ACTION_CENTER = "actionCenter"
+    ACTION_CENTER_QUICK_FORM = "actionCenterQuickForm"
+    UNKNOWN = "unknown"  # fallback branch discriminator
+
+
 class AgentContextRetrievalMode(str, CaseInsensitiveEnum):
     """Agent context retrieval mode enumeration."""
 
@@ -691,13 +699,9 @@ def _resolve_task_title(v: Any) -> Any:
     return v
 
 
-class AgentEscalationChannelProperties(BaseResourceProperties):
-    """Agent escalation channel properties model."""
+class BaseEscalationChannelProperties(BaseResourceProperties):
+    """Fields shared by every escalation channel's properties."""
 
-    app_name: str | None = Field(default=None, alias="appName")
-    app_version: int = Field(..., alias="appVersion")
-    folder_name: Optional[str] = Field(None, alias="folderName")
-    resource_key: str | None = Field(default=None, alias="resourceKey")
     is_actionable_message_enabled: Optional[bool] = Field(
         None, alias="isActionableMessageEnabled"
     )
@@ -706,12 +710,31 @@ class AgentEscalationChannelProperties(BaseResourceProperties):
     )
 
 
-class AgentEscalationChannel(BaseCfg):
-    """Agent escalation channel model."""
+class AgentEscalationChannelProperties(BaseEscalationChannelProperties):
+    """Action Center app-task channel properties (channel type ``actionCenter``)."""
+
+    app_name: str | None = Field(default=None, alias="appName")
+    app_version: int = Field(..., alias="appVersion")
+    folder_name: Optional[str] = Field(None, alias="folderName")
+    resource_key: str | None = Field(default=None, alias="resourceKey")
+
+
+class AgentQuickFormChannelProperties(BaseEscalationChannelProperties):
+    """Quick Form channel properties (channel type ``actionCenterQuickForm``)."""
+
+    schema: Dict[str, Any] = Field(...)  # type: ignore[assignment]
+
+    @property
+    def schema_id(self) -> str | None:
+        """Return the schema id nested inside schema."""
+        return self.schema.get("schemaId")
+
+
+class BaseAgentEscalationChannel(BaseCfg):
+    """Fields shared by every escalation channel variant."""
 
     id: Optional[str] = Field(None, alias="id")
     name: str = Field(..., alias="name")
-    type: str = Field(alias="type")
     description: str = Field(..., alias="description")
     input_schema: Dict[str, Any] = Field(..., alias="inputSchema")
     output_schema: Dict[str, Any] = Field(EMPTY_SCHEMA, alias="outputSchema")
@@ -719,22 +742,58 @@ class AgentEscalationChannel(BaseCfg):
         {}, alias="argumentProperties"
     )
     outcome_mapping: Optional[Dict[str, str]] = Field(None, alias="outcomeMapping")
-    properties: AgentEscalationChannelProperties = Field(..., alias="properties")
     recipients: List[AgentEscalationRecipient] = Field(..., alias="recipients")
     task_title: Optional[Union[str, TaskTitle]] = Field(
         default="Escalation Task", alias="taskTitle"
     )
     priority: Optional[str] = None
     labels: List[str] = Field(default_factory=list)
-    # schema_body avoids shadowing pydantic.BaseModel.schema(); JSON alias stays "schema".
-    schema_id: Optional[str] = Field(None, alias="schemaId")
-    schema_body: Optional[Dict[str, Any]] = Field(None, alias="schema")
 
     @model_validator(mode="before")
     @classmethod
     def _apply_task_title_resolution(cls, v: Any) -> Any:
         """Apply task title resolution."""
         return _resolve_task_title(v)
+
+
+class AgentActionCenterEscalationChannel(BaseAgentEscalationChannel):
+    """Action Center app-task escalation channel."""
+
+    type: Literal[AgentEscalationChannelType.ACTION_CENTER] = Field(
+        default=AgentEscalationChannelType.ACTION_CENTER, alias="type"
+    )
+    properties: AgentEscalationChannelProperties = Field(..., alias="properties")
+
+
+class AgentQuickFormEscalationChannel(BaseAgentEscalationChannel):
+    """Quick Form escalation channel; FormLib schema lives in ``properties.schema``."""
+
+    type: Literal[AgentEscalationChannelType.ACTION_CENTER_QUICK_FORM] = Field(
+        default=AgentEscalationChannelType.ACTION_CENTER_QUICK_FORM, alias="type"
+    )
+    properties: AgentQuickFormChannelProperties = Field(..., alias="properties")
+
+
+class AgentUnknownEscalationChannel(BaseAgentEscalationChannel):
+    """Fallback for unknown or future escalation channel types."""
+
+    type: Literal[AgentEscalationChannelType.UNKNOWN] = Field(
+        default=AgentEscalationChannelType.UNKNOWN, alias="type"
+    )
+    properties: BaseEscalationChannelProperties = Field(
+        default_factory=BaseEscalationChannelProperties, alias="properties"
+    )
+
+
+AgentEscalationChannel = Annotated[
+    Union[
+        AgentActionCenterEscalationChannel,
+        AgentQuickFormEscalationChannel,
+        AgentUnknownEscalationChannel,
+    ],
+    Field(discriminator="type"),
+    _case_insensitive_enum_validator("type", AgentEscalationChannelType),
+]
 
 
 class AgentEscalationResourceConfig(BaseAgentResourceConfig):
@@ -770,23 +829,6 @@ class AgentIxpVsEscalationResourceConfig(BaseAgentResourceConfig):
     vs_escalation_properties: AgentIxpVsEscalationProperties = Field(
         ..., alias="vsEscalationProperties"
     )
-
-
-class AgentQuickFormEscalationResourceConfig(BaseAgentResourceConfig):
-    """Quick Form Agent escalation resource configuration model (escalationType=2).
-
-    Quick Form escalations render a schema-first HITL task in Action Center via FormLib.
-    The schema (and its key) live on the channel (see AgentEscalationChannel.schema_id /
-    schema) and are sent inline to Orchestrator's GenericTasks/CreateTask endpoint.
-    """
-
-    id: Optional[str] = Field(None, alias="id")
-    resource_type: Literal[AgentResourceType.ESCALATION] = Field(
-        alias="$resourceType", default=AgentResourceType.ESCALATION, frozen=True
-    )
-    channels: List[AgentEscalationChannel] = Field(alias="channels")
-    is_agent_memory_enabled: bool = Field(default=False, alias="isAgentMemoryEnabled")
-    escalation_type: Literal[2] = Field(default=2, alias="escalationType")
 
 
 class BaseAgentToolResourceConfig(BaseAgentResourceConfig):
@@ -994,11 +1036,11 @@ ToolResourceConfig = Annotated[
     Field(discriminator="type"),
 ]
 
+
 EscalationResourceConfig = Annotated[
     Union[
         Annotated[AgentEscalationResourceConfig, Tag(0)],
         Annotated[AgentIxpVsEscalationResourceConfig, Tag(1)],
-        Annotated[AgentQuickFormEscalationResourceConfig, Tag(2)],
     ],
     Discriminator(lambda v: v.get("escalation_type") or v.get("escalationType") or 0),
 ]

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -2664,6 +2664,28 @@ class TestAgentBuilderConfig:
                 }
             )
 
+    def test_unknown_escalation_channel_type_is_rejected(self):
+        """An unrecognized channel type fails to parse; the runtime cannot handle it."""
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationResourceConfig).validate_python(
+                {
+                    "$resourceType": "escalation",
+                    "name": "Escalation",
+                    "description": "",
+                    "channels": [
+                        {
+                            "name": "c",
+                            "description": "",
+                            "inputSchema": {"type": "object", "properties": {}},
+                            "type": "someFutureChannel",
+                            "recipients": [],
+                            "properties": {},
+                        }
+                    ],
+                    "isAgentMemoryEnabled": False,
+                }
+            )
+
     def test_task_title_text_builder_type(self):
         """Test TextBuilderTaskTitle with tokens."""
         from uipath.agent.models.agent import (

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -5,6 +5,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from uipath.agent.models.agent import (
     AgentA2aResourceConfig,
+    AgentActionCenterEscalationChannel,
     AgentBooleanOperator,
     AgentBooleanRule,
     AgentBuiltInValidatorGuardrail,
@@ -14,7 +15,6 @@ from uipath.agent.models.agent import (
     AgentContextType,
     AgentCustomGuardrail,
     AgentDefinition,
-    AgentEscalationChannel,
     AgentEscalationRecipient,
     AgentEscalationRecipientType,
     AgentEscalationResourceConfig,
@@ -36,6 +36,7 @@ from uipath.agent.models.agent import (
     AgentNumberOperator,
     AgentNumberRule,
     AgentProcessToolResourceConfig,
+    AgentQuickFormChannelProperties,
     AgentResourceType,
     AgentToolArgumentPropertiesVariant,
     AgentToolType,
@@ -2607,10 +2608,61 @@ class TestAgentBuilderConfig:
         assert len(channel.recipients) == 0
 
         # Validate channel properties
+        assert isinstance(channel, AgentActionCenterEscalationChannel)
         assert channel.properties.app_name is None
         assert channel.properties.app_version == 1
         assert channel.properties.folder_name is None
         assert channel.properties.resource_key is None
+
+    def test_quick_form_channel_properties_derive_schema_id_from_body(self):
+        """schema_id reads the schemaId nested inside the schema body."""
+
+        props = AgentQuickFormChannelProperties.model_validate(
+            {
+                "schema": {
+                    "schemaId": "e74ebb74-80ba-47b9-a370-532a1ba4c41e",
+                    "fields": [],
+                    "outcomes": [],
+                },
+            }
+        )
+        assert props.schema_id == "e74ebb74-80ba-47b9-a370-532a1ba4c41e"
+
+    def test_quick_form_channel_properties_schema_id_none_when_absent(self):
+        """schema_id is None when the schema body carries no schemaId."""
+
+        props = AgentQuickFormChannelProperties.model_validate(
+            {"schema": {"fields": [], "outcomes": []}}
+        )
+        assert props.schema_id is None
+
+    def test_quick_form_channel_properties_require_schema(self):
+        with pytest.raises(ValidationError):
+            AgentQuickFormChannelProperties.model_validate(
+                {"isActionableMessageEnabled": False}
+            )
+
+    def test_quick_form_channel_requires_schema(self):
+        """A quick-form channel without a schema fails to parse."""
+        with pytest.raises(ValidationError):
+            TypeAdapter(AgentEscalationResourceConfig).validate_python(
+                {
+                    "$resourceType": "escalation",
+                    "name": "Escalation",
+                    "description": "",
+                    "channels": [
+                        {
+                            "name": "c",
+                            "description": "",
+                            "inputSchema": {"type": "object", "properties": {}},
+                            "type": "actionCenterQuickForm",
+                            "recipients": [],
+                            "properties": {"isActionableMessageEnabled": False},
+                        }
+                    ],
+                    "isAgentMemoryEnabled": False,
+                }
+            )
 
     def test_task_title_text_builder_type(self):
         """Test TextBuilderTaskTitle with tokens."""
@@ -2664,7 +2716,7 @@ class TestAgentBuilderConfig:
             },
         }
 
-        channel = AgentEscalationChannel(**channel_data)  # type: ignore[arg-type]
+        channel = AgentActionCenterEscalationChannel(**channel_data)  # type: ignore[arg-type]
 
         assert isinstance(channel.task_title, dict) or hasattr(
             channel.task_title, "tokens"
@@ -2688,7 +2740,7 @@ class TestAgentBuilderConfig:
             "taskTitle": "Legacy Task Title",
         }
 
-        channel = AgentEscalationChannel(**channel_data)  # type: ignore[arg-type]
+        channel = AgentActionCenterEscalationChannel(**channel_data)  # type: ignore[arg-type]
 
         assert channel.task_title == "Legacy Task Title"
 
@@ -2709,7 +2761,7 @@ class TestAgentBuilderConfig:
             "recipients": [],
         }
 
-        channel = AgentEscalationChannel(**channel_data)  # type: ignore[arg-type]
+        channel = AgentActionCenterEscalationChannel(**channel_data)  # type: ignore[arg-type]
 
         assert channel.task_title == "Escalation Task"
 

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -5,7 +5,6 @@ from pydantic import TypeAdapter, ValidationError
 
 from uipath.agent.models.agent import (
     AgentA2aResourceConfig,
-    AgentActionCenterEscalationChannel,
     AgentBooleanOperator,
     AgentBooleanRule,
     AgentBuiltInValidatorGuardrail,
@@ -15,6 +14,7 @@ from uipath.agent.models.agent import (
     AgentContextType,
     AgentCustomGuardrail,
     AgentDefinition,
+    AgentEscalationChannel,
     AgentEscalationRecipient,
     AgentEscalationRecipientType,
     AgentEscalationResourceConfig,
@@ -2608,7 +2608,7 @@ class TestAgentBuilderConfig:
         assert len(channel.recipients) == 0
 
         # Validate channel properties
-        assert isinstance(channel, AgentActionCenterEscalationChannel)
+        assert isinstance(channel, AgentEscalationChannel)
         assert channel.properties.app_name is None
         assert channel.properties.app_version == 1
         assert channel.properties.folder_name is None
@@ -2738,7 +2738,7 @@ class TestAgentBuilderConfig:
             },
         }
 
-        channel = AgentActionCenterEscalationChannel(**channel_data)  # type: ignore[arg-type]
+        channel = AgentEscalationChannel(**channel_data)  # type: ignore[arg-type]
 
         assert isinstance(channel.task_title, dict) or hasattr(
             channel.task_title, "tokens"
@@ -2762,7 +2762,7 @@ class TestAgentBuilderConfig:
             "taskTitle": "Legacy Task Title",
         }
 
-        channel = AgentActionCenterEscalationChannel(**channel_data)  # type: ignore[arg-type]
+        channel = AgentEscalationChannel(**channel_data)  # type: ignore[arg-type]
 
         assert channel.task_title == "Legacy Task Title"
 
@@ -2783,7 +2783,7 @@ class TestAgentBuilderConfig:
             "recipients": [],
         }
 
-        channel = AgentActionCenterEscalationChannel(**channel_data)  # type: ignore[arg-type]
+        channel = AgentEscalationChannel(**channel_data)  # type: ignore[arg-type]
 
         assert channel.task_title == "Escalation Task"
 

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.78"
+version = "2.10.79"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

Agent-model support for QuickForm escalations on low-code agents. QuickForm is a **channel variant** of the standard escalation (told apart by channel `type`), not a separate resource type.

## Changes (`agent/models/agent.py`)

- `AgentEscalationChannel` stays the concrete **Action Center** channel (`type` `actionCenter`); `AgentQuickFormEscalationChannel` is the quick-form variant (`actionCenterQuickForm`). The `channels` field is typed as the `EscalationChannel` discriminated union (`Field(discriminator="type")` + case-insensitive normalization). An unrecognized channel `type` is **rejected at parse time** — the runtime cannot execute a channel it does not know, so there is deliberately no silent fallback.
- `AgentQuickFormChannelProperties` carries the FormLib schema inline as `form_schema` (alias `schema`, with a `schema_id` accessor); `AgentEscalationChannelProperties` (Action Center) owns the app fields (`app_name`, `app_version`, `folder_name`, `resource_key`); the shared base keeps only the actionable-message fields.
- Escalation resource union: `AgentEscalationResourceConfig` (`escalationType=0`, shared by app-task and QuickForm) and `AgentIxpVsEscalationResourceConfig` (`escalationType=1`).

Package bumped to `2.10.79`.

### Compatibility

`AgentEscalationChannel` remains a concrete, directly-instantiable model under its original name, so existing consumers that build `AgentEscalationChannel(...)` keep working (verified against the `uipath-langchain` cross-test). The only intentional break is that unknown/future channel types now raise on parse instead of falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
