### PR TITLE
fix: eph folder key issue

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.59"
+version = "0.1.60"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -2262,13 +2262,11 @@ class ContextGroundingService(FolderContext, BaseService):
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        folder_key = self._resolve_folder_key(folder_key, folder_path)
-
+        # Folder key not needed by retrieve by id. Adding it breaks ephemeral indexes
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(f"/ecs_/v2/indexes/{id}"),
             headers={
-                **header_folder(folder_key, None),
                 **header_job_key(),
             },
         )

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -696,8 +696,12 @@ class ContextGroundingService(FolderContext, BaseService):
         Returns:
             ContextGroundingIndex: The created index information.
         """
-        if folder_key is not None or folder_path is not None:
-            folder_key = self._resolve_folder_key(folder_key, folder_path)
+        # Resolve the folder key the same way retrieve_by_id does (falling back
+        # to the ambient folder context) so the index is created in the same
+        # folder scope it will later be retrieved from. Otherwise the index is
+        # created tenant-scoped but the GET sends x-uipath-folderkey, scoping the
+        # lookup to a folder the index doesn't live in -> 404 "Schema not found".
+        folder_key = self._resolve_folder_key(folder_key, folder_path)
         spec = self._create_ephemeral_spec(
             usage,
             attachments,
@@ -733,8 +737,12 @@ class ContextGroundingService(FolderContext, BaseService):
         Returns:
             ContextGroundingIndex: The created index information.
         """
-        if folder_key is not None or folder_path is not None:
-            folder_key = self._resolve_folder_key(folder_key, folder_path)
+        # Resolve the folder key the same way retrieve_by_id does (falling back
+        # to the ambient folder context) so the index is created in the same
+        # folder scope it will later be retrieved from. Otherwise the index is
+        # created tenant-scoped but the GET sends x-uipath-folderkey, scoping the
+        # lookup to a folder the index doesn't live in -> 404 "Schema not found".
+        folder_key = self._resolve_folder_key(folder_key, folder_path)
         spec = self._create_ephemeral_spec(
             usage,
             attachments,
@@ -2262,11 +2270,13 @@ class ContextGroundingService(FolderContext, BaseService):
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
     ) -> RequestSpec:
-        # Folder key not needed by retrieve by id. Adding it breaks ephemeral indexes
+        folder_key = self._resolve_folder_key(folder_key, folder_path)
+
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(f"/ecs_/v2/indexes/{id}"),
             headers={
+                **header_folder(folder_key, None),
                 **header_job_key(),
             },
         )

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -696,11 +696,6 @@ class ContextGroundingService(FolderContext, BaseService):
         Returns:
             ContextGroundingIndex: The created index information.
         """
-        # Resolve the folder key the same way retrieve_by_id does (falling back
-        # to the ambient folder context) so the index is created in the same
-        # folder scope it will later be retrieved from. Otherwise the index is
-        # created tenant-scoped but the GET sends x-uipath-folderkey, scoping the
-        # lookup to a folder the index doesn't live in -> 404 "Schema not found".
         folder_key = self._resolve_folder_key(folder_key, folder_path)
         spec = self._create_ephemeral_spec(
             usage,
@@ -737,11 +732,6 @@ class ContextGroundingService(FolderContext, BaseService):
         Returns:
             ContextGroundingIndex: The created index information.
         """
-        # Resolve the folder key the same way retrieve_by_id does (falling back
-        # to the ambient folder context) so the index is created in the same
-        # folder scope it will later be retrieved from. Otherwise the index is
-        # created tenant-scoped but the GET sends x-uipath-folderkey, scoping the
-        # lookup to a folder the index doesn't live in -> 404 "Schema not found".
         folder_key = self._resolve_folder_key(folder_key, folder_path)
         spec = self._create_ephemeral_spec(
             usage,

--- a/packages/uipath-platform/tests/services/test_context_grounding_service.py
+++ b/packages/uipath-platform/tests/services/test_context_grounding_service.py
@@ -8,6 +8,7 @@ from pytest_httpx import HTTPXMock
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common.constants import (
     ENV_JOB_KEY,
+    HEADER_FOLDER_KEY,
     HEADER_JOB_KEY,
     HEADER_USER_AGENT,
 )
@@ -3918,3 +3919,61 @@ class TestJobKeyHeader:
 
         headers = mock_request.call_args[1]["headers"]
         assert HEADER_JOB_KEY not in headers
+
+
+class TestRetrieveByIdFolderScoping:
+    """retrieve_by_id must not send a folder header.
+
+    Indexes are looked up by id tenant-wide. Ephemeral indexes are created
+    tenant-scoped, so sending x-uipath-folderkey on the GET scopes the lookup to
+    a folder the index does not live in, producing a 404 "Schema not found".
+    Regression: ECS-1819.
+    """
+
+    def test_omits_folder_header_even_with_ambient_folder(
+        self,
+        service: ContextGroundingService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(ENV_JOB_KEY, raising=False)
+        # Simulate running inside a folder context (e.g. UIPATH_FOLDER_KEY set).
+        service._folder_key = "ambient-folder-key"
+
+        with patch.object(service, "request") as mock_request:
+            mock_request.return_value = MagicMock()
+            service.retrieve_by_id("ephemeral-index-id")
+
+        headers = mock_request.call_args[1]["headers"]
+        assert HEADER_FOLDER_KEY not in headers
+
+    @pytest.mark.anyio
+    async def test_async_omits_folder_header_even_with_ambient_folder(
+        self,
+        service: ContextGroundingService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(ENV_JOB_KEY, raising=False)
+        service._folder_key = "ambient-folder-key"
+
+        with patch.object(service, "request_async") as mock_request:
+            mock_request.return_value = MagicMock()
+            await service.retrieve_by_id_async("ephemeral-index-id")
+
+        headers = mock_request.call_args[1]["headers"]
+        assert HEADER_FOLDER_KEY not in headers
+
+    def test_still_carries_job_key(
+        self,
+        service: ContextGroundingService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(ENV_JOB_KEY, "job-key-retrieve")
+        service._folder_key = "ambient-folder-key"
+
+        with patch.object(service, "request") as mock_request:
+            mock_request.return_value = MagicMock()
+            service.retrieve_by_id("ephemeral-index-id")
+
+        headers = mock_request.call_args[1]["headers"]
+        assert headers[HEADER_JOB_KEY] == "job-key-retrieve"
+        assert HEADER_FOLDER_KEY not in headers

--- a/packages/uipath-platform/tests/services/test_context_grounding_service.py
+++ b/packages/uipath-platform/tests/services/test_context_grounding_service.py
@@ -8,7 +8,6 @@ from pytest_httpx import HTTPXMock
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common.constants import (
     ENV_JOB_KEY,
-    HEADER_FOLDER_KEY,
     HEADER_JOB_KEY,
     HEADER_USER_AGENT,
 )
@@ -3179,6 +3178,19 @@ class TestContextGroundingService:
         import uuid
 
         httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
+
+        httpx_mock.add_response(
             url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/createephemeral",
             status_code=200,
             json={
@@ -3203,22 +3215,27 @@ class TestContextGroundingService:
         if sent_requests is None:
             raise Exception("No request was sent")
 
-        assert sent_requests[0].method == "POST"
-        assert (
-            sent_requests[0].url
-            == f"{base_url}{org}{tenant}/ecs_/v2/indexes/createephemeral"
+        create_request = next(
+            r
+            for r in sent_requests
+            if str(r.url).endswith("/ecs_/v2/indexes/createephemeral")
         )
+        assert create_request.method == "POST"
 
-        request_data = json.loads(sent_requests[0].content)
+        request_data = json.loads(create_request.content)
         assert request_data["usage"] == "DeepRAG"
         assert "dataSource" in request_data
         assert request_data["dataSource"]["attachments"] == [
             str(att) for att in attachment_ids
         ]
 
-        assert HEADER_USER_AGENT in sent_requests[0].headers
+        # Ambient folder context is resolved and scopes the create, matching how
+        # retrieve_by_id resolves the folder for the subsequent GET.
+        assert create_request.headers["x-uipath-folderkey"] == "test-folder-key"
+
+        assert HEADER_USER_AGENT in create_request.headers
         assert (
-            sent_requests[0].headers[HEADER_USER_AGENT]
+            create_request.headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ContextGroundingService.create_ephemeral_index/{version}"
         )
 
@@ -3233,6 +3250,19 @@ class TestContextGroundingService:
         version: str,
     ) -> None:
         import uuid
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/api/FoldersNavigation/GetFoldersForCurrentUser?searchText=test-folder-path&skip=0&take=20",
+            status_code=200,
+            json={
+                "PageItems": [
+                    {
+                        "Key": "test-folder-key",
+                        "FullyQualifiedName": "test-folder-path",
+                    }
+                ]
+            },
+        )
 
         httpx_mock.add_response(
             url=f"{base_url}{org}{tenant}/ecs_/v2/indexes/createephemeral",
@@ -3259,22 +3289,27 @@ class TestContextGroundingService:
         if sent_requests is None:
             raise Exception("No request was sent")
 
-        assert sent_requests[0].method == "POST"
-        assert (
-            sent_requests[0].url
-            == f"{base_url}{org}{tenant}/ecs_/v2/indexes/createephemeral"
+        create_request = next(
+            r
+            for r in sent_requests
+            if str(r.url).endswith("/ecs_/v2/indexes/createephemeral")
         )
+        assert create_request.method == "POST"
 
-        request_data = json.loads(sent_requests[0].content)
+        request_data = json.loads(create_request.content)
         assert request_data["usage"] == "DeepRAG"
         assert "dataSource" in request_data
         assert request_data["dataSource"]["attachments"] == [
             str(att) for att in attachment_ids
         ]
 
-        assert HEADER_USER_AGENT in sent_requests[0].headers
+        # Ambient folder context is resolved and scopes the create, matching how
+        # retrieve_by_id resolves the folder for the subsequent GET.
+        assert create_request.headers["x-uipath-folderkey"] == "test-folder-key"
+
+        assert HEADER_USER_AGENT in create_request.headers
         assert (
-            sent_requests[0].headers[HEADER_USER_AGENT]
+            create_request.headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ContextGroundingService.create_ephemeral_index_async/{version}"
         )
 
@@ -3919,61 +3954,3 @@ class TestJobKeyHeader:
 
         headers = mock_request.call_args[1]["headers"]
         assert HEADER_JOB_KEY not in headers
-
-
-class TestRetrieveByIdFolderScoping:
-    """retrieve_by_id must not send a folder header.
-
-    Indexes are looked up by id tenant-wide. Ephemeral indexes are created
-    tenant-scoped, so sending x-uipath-folderkey on the GET scopes the lookup to
-    a folder the index does not live in, producing a 404 "Schema not found".
-    Regression: ECS-1819.
-    """
-
-    def test_omits_folder_header_even_with_ambient_folder(
-        self,
-        service: ContextGroundingService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.delenv(ENV_JOB_KEY, raising=False)
-        # Simulate running inside a folder context (e.g. UIPATH_FOLDER_KEY set).
-        service._folder_key = "ambient-folder-key"
-
-        with patch.object(service, "request") as mock_request:
-            mock_request.return_value = MagicMock()
-            service.retrieve_by_id("ephemeral-index-id")
-
-        headers = mock_request.call_args[1]["headers"]
-        assert HEADER_FOLDER_KEY not in headers
-
-    @pytest.mark.anyio
-    async def test_async_omits_folder_header_even_with_ambient_folder(
-        self,
-        service: ContextGroundingService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.delenv(ENV_JOB_KEY, raising=False)
-        service._folder_key = "ambient-folder-key"
-
-        with patch.object(service, "request_async") as mock_request:
-            mock_request.return_value = MagicMock()
-            await service.retrieve_by_id_async("ephemeral-index-id")
-
-        headers = mock_request.call_args[1]["headers"]
-        assert HEADER_FOLDER_KEY not in headers
-
-    def test_still_carries_job_key(
-        self,
-        service: ContextGroundingService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setenv(ENV_JOB_KEY, "job-key-retrieve")
-        service._folder_key = "ambient-folder-key"
-
-        with patch.object(service, "request") as mock_request:
-            mock_request.return_value = MagicMock()
-            service.retrieve_by_id("ephemeral-index-id")
-
-        headers = mock_request.call_args[1]["headers"]
-        assert headers[HEADER_JOB_KEY] == "job-key-retrieve"
-        assert HEADER_FOLDER_KEY not in headers

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.59"
+version = "0.1.60"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
make sure the create ephemeral index call has folder key. follows the same path to get it as our other methods now which also checks env vars

relevant issue: https://uipath-product.slack.com/archives/C060F2VLC20/p1780340678652109?thread_ts=1779989349.104999&cid=C060F2VLC20