### PR TITLE
chore: add platform mcp type

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.63"
+version = "0.1.64"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/mcp.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/mcp.py
@@ -17,6 +17,7 @@ class McpServerType(IntEnum):
     SelfHosted = 3  # tunnel to (externally) self-hosted server
     Remote = 4  # HTTP connection to remote MCP server
     ProcessAssistant = 5  # Dynamic user process assistant
+    Platform = 6  # Platform MCP server (e.g: Orchestrator, TestManager)
 
 
 class McpServerStatus(IntEnum):

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.63"
+version = "0.1.64"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.63"
+version = "0.1.64"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Description

Add type `Platform` to the `McpServerType` enum. 