### PR TITLE
feat: emit RunSource on eval telemetry from UIPATH_EVAL_RUN_SOURCE [AE-1329]

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.74"
+version = "2.10.75"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_evals/_telemetry.py
+++ b/packages/uipath/src/uipath/_cli/_evals/_telemetry.py
@@ -329,5 +329,15 @@ class EvalTelemetrySubscriber:
         if tenant_id:
             properties["TenantId"] = tenant_id
 
+        # Origin of the eval-set run as classified by the caller (e.g. Manual,
+        # Protegi, FirstSuccessfulRun). The Agents backend forwards the value
+        # via UIPATH_EVAL_RUN_SOURCE so adoption dashboards can exclude
+        # auto-triggered runs (e.g. first-successful-run) from user-driven counts.
+        # Distinct from the `Source` dimension below, which categorises the SDK
+        # emitter ("uipath-python-cli"), not the run origin.
+        run_source = os.getenv("UIPATH_EVAL_RUN_SOURCE")
+        if run_source:
+            properties["RunSource"] = run_source
+
         properties["Source"] = "uipath-python-cli"
         properties["ApplicationName"] = "UiPath.Eval"

--- a/packages/uipath/tests/cli/eval/test_eval_telemetry.py
+++ b/packages/uipath/tests/cli/eval/test_eval_telemetry.py
@@ -431,6 +431,7 @@ class TestEnrichProperties:
                 "UIPATH_PROJECT_ID": "project-123",
                 "UIPATH_ORGANIZATION_ID": "org-456",
                 "UIPATH_TENANT_ID": "tenant-abc",
+                "UIPATH_EVAL_RUN_SOURCE": "FirstSuccessfulRun",
             },
         ):
             subscriber._enrich_properties(properties)
@@ -440,6 +441,7 @@ class TestEnrichProperties:
         assert properties["CloudOrganizationId"] == "org-456"
         assert properties["CloudUserId"] == "user-789"
         assert properties["TenantId"] == "tenant-abc"
+        assert properties["RunSource"] == "FirstSuccessfulRun"
 
     @patch("uipath._cli._evals._telemetry.get_claim_from_token")
     def test_enrich_properties_skips_missing_env_vars(self, mock_get_claim):
@@ -455,6 +457,7 @@ class TestEnrichProperties:
                 "UIPATH_PROJECT_ID",
                 "UIPATH_ORGANIZATION_ID",
                 "UIPATH_TENANT_ID",
+                "UIPATH_EVAL_RUN_SOURCE",
             ]:
                 os.environ.pop(key, None)
 
@@ -465,6 +468,7 @@ class TestEnrichProperties:
         assert "CloudOrganizationId" not in properties
         assert "CloudUserId" not in properties
         assert "TenantId" not in properties
+        assert "RunSource" not in properties
 
 
 class TestExceptionHandling:

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.74"
+version = "2.10.75"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

The Agents backend tags FTR-auto-created eval-set runs with `EvalRunSource.FirstSuccessfulRun` so adoption dashboards can exclude them from user-driven counts. The .NET workflow's `EvalSetRunStart` event already carries the `RunSource` dimension. The Python-emitted events (`EvalSetRun.Start/End`, `EvalRun.Start/End` under `ApplicationName=UiPath.Eval`) — which is where most per-eval telemetry lives — did not.

This PR reads `UIPATH_EVAL_RUN_SOURCE` in `EvalTelemetrySubscriber._enrich_properties()` and surfaces it as the `RunSource` dimension on every eval telemetry event the subscriber emits. The env var is set by the Agents backend when it schedules the Python eval worker (see paired Agents PR [#5404](https://github.com/UiPath/Agents/pull/5404)).

## Why a new dimension and not the existing `Source`

`Source` already carries `"uipath-python-cli"` — it identifies the **emitter** (which SDK fired this telemetry). The new `RunSource` identifies the **origin classification** of the run (Manual / Protegi / FirstSuccessfulRun). They aren't the same concept and dashboards need both.

## Cross-repo coupling

This change is half of an end-to-end story:
- **uipath-python (this PR):** consume `UIPATH_EVAL_RUN_SOURCE` env var → emit as `RunSource` telemetry dimension.
- **Agents [#5404](https://github.com/UiPath/Agents/pull/5404):** set `UIPATH_EVAL_RUN_SOURCE` env var when scheduling the eval worker.

Both must land for FTR runs to be filterable on the Python-emitted events. Until then, the env var is simply absent and the new code path is a no-op — purely additive, zero risk.

## Testing

- `tests/cli/eval/test_eval_telemetry.py` — 24/24 pass.
- Extended `test_enrich_properties_adds_env_vars` to assert `RunSource` is set when env var present.
- Extended `test_enrich_properties_skips_missing_env_vars` to assert it's omitted when env var absent.
- `ruff format` + `ruff check` clean on the touched files.

## Reference

- [AE-1329](https://uipath.atlassian.net/browse/AE-1329)
- Verified via Application Insights query on alpha env (`agents-alp-appins-ne-appins`): without this change, `EvalSetRun.Start` from `UiPath.AgentService` carries `RunSource=FirstSuccessfulRun` but the four `UiPath.Eval` events for the same `EvalSetRunId` carry no `RunSource` dimension at all.


[AE-1329]: https://uipath.atlassian.net/browse/AE-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ