### PR TITLE
docs: fix pack default extensions list and leading dot example

### DIFF
--- a/packages/uipath/docs/cli/index.md
+++ b/packages/uipath/docs/cli/index.md
@@ -198,6 +198,7 @@ By default, the following file types are included in the `.nupkg` file:
 - `.json`
 - `.yaml`
 - `.yml`
+- `.md`
 
 ---
 
@@ -212,7 +213,7 @@ To include additional files, update the `uipath.json` file by adding a `packOpti
             "<file here>"
         ],
         "fileExtensionsIncluded": [
-            "<new file extension to include (e.g., 'go')>"
+            "<new file extension to include, with leading dot (e.g., '.go')>"
         ]
     }
 }


### PR DESCRIPTION
## Summary
- add `.md` to the default file extensions listed in the pack docs
- clarify that `fileExtensionsIncluded` values must include a leading dot (e.g. `.go`, not `go`)