### PR TITLE
feat(agent): add Function tool type for agent process tools

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.71"
+version = "2.10.72"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -113,6 +113,7 @@ class AgentToolType(str, CaseInsensitiveEnum):
     API = "Api"
     PROCESS_ORCHESTRATION = "ProcessOrchestration"
     FLOW = "Flow"
+    FUNCTION = "Function"
     INTEGRATION = "Integration"
     INTERNAL = "Internal"
     IXP = "Ixp"
@@ -792,6 +793,7 @@ class AgentProcessToolResourceConfig(BaseAgentToolResourceConfig):
         AgentToolType.API,
         AgentToolType.PROCESS_ORCHESTRATION,
         AgentToolType.FLOW,
+        AgentToolType.FUNCTION,
     ]
     output_schema: Dict[str, Any] = Field(EMPTY_SCHEMA, alias="outputSchema")
     properties: AgentProcessToolProperties
@@ -1336,6 +1338,7 @@ class AgentDefinition(BaseModel):
             "api": "Api",
             "processorchestration": "ProcessOrchestration",
             "flow": "Flow",
+            "function": "Function",
             "integration": "Integration",
             "internal": "Internal",
             "ixp": "Ixp",

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -3627,6 +3627,75 @@ class TestAgentBuilderConfigResources:
         assert isinstance(tool_resource, AgentProcessToolResourceConfig)
         assert tool_resource.type == AgentToolType.FLOW
 
+    def test_function_tool_type_enum_value(self):
+        """AgentToolType.FUNCTION exists with the wire value 'Function' and is case-insensitive."""
+        assert AgentToolType.FUNCTION.value == "Function"
+        assert AgentToolType("function") is AgentToolType.FUNCTION
+        assert AgentToolType("FUNCTION") is AgentToolType.FUNCTION
+
+    def test_function_tool_resource_deserialization(self):
+        """A resource with type='Function' is parsed as AgentProcessToolResourceConfig."""
+        resources = [
+            {
+                "$resourceType": "tool",
+                "type": "Function",
+                "id": "function-tool-1",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                },
+                "outputSchema": {"type": "object", "properties": {}},
+                "arguments": {},
+                "settings": {"timeout": 0, "maxAttempts": 0, "retryDelay": 0},
+                "properties": {
+                    "processName": "MyFunction",
+                    "folderPath": "/Shared/Functions",
+                },
+                "name": "Function Tool",
+                "description": "Test Function tool",
+            }
+        ]
+
+        json_data = self._agent_dict_with_resources(resources)
+        config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
+            json_data
+        )
+
+        tool_resource = config.resources[0]
+        assert isinstance(tool_resource, AgentProcessToolResourceConfig)
+        assert tool_resource.type == AgentToolType.FUNCTION
+        assert tool_resource.properties.process_name == "MyFunction"
+        assert tool_resource.properties.folder_path == "/Shared/Functions"
+
+    def test_function_tool_resource_case_insensitive(self):
+        """A resource with lowercase type='function' also deserializes via CaseInsensitiveEnum."""
+        resources = [
+            {
+                "$resourceType": "tool",
+                "type": "function",
+                "id": "function-tool-2",
+                "inputSchema": {"type": "object", "properties": {}},
+                "outputSchema": {"type": "object", "properties": {}},
+                "arguments": {},
+                "settings": {"timeout": 0, "maxAttempts": 0, "retryDelay": 0},
+                "properties": {
+                    "processName": "MyFunction",
+                    "folderPath": "/Shared/Functions",
+                },
+                "name": "Function Tool",
+                "description": "Test Function tool",
+            }
+        ]
+
+        json_data = self._agent_dict_with_resources(resources)
+        config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
+            json_data
+        )
+
+        tool_resource = config.resources[0]
+        assert isinstance(tool_resource, AgentProcessToolResourceConfig)
+        assert tool_resource.type == AgentToolType.FUNCTION
+
     def test_escalation_missing_escalation_type_defaults_to_zero(self):
         """Test that missing escalationType defaults to 0."""
         resources = [

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.71"
+version = "2.10.72"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Add `AgentToolType.FUNCTION` (wire value `Function`) and include it in the discriminator set for `AgentProcessToolResourceConfig` so Function tools deserialize alongside Process/API/ProcessOrchestration/Flow.
- Register `function` → `Function` in the case-insensitive alias map on `AgentDefinition`.
- Bump `uipath` to 2.10.72.

## Test plan
- [x] `pytest packages/uipath/tests/agent/models/test_agent.py` — new tests cover enum value, case-insensitive parsing, and deserialization of a `type: "Function"` resource as `AgentProcessToolResourceConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)