### PR TITLE
feat(eval): support list of keys in target_output_key

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.77"
+version = "2.10.78"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/samples/list_target_output_key_test/bindings.json
+++ b/packages/uipath/samples/list_target_output_key_test/bindings.json
@@ -1,0 +1,4 @@
+{
+    "version": "2.0",
+    "resources": []
+}

--- a/packages/uipath/samples/list_target_output_key_test/entry-points.json
+++ b/packages/uipath/samples/list_target_output_key_test/entry-points.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+  "$id": "entry-points.json",
+  "entryPoints": [
+    {
+      "filePath": "main",
+      "uniqueId": "main",
+      "type": "function",
+      "input": {
+        "type": "object",
+        "properties": {
+          "product_id": {
+            "type": "string"
+          }
+        },
+        "description": "Input schema.",
+        "required": [
+          "product_id"
+        ]
+      },
+      "output": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "price": { "type": "number" },
+          "category": { "type": "string" },
+          "in_stock": { "type": "boolean" },
+          "rating": { "type": "number" }
+        },
+        "description": "Output schema.",
+        "required": [
+          "name",
+          "price",
+          "category",
+          "in_stock",
+          "rating"
+        ]
+      }
+    }
+  ]
+}

--- a/packages/uipath/samples/list_target_output_key_test/evaluations/eval-sets/default.json
+++ b/packages/uipath/samples/list_target_output_key_test/evaluations/eval-sets/default.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.0",
+  "id": "list-target-output-key-tests",
+  "name": "List Target Output Key Tests",
+  "evaluatorRefs": [
+    "ListKeysExactMatch",
+    "ListKeysJsonSimilarity"
+  ],
+  "evaluations": [
+    {
+      "id": "headphones-all-match",
+      "name": "Headphones - all keys match",
+      "inputs": {
+        "product_id": "p001"
+      },
+      "evaluationCriterias": {
+        "ListKeysExactMatch": {
+          "expectedOutput": {
+            "name": "Wireless Headphones",
+            "price": 79.99
+          }
+        },
+        "ListKeysJsonSimilarity": {
+          "expectedOutput": {
+            "category": "Electronics",
+            "in_stock": true
+          }
+        }
+      }
+    },
+    {
+      "id": "shoes-all-match",
+      "name": "Running Shoes - all keys match",
+      "inputs": {
+        "product_id": "p002"
+      },
+      "evaluationCriterias": {
+        "ListKeysExactMatch": {
+          "expectedOutput": {
+            "name": "Running Shoes",
+            "price": 120.0
+          }
+        },
+        "ListKeysJsonSimilarity": {
+          "expectedOutput": {
+            "category": "Sports",
+            "in_stock": false
+          }
+        }
+      }
+    },
+    {
+      "id": "headphones-wrong-price",
+      "name": "Headphones - wrong price (should fail)",
+      "inputs": {
+        "product_id": "p001"
+      },
+      "evaluationCriterias": {
+        "ListKeysExactMatch": {
+          "expectedOutput": {
+            "name": "Wireless Headphones",
+            "price": 999.0
+          }
+        },
+        "ListKeysJsonSimilarity": {
+          "expectedOutput": {
+            "category": "Electronics",
+            "in_stock": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/uipath/samples/list_target_output_key_test/evaluations/evaluators/list-keys-exact-match.json
+++ b/packages/uipath/samples/list_target_output_key_test/evaluations/evaluators/list-keys-exact-match.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "id": "ListKeysExactMatch",
+  "description": "Asserts 'name' and 'price' together using a list of target output keys",
+  "evaluatorTypeId": "uipath-exact-match",
+  "evaluatorConfig": {
+    "name": "ListKeysExactMatch",
+    "targetOutputKey": ["name", "price"]
+  }
+}

--- a/packages/uipath/samples/list_target_output_key_test/evaluations/evaluators/list-keys-json-similarity.json
+++ b/packages/uipath/samples/list_target_output_key_test/evaluations/evaluators/list-keys-json-similarity.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "id": "ListKeysJsonSimilarity",
+  "description": "Checks 'category' and 'in_stock' together using a list of target output keys",
+  "evaluatorTypeId": "uipath-json-similarity",
+  "evaluatorConfig": {
+    "name": "ListKeysJsonSimilarity",
+    "targetOutputKey": ["category", "in_stock"]
+  }
+}

--- a/packages/uipath/samples/list_target_output_key_test/main.py
+++ b/packages/uipath/samples/list_target_output_key_test/main.py
@@ -1,0 +1,74 @@
+"""Agent demonstrating list targetOutputKey evaluation.
+
+This agent simulates a product lookup: given a product ID it returns
+a structured response with several fields. The evaluators use a list
+of keys so that multiple fields can be asserted in a single evaluator
+configuration, without comparing the entire output dict.
+"""
+
+from pydantic import BaseModel
+
+CATALOG: dict[str, dict[str, object]] = {
+    "p001": {
+        "name": "Wireless Headphones",
+        "price": 79.99,
+        "category": "Electronics",
+        "in_stock": True,
+        "rating": 4.5,
+    },
+    "p002": {
+        "name": "Running Shoes",
+        "price": 120.0,
+        "category": "Sports",
+        "in_stock": False,
+        "rating": 4.8,
+    },
+    "p003": {
+        "name": "Coffee Maker",
+        "price": 49.99,
+        "category": "Kitchen",
+        "in_stock": True,
+        "rating": 4.2,
+    },
+}
+
+
+class Input(BaseModel):
+    """Input schema."""
+
+    product_id: str
+
+
+class Output(BaseModel):
+    """Output schema."""
+
+    name: str
+    price: float
+    category: str
+    in_stock: bool
+    rating: float
+
+
+def main(input_data: Input) -> Output:
+    """Look up a product by ID and return its details.
+
+    Args:
+        input_data: Input containing the product ID.
+
+    Returns:
+        Output with product details.
+
+    Raises:
+        ValueError: If the product ID is not found.
+    """
+    product = CATALOG.get(input_data.product_id)
+    if product is None:
+        raise ValueError(f"Product '{input_data.product_id}' not found")
+
+    return Output(
+        name=str(product["name"]),
+        price=float(product["price"]),  # type: ignore[arg-type]
+        category=str(product["category"]),
+        in_stock=bool(product["in_stock"]),
+        rating=float(product["rating"]),  # type: ignore[arg-type]
+    )

--- a/packages/uipath/samples/list_target_output_key_test/pyproject.toml
+++ b/packages/uipath/samples/list_target_output_key_test/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "list-target-output-key-test"
+version = "0.1.0"
+description = "Sample agent demonstrating list targetOutputKey evaluation"
+authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
+requires-python = ">=3.11"
+dependencies = [
+  "uipath"
+]
+
+[tool.uv.sources]
+uipath = { path = "../..", editable = true }

--- a/packages/uipath/samples/list_target_output_key_test/uipath.json
+++ b/packages/uipath/samples/list_target_output_key_test/uipath.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
+  "runtimeOptions": {
+    "isConversational": false
+  },
+  "packOptions": {
+    "fileExtensionsIncluded": [],
+    "filesIncluded": [],
+    "filesExcluded": [],
+    "directoriesExcluded": [],
+    "includeUvLock": true
+  },
+  "functions": {
+    "main": "main.py:main"
+  },
+  "agents": {}
+}

--- a/packages/uipath/samples/multi-output-agent/evaluations/eval-sets/list-keys.json
+++ b/packages/uipath/samples/multi-output-agent/evaluations/eval-sets/list-keys.json
@@ -1,0 +1,51 @@
+{
+  "version": "1.0",
+  "id": "list-keys-eval-set",
+  "name": "List Target Output Key Tests",
+  "evaluatorRefs": [
+    "list-keys-exact-match"
+  ],
+  "evaluations": [
+    {
+      "id": "list-keys-basic",
+      "name": "Check multiple keys - order completed",
+      "inputs": {
+        "customer_name": "John Doe",
+        "items": [
+          {"name": "Widget", "quantity": 2, "price": 9.99},
+          {"name": "Gadget", "quantity": 1, "price": 24.99}
+        ]
+      },
+      "evaluationCriterias": {
+        "list-keys-exact-match": {
+          "expectedOutput": {
+            "summary": {
+              "status": "completed",
+              "total": 44.97
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "list-keys-mismatch",
+      "name": "Check multiple keys - wrong total (should fail)",
+      "inputs": {
+        "customer_name": "Jane Smith",
+        "items": [
+          {"name": "Book", "quantity": 1, "price": 15.0}
+        ]
+      },
+      "evaluationCriterias": {
+        "list-keys-exact-match": {
+          "expectedOutput": {
+            "summary": {
+              "status": "completed",
+              "total": 999.0
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/uipath/samples/multi-output-agent/evaluations/evaluators/list-keys-exact-match.json
+++ b/packages/uipath/samples/multi-output-agent/evaluations/evaluators/list-keys-exact-match.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "id": "list-keys-exact-match",
+  "description": "Exact match on multiple output keys at once (summary.status and summary.total)",
+  "evaluatorTypeId": "uipath-exact-match",
+  "evaluatorConfig": {
+    "name": "ListKeysExactMatch",
+    "targetOutputKey": ["summary.status", "summary.total"]
+  }
+}

--- a/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
@@ -137,6 +137,13 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
         key = self.evaluator_config.target_output_key
 
         if isinstance(key, list):
+            if not isinstance(agent_execution.agent_output, dict):
+                raise UiPathEvaluationError(
+                    code="INVALID_ACTUAL_OUTPUT",
+                    title="When target output keys are specified, actual output must be a dictionary",
+                    detail=f"Got {type(agent_execution.agent_output).__name__}",
+                    category=UiPathEvaluationErrorCategory.USER,
+                )
             try:
                 list_result: dict[str, Any] = {
                     k: resolve_output_path(agent_execution.agent_output, k) for k in key
@@ -181,60 +188,67 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
             category=UiPathEvaluationErrorCategory.SYSTEM,
         )
 
+    def _resolve_list_key_expected(
+        self, expected_output: Any, keys: list[str]
+    ) -> dict[str, Any]:
+        """Parse and resolve expected output for a list of keys."""
+        if isinstance(expected_output, str):
+            try:
+                expected_output = json.loads(expected_output)
+            except json.JSONDecodeError as e:
+                raise UiPathEvaluationError(
+                    code="INVALID_EXPECTED_OUTPUT",
+                    title="When target output keys are specified, expected output must be a dictionary or a valid JSON string",
+                    detail=f"Error: {e}",
+                    category=UiPathEvaluationErrorCategory.USER,
+                ) from e
+        if not isinstance(expected_output, dict):
+            raise UiPathEvaluationError(
+                code="INVALID_EXPECTED_OUTPUT",
+                title="When target output keys are specified, expected output must be a dictionary",
+                detail=f"Got {type(expected_output).__name__}",
+                category=UiPathEvaluationErrorCategory.USER,
+            )
+        try:
+            return {k: resolve_output_path(expected_output, k) for k in keys}
+        except (KeyError, IndexError, TypeError) as e:
+            raise UiPathEvaluationError(
+                code="TARGET_OUTPUT_KEY_NOT_FOUND",
+                title="One or more target output keys not found in expected output",
+                detail=f"Error: {e}",
+                category=UiPathEvaluationErrorCategory.USER,
+            ) from e
+
+    def _resolve_scalar_key_expected(self, expected_output: Any, key: str) -> Any:
+        """Parse and resolve expected output for a single key."""
+        if isinstance(expected_output, str):
+            try:
+                expected_output = json.loads(expected_output)
+            except json.JSONDecodeError as e:
+                raise UiPathEvaluationError(
+                    code="INVALID_EXPECTED_OUTPUT",
+                    title="When target output key is not '*', expected output must be a dictionary or a valid JSON string",
+                    detail=f"Error: {e}",
+                    category=UiPathEvaluationErrorCategory.USER,
+                ) from e
+        try:
+            return resolve_output_path(expected_output, key)
+        except (KeyError, IndexError, TypeError) as e:
+            raise UiPathEvaluationError(
+                code="TARGET_OUTPUT_KEY_NOT_FOUND",
+                title="Target output key not found in expected output",
+                detail=f"Error: {e}",
+                category=UiPathEvaluationErrorCategory.USER,
+            ) from e
+
     def _get_expected_output(self, evaluation_criteria: T) -> Any:
         """Load the expected output from the evaluation criteria."""
         expected_output = self._get_full_expected_output(evaluation_criteria)
         key = self.evaluator_config.target_output_key
-
         if isinstance(key, list):
-            if isinstance(expected_output, str):
-                try:
-                    expected_output = json.loads(expected_output)
-                except json.JSONDecodeError as e:
-                    raise UiPathEvaluationError(
-                        code="INVALID_EXPECTED_OUTPUT",
-                        title="When target output keys are specified, expected output must be a dictionary or a valid JSON string",
-                        detail=f"Error: {e}",
-                        category=UiPathEvaluationErrorCategory.USER,
-                    ) from e
-            if not isinstance(expected_output, dict):
-                raise UiPathEvaluationError(
-                    code="INVALID_EXPECTED_OUTPUT",
-                    title="When target output keys are specified, expected output must be a dictionary",
-                    detail=f"Got {type(expected_output).__name__}",
-                    category=UiPathEvaluationErrorCategory.USER,
-                )
-            try:
-                expected_output = {
-                    k: resolve_output_path(expected_output, k) for k in key
-                }
-            except (KeyError, IndexError, TypeError) as e:
-                raise UiPathEvaluationError(
-                    code="TARGET_OUTPUT_KEY_NOT_FOUND",
-                    title="One or more target output keys not found in expected output",
-                    detail=f"Error: {e}",
-                    category=UiPathEvaluationErrorCategory.USER,
-                ) from e
+            expected_output = self._resolve_list_key_expected(expected_output, key)
         elif key != "*":
-            if isinstance(expected_output, str):
-                try:
-                    expected_output = json.loads(expected_output)
-                except json.JSONDecodeError as e:
-                    raise UiPathEvaluationError(
-                        code="INVALID_EXPECTED_OUTPUT",
-                        title="When target output key is not '*', expected output must be a dictionary or a valid JSON string",
-                        detail=f"Error: {e}",
-                        category=UiPathEvaluationErrorCategory.USER,
-                    ) from e
-            try:
-                expected_output = resolve_output_path(expected_output, key)
-            except (KeyError, IndexError, TypeError) as e:
-                raise UiPathEvaluationError(
-                    code="TARGET_OUTPUT_KEY_NOT_FOUND",
-                    title="Target output key not found in expected output",
-                    detail=f"Error: {e}",
-                    category=UiPathEvaluationErrorCategory.USER,
-                ) from e
+            expected_output = self._resolve_scalar_key_expected(expected_output, key)
         return self._normalize_numbers(expected_output)
 
     async def validate_and_evaluate_criteria(

--- a/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
@@ -86,8 +86,8 @@ class OutputEvaluatorConfig(BaseEvaluatorConfig[T]):
     specific output evaluation criteria types while maintaining type safety.
     """
 
-    target_output_key: str = Field(
-        default="*", description="Key to extract output from agent execution"
+    target_output_key: str | list[str] = Field(
+        default="*", description="Key or list of keys to extract output from agent execution"
     )
     line_by_line_evaluator: bool = Field(
         default=False,
@@ -133,12 +133,21 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
         If the output is a job attachment URI, downloads the attachment
         and returns its content as a string.
         """
-        if self.evaluator_config.target_output_key != "*":
+        key = self.evaluator_config.target_output_key
+
+        if isinstance(key, list):
             try:
-                result = resolve_output_path(
-                    agent_execution.agent_output,
-                    self.evaluator_config.target_output_key,
-                )
+                result = {k: resolve_output_path(agent_execution.agent_output, k) for k in key}
+            except (KeyError, IndexError, TypeError) as e:
+                raise UiPathEvaluationError(
+                    code="TARGET_OUTPUT_KEY_NOT_FOUND",
+                    title="One or more target output keys not found in actual output",
+                    detail=f"Error: {e}",
+                    category=UiPathEvaluationErrorCategory.USER,
+                ) from e
+        elif key != "*":
+            try:
+                result = resolve_output_path(agent_execution.agent_output, key)
             except (KeyError, IndexError, TypeError) as e:
                 raise UiPathEvaluationError(
                     code="TARGET_OUTPUT_KEY_NOT_FOUND",
@@ -149,7 +158,6 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
         else:
             result = agent_execution.agent_output
 
-        # Check if result is a job attachment URI and download if so
         if is_job_attachment_uri(result):
             attachment_id = extract_attachment_id(result)
             result = download_attachment_as_string(attachment_id)
@@ -168,7 +176,29 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
     def _get_expected_output(self, evaluation_criteria: T) -> Any:
         """Load the expected output from the evaluation criteria."""
         expected_output = self._get_full_expected_output(evaluation_criteria)
-        if self.evaluator_config.target_output_key != "*":
+        key = self.evaluator_config.target_output_key
+
+        if isinstance(key, list):
+            if isinstance(expected_output, str):
+                try:
+                    expected_output = json.loads(expected_output)
+                except json.JSONDecodeError as e:
+                    raise UiPathEvaluationError(
+                        code="INVALID_EXPECTED_OUTPUT",
+                        title="When target output keys are specified, expected output must be a dictionary or a valid JSON string",
+                        detail=f"Error: {e}",
+                        category=UiPathEvaluationErrorCategory.USER,
+                    ) from e
+            try:
+                expected_output = {k: resolve_output_path(expected_output, k) for k in key}
+            except (KeyError, IndexError, TypeError) as e:
+                raise UiPathEvaluationError(
+                    code="TARGET_OUTPUT_KEY_NOT_FOUND",
+                    title="One or more target output keys not found in expected output",
+                    detail=f"Error: {e}",
+                    category=UiPathEvaluationErrorCategory.USER,
+                ) from e
+        elif key != "*":
             if isinstance(expected_output, str):
                 try:
                     expected_output = json.loads(expected_output)
@@ -180,10 +210,7 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                         category=UiPathEvaluationErrorCategory.USER,
                     ) from e
             try:
-                expected_output = resolve_output_path(
-                    expected_output,
-                    self.evaluator_config.target_output_key,
-                )
+                expected_output = resolve_output_path(expected_output, key)
             except (KeyError, IndexError, TypeError) as e:
                 raise UiPathEvaluationError(
                     code="TARGET_OUTPUT_KEY_NOT_FOUND",
@@ -225,7 +252,9 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
         validated_criteria = self.validate_evaluation_criteria(evaluation_criteria)
 
         # Check if line-by-line evaluation is enabled
-        if not self.evaluator_config.line_by_line_evaluator:
+        if not self.evaluator_config.line_by_line_evaluator or isinstance(
+            self.evaluator_config.target_output_key, list
+        ):
             # Standard evaluation
             return await self.evaluate(agent_execution, validated_criteria)
 
@@ -248,51 +277,36 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
         """
         from .line_by_line_utils import build_line_by_line_result, evaluate_lines
 
-        # Get the full actual and expected outputs before splitting
+        key_str = self.evaluator_config.target_output_key if isinstance(self.evaluator_config.target_output_key, str) else "*"
+
         actual_output = self._get_actual_output(agent_execution)
         expected_output = self._get_expected_output(evaluation_criteria)
 
-        # Split into lines using utility function
-        actual_lines = split_into_lines(
-            actual_output,
-            self.evaluator_config.line_delimiter,
-            self.evaluator_config.target_output_key,
-        )
-        expected_lines = split_into_lines(
-            expected_output,
-            self.evaluator_config.line_delimiter,
-            self.evaluator_config.target_output_key,
-        )
+        actual_lines = split_into_lines(actual_output, self.evaluator_config.line_delimiter, key_str)
+        expected_lines = split_into_lines(expected_output, self.evaluator_config.line_delimiter, key_str)
 
-        # Store original agent execution data
         original_agent_output = agent_execution.agent_output
 
-        # Create function to build line criteria
         def create_line_criteria(expected_line: str) -> Any:
             from .line_by_line_utils import wrap_line_in_structure
 
-            line_expected_output = wrap_line_in_structure(
-                expected_line, self.evaluator_config.target_output_key
-            )
+            line_expected_output = wrap_line_in_structure(expected_line, key_str)
             line_criteria_dict = evaluation_criteria.model_dump()
             if "expected_output" in line_criteria_dict:
                 line_criteria_dict["expected_output"] = line_expected_output
             return type(evaluation_criteria).model_validate(line_criteria_dict)
 
-        # Evaluate all lines using utility function
         line_details, line_results = await evaluate_lines(
             actual_lines=actual_lines,
             expected_lines=expected_lines,
-            target_output_key=self.evaluator_config.target_output_key,
+            target_output_key=key_str,
             agent_execution=agent_execution,
             evaluate_fn=self.evaluate,
             create_line_criteria_fn=create_line_criteria,
         )
 
-        # Restore original agent output
         agent_execution.agent_output = original_agent_output
 
-        # Build and return the aggregated result using utility function
         return build_line_by_line_result(
             line_details=line_details,
             line_results=line_results,

--- a/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
@@ -137,7 +137,9 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
 
         if isinstance(key, list):
             try:
-                result = {k: resolve_output_path(agent_execution.agent_output, k) for k in key}
+                result: dict[str, Any] = {
+                    k: resolve_output_path(agent_execution.agent_output, k) for k in key
+                }
             except (KeyError, IndexError, TypeError) as e:
                 raise UiPathEvaluationError(
                     code="TARGET_OUTPUT_KEY_NOT_FOUND",
@@ -145,6 +147,11 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                     detail=f"Error: {e}",
                     category=UiPathEvaluationErrorCategory.USER,
                 ) from e
+            for k, v in result.items():
+                if is_job_attachment_uri(v):
+                    attachment_id = extract_attachment_id(v)
+                    result[k] = download_attachment_as_string(attachment_id)
+            return self._normalize_numbers(result)
         elif key != "*":
             try:
                 result = resolve_output_path(agent_execution.agent_output, key)
@@ -189,6 +196,13 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                         detail=f"Error: {e}",
                         category=UiPathEvaluationErrorCategory.USER,
                     ) from e
+            if not isinstance(expected_output, dict):
+                raise UiPathEvaluationError(
+                    code="INVALID_EXPECTED_OUTPUT",
+                    title="When target output keys are specified, expected output must be a dictionary",
+                    detail=f"Got {type(expected_output).__name__}",
+                    category=UiPathEvaluationErrorCategory.USER,
+                )
             try:
                 expected_output = {k: resolve_output_path(expected_output, k) for k in key}
             except (KeyError, IndexError, TypeError) as e:

--- a/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
@@ -87,7 +87,8 @@ class OutputEvaluatorConfig(BaseEvaluatorConfig[T]):
     """
 
     target_output_key: str | list[str] = Field(
-        default="*", description="Key or list of keys to extract output from agent execution"
+        default="*",
+        description="Key or list of keys to extract output from agent execution",
     )
     line_by_line_evaluator: bool = Field(
         default=False,
@@ -137,7 +138,7 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
 
         if isinstance(key, list):
             try:
-                result: dict[str, Any] = {
+                list_result: dict[str, Any] = {
                     k: resolve_output_path(agent_execution.agent_output, k) for k in key
                 }
             except (KeyError, IndexError, TypeError) as e:
@@ -147,11 +148,11 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                     detail=f"Error: {e}",
                     category=UiPathEvaluationErrorCategory.USER,
                 ) from e
-            for k, v in result.items():
+            for k, v in list_result.items():
                 if is_job_attachment_uri(v):
                     attachment_id = extract_attachment_id(v)
-                    result[k] = download_attachment_as_string(attachment_id)
-            return self._normalize_numbers(result)
+                    list_result[k] = download_attachment_as_string(attachment_id)
+            return self._normalize_numbers(list_result)
         elif key != "*":
             try:
                 result = resolve_output_path(agent_execution.agent_output, key)
@@ -204,7 +205,9 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                     category=UiPathEvaluationErrorCategory.USER,
                 )
             try:
-                expected_output = {k: resolve_output_path(expected_output, k) for k in key}
+                expected_output = {
+                    k: resolve_output_path(expected_output, k) for k in key
+                }
             except (KeyError, IndexError, TypeError) as e:
                 raise UiPathEvaluationError(
                     code="TARGET_OUTPUT_KEY_NOT_FOUND",
@@ -291,13 +294,21 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
         """
         from .line_by_line_utils import build_line_by_line_result, evaluate_lines
 
-        key_str = self.evaluator_config.target_output_key if isinstance(self.evaluator_config.target_output_key, str) else "*"
+        key_str = (
+            self.evaluator_config.target_output_key
+            if isinstance(self.evaluator_config.target_output_key, str)
+            else "*"
+        )
 
         actual_output = self._get_actual_output(agent_execution)
         expected_output = self._get_expected_output(evaluation_criteria)
 
-        actual_lines = split_into_lines(actual_output, self.evaluator_config.line_delimiter, key_str)
-        expected_lines = split_into_lines(expected_output, self.evaluator_config.line_delimiter, key_str)
+        actual_lines = split_into_lines(
+            actual_output, self.evaluator_config.line_delimiter, key_str
+        )
+        expected_lines = split_into_lines(
+            expected_output, self.evaluator_config.line_delimiter, key_str
+        )
 
         original_agent_output = agent_execution.agent_output
 

--- a/packages/uipath/testcases/list-target-output-key-evals/pyproject.toml
+++ b/packages/uipath/testcases/list-target-output-key-evals/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "list-target-output-key-evals"
+version = "0.0.1"
+description = "Tests for evaluating multiple output keys at once using a list targetOutputKey"
+authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
+dependencies = [
+    "uipath",
+]
+requires-python = ">=3.11"
+
+[tool.uv.sources]
+uipath = { path = "../../", editable = true }

--- a/packages/uipath/testcases/list-target-output-key-evals/run.sh
+++ b/packages/uipath/testcases/list-target-output-key-evals/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Syncing dependencies..."
+uv sync
+
+echo "Authenticating with UiPath..."
+uv run uipath auth --client-id="$CLIENT_ID" --client-secret="$CLIENT_SECRET" --base-url="$BASE_URL"
+
+echo "Running list targetOutputKey evaluations..."
+uv run uipath eval main ../../samples/list_target_output_key_test/evaluations/eval-sets/default.json --no-report --output-file default.json
+
+echo "Test completed successfully!"

--- a/packages/uipath/testcases/list-target-output-key-evals/src/assert.py
+++ b/packages/uipath/testcases/list-target-output-key-evals/src/assert.py
@@ -1,0 +1,90 @@
+"""Assertions for list-target-output-key-evals testcase.
+
+Validates that evaluating multiple output fields at once (targetOutputKey as a
+list) works correctly for both ExactMatch and JsonSimilarity evaluators.
+
+Expected outcomes
+-----------------
+- headphones-all-match  : ListKeysExactMatch=1.0, ListKeysJsonSimilarity=1.0
+- shoes-all-match       : ListKeysExactMatch=1.0, ListKeysJsonSimilarity=1.0
+- headphones-wrong-price: ListKeysExactMatch=0.0, ListKeysJsonSimilarity=1.0
+"""
+
+import json
+import os
+
+# Maps evaluationName → evaluator ID → expected score (1.0 = pass, 0.0 = fail)
+EXPECTED: dict[str, dict[str, float]] = {
+    "Headphones - all keys match": {
+        "ListKeysExactMatch": 1.0,
+        "ListKeysJsonSimilarity": 1.0,
+    },
+    "Running Shoes - all keys match": {
+        "ListKeysExactMatch": 1.0,
+        "ListKeysJsonSimilarity": 1.0,
+    },
+    "Headphones - wrong price (should fail)": {
+        "ListKeysExactMatch": 0.0,
+        "ListKeysJsonSimilarity": 1.0,
+    },
+}
+
+
+def main() -> None:
+    output_file = "default.json"
+    assert os.path.isfile(output_file), f"Output file '{output_file}' not found"
+    print(f"Found output file: {output_file}")
+
+    with open(output_file, "r", encoding="utf-8") as f:
+        output_data = json.load(f)
+
+    assert "evaluationSetResults" in output_data, "Missing 'evaluationSetResults'"
+    evaluation_results = output_data["evaluationSetResults"]
+    assert len(evaluation_results) > 0, "No evaluation results found"
+    print(f"Found {len(evaluation_results)} evaluation result(s)")
+
+    failures: list[str] = []
+
+    for eval_result in evaluation_results:
+        eval_name = eval_result.get("evaluationName", "")
+        expected_scores = EXPECTED.get(eval_name)
+
+        if expected_scores is None:
+            print(f"  [skip] '{eval_name}' not in EXPECTED map")
+            continue
+
+        print(f"\n  Validating: {eval_name}")
+
+        run_results = eval_result.get("evaluationRunResults", [])
+        assert len(run_results) > 0, f"No run results for '{eval_name}'"
+
+        for run in run_results:
+            evaluator_id = run.get("evaluatorId", run.get("evaluatorName", ""))
+            score = run.get("result", {}).get("score", None)
+
+            if evaluator_id not in expected_scores:
+                print(f"    [skip] unexpected evaluator '{evaluator_id}'")
+                continue
+
+            expected = expected_scores[evaluator_id]
+            ok = score == expected
+            status = "pass" if ok else "FAIL"
+            print(f"    {evaluator_id}: score={score} expected={expected} ({status})")
+            if not ok:
+                failures.append(
+                    f"{eval_name} / {evaluator_id}: got {score}, expected {expected}"
+                )
+
+    print(f"\n{'=' * 60}")
+    if failures:
+        for f in failures:
+            print(f"  FAIL: {f}")
+        print(f"{'=' * 60}")
+        assert False, f"{len(failures)} assertion(s) failed"
+
+    print("  All assertions passed!")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/uipath/testcases/list-target-output-key-evals/uipath.json
+++ b/packages/uipath/testcases/list-target-output-key-evals/uipath.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "main": "../../samples/list_target_output_key_test/main.py:main"
+  }
+}

--- a/packages/uipath/tests/evaluators/test_documentation_examples.py
+++ b/packages/uipath/tests/evaluators/test_documentation_examples.py
@@ -340,6 +340,52 @@ class TestExactMatchExamples:
 
         assert result.score == 1.0
 
+    @pytest.mark.asyncio
+    async def test_list_target_output_key(self) -> None:
+        """Test evaluating multiple output fields at once using a list of keys.
+
+        Mirrors the multi-output-agent sample (list-keys-exact-match evaluator).
+        """
+        # Agent returns a rich nested output; we only care about two summary fields.
+        agent_execution = AgentExecution(
+            agent_input={"customer_name": "John Doe", "items": []},
+            agent_output={
+                "order_id": "ORD-001",
+                "summary": {"status": "completed", "total": 44.97, "item_count": 3},
+                "tags": ["priority", "express"],
+            },
+            agent_trace=[],
+        )
+
+        evaluator = TypeAdapter(ExactMatchEvaluator).validate_python(
+            dict(
+                id="list-keys-exact-match",
+                evaluatorConfig={
+                    "name": "ListKeysExactMatch",
+                    # Pass a list to assert multiple fields in a single evaluator run.
+                    "target_output_key": ["summary.status", "summary.total"],
+                },
+            )
+        )
+
+        # Both keys match → score 1.0
+        result = await evaluator.validate_and_evaluate_criteria(
+            agent_execution=agent_execution,
+            evaluation_criteria={
+                "expected_output": {"summary": {"status": "completed", "total": 44.97}}
+            },
+        )
+        assert result.score == 1.0
+
+        # One key differs → score 0.0
+        result = await evaluator.validate_and_evaluate_criteria(
+            agent_execution=agent_execution,
+            evaluation_criteria={
+                "expected_output": {"summary": {"status": "completed", "total": 999.0}}
+            },
+        )
+        assert result.score == 0.0
+
 
 class TestJsonSimilarityExamples:
     """Test examples from docs/eval/json_similarity.md."""

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -447,6 +447,224 @@ class TestExactMatchEvaluator:
         assert line3_result.score == 1.0
 
 
+class TestListTargetOutputKey:
+    """Test target_output_key as a list of keys."""
+
+    @pytest.mark.asyncio
+    async def test_exact_match_list_keys_all_match(self) -> None:
+        """All listed keys match → score 1.0."""
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok", "total": 42, "extra": "ignored"},
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListKeys",
+            "target_output_key": ["status", "total"],
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"status": "ok", "total": 42}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_exact_match_list_keys_value_mismatch(self) -> None:
+        """One key's value differs → score 0.0."""
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok", "total": 99},
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListKeys",
+            "target_output_key": ["status", "total"],
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"status": "ok", "total": 42}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_exact_match_list_keys_dot_notation(self) -> None:
+        """Nested dot-notation paths inside a list of keys."""
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"order": {"status": "shipped"}, "qty": 3},
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListDotKeys",
+            "target_output_key": ["order.status", "qty"],
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"order": {"status": "shipped"}, "qty": 3}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_missing_key_in_actual_raises(self) -> None:
+        """Missing key in actual output returns an ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok"},  # 'total' is missing
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListKeys",
+            "target_output_key": ["status", "total"],
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"status": "ok", "total": 42}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_missing_key_in_expected_raises(self) -> None:
+        """Missing key in expected output returns an ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok", "total": 42},
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListKeys",
+            "target_output_key": ["status", "total"],
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={
+                "status": "ok"
+            }  # 'total' missing  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_expected_as_json_string(self) -> None:
+        """Expected output as a JSON string is parsed when key is a list."""
+        import json
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok", "total": 5},
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListKeys",
+            "target_output_key": ["status", "total"],
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output=json.dumps({"status": "ok", "total": 5})  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_invalid_json_string_expected_raises(self) -> None:
+        """Invalid JSON string for expected output returns an ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchListKeys", "target_output_key": ["status"]}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output="not valid json"  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_disables_line_by_line(self) -> None:
+        """line_by_line_evaluator=True is ignored when target_output_key is a list."""
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"a": "x", "b": "y"},
+            agent_trace=[],
+        )
+        config = {
+            "name": "ExactMatchListLbl",
+            "target_output_key": ["a", "b"],
+            "line_by_line_evaluator": True,
+        }
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        raw_criteria = {"expected_output": {"a": "x", "b": "y"}}
+        # Should not raise or split into lines; returns a plain NumericEvaluationResult
+        result = await evaluator.validate_and_evaluate_criteria(execution, raw_criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+        # No line-by-line details attached
+        assert (
+            not hasattr(result, "_line_by_line_results")
+            or result._line_by_line_results is None
+        )  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_json_similarity_list_keys_perfect_match(self) -> None:
+        """JsonSimilarityEvaluator with list keys scores 1.0 on exact match."""
+        from uipath.eval.evaluators.json_similarity_evaluator import (
+            JsonSimilarityEvaluator,
+        )
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"name": "Alice", "score": 100, "extra": "ignored"},
+            agent_trace=[],
+        )
+        config = {
+            "name": "JsonSimListKeys",
+            "target_output_key": ["name", "score"],
+        }
+        evaluator = JsonSimilarityEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"name": "Alice", "score": 100}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+
+
 class TestContainsEvaluator:
     """Test ContainsEvaluator.evaluate() method."""
 

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -671,7 +671,7 @@ class TestListTargetOutputKey:
 
         execution = AgentExecution(
             agent_input={},
-            agent_output="just a string",  # type: ignore[arg-type]
+            agent_output="just a string",  # pyright: ignore[reportArgumentType]
             agent_trace=[],
         )
         config = {"name": "ExactMatchListKeys", "target_output_key": ["status"]}
@@ -862,8 +862,8 @@ class TestListTargetOutputKey:
             def get_evaluator_id(cls) -> str:
                 return "uipath-minimal-test"
 
-            async def evaluate(self, agent_execution: Any, evaluation_criteria: Any) -> EvaluationResult:  # type: ignore[override]
-                return None  # type: ignore[return-value]
+            async def evaluate(self, agent_execution: Any, evaluation_criteria: Any) -> EvaluationResult:  # pyright: ignore[reportReturnType]
+                return None  # pyright: ignore[reportReturnType]
 
             def validate_evaluation_criteria(self, raw: Any) -> OutputEvaluationCriteria:
                 return OutputEvaluationCriteria.model_validate(raw)
@@ -875,7 +875,7 @@ class TestListTargetOutputKey:
             }
         )
         with pytest.raises(UiPathEvaluationError) as exc_info:
-            evaluator._get_full_expected_output(  # type: ignore[arg-type]
+            evaluator._get_full_expected_output(  # pyright: ignore[reportArgumentType]
                 OutputEvaluationCriteria(expected_output={})  # pyright: ignore[reportCallIssue]
             )
         assert "NOT_IMPLEMENTED" in exc_info.value.error_info.code

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -664,6 +664,222 @@ class TestListTargetOutputKey:
         assert isinstance(result, NumericEvaluationResult)
         assert result.score == 1.0
 
+    @pytest.mark.asyncio
+    async def test_list_keys_non_dict_actual_raises(self) -> None:
+        """Non-dict agent_output with list key returns ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output="just a string",  # type: ignore[arg-type]
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchListKeys", "target_output_key": ["status"]}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"status": "ok"}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_non_dict_json_expected_raises(self) -> None:
+        """Valid JSON that parses to a non-dict returns ErrorEvaluationResult."""
+        import json
+
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchListKeys", "target_output_key": ["status"]}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        # Valid JSON but not an object — triggers the isinstance(expected_output, dict) guard
+        criteria = OutputEvaluationCriteria(
+            expected_output=json.dumps("just a string")  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_list_keys_attachment_uri_downloaded(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Attachment URIs within list-key actual output values are downloaded."""
+        att_uri = "urn:uipath:cas:file:orchestrator:00000000-0000-0000-0000-000000000001"
+        mocker.patch(
+            "uipath.eval.evaluators.output_evaluator.download_attachment_as_string",
+            return_value="downloaded_content",
+        )
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"file": att_uri, "status": "ok"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchListKeys", "target_output_key": ["file", "status"]}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"file": "downloaded_content", "status": "ok"}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_scalar_key_attachment_uri_downloaded(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Attachment URI in scalar-key actual output is downloaded."""
+        att_uri = "urn:uipath:cas:file:orchestrator:00000000-0000-0000-0000-000000000002"
+        mocker.patch(
+            "uipath.eval.evaluators.output_evaluator.download_attachment_as_string",
+            return_value="file_content",
+        )
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"report": att_uri},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchScalarAtt", "target_output_key": "report"}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"report": "file_content"}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, NumericEvaluationResult)
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_scalar_key_missing_in_actual_raises(self) -> None:
+        """Missing scalar target_output_key in actual output returns ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"other": "value"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchMissingActual", "target_output_key": "missing_key"}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output={"missing_key": "val"}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_scalar_key_missing_in_expected_raises(self) -> None:
+        """Missing scalar target_output_key in expected output returns ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchMissingExpected", "target_output_key": "status"}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        # expected output dict doesn't contain the target key
+        criteria = OutputEvaluationCriteria(
+            expected_output={"other_key": "ok"}  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_scalar_key_invalid_json_expected_raises(self) -> None:
+        """Invalid JSON string for expected output with scalar key returns ErrorEvaluationResult."""
+        from uipath.eval.models.models import ErrorEvaluationResult
+
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchInvalidJson", "target_output_key": "status"}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        criteria = OutputEvaluationCriteria(
+            expected_output="not valid json"  # pyright: ignore[reportCallIssue]
+        )
+        result = await evaluator.evaluate(execution, criteria)
+        assert isinstance(result, ErrorEvaluationResult)
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_validate_and_evaluate_criteria_none_raises(self) -> None:
+        """None criteria with no default configured raises UiPathEvaluationError."""
+        execution = AgentExecution(
+            agent_input={},
+            agent_output={"status": "ok"},
+            agent_trace=[],
+        )
+        config = {"name": "ExactMatchNoCriteria"}
+        evaluator = ExactMatchEvaluator.model_validate(
+            {"evaluatorConfig": config, "id": str(uuid.uuid4())}
+        )
+        with pytest.raises(UiPathEvaluationError) as exc_info:
+            await evaluator.validate_and_evaluate_criteria(execution, None)
+        assert "MISSING_EVALUATION_CRITERIA" in exc_info.value.error_info.code
+
+    def test_base_output_evaluator_get_full_expected_output_raises(self) -> None:
+        """BaseOutputEvaluator._get_full_expected_output raises NOT_IMPLEMENTED."""
+        from uipath.eval.evaluators.output_evaluator import (
+            BaseOutputEvaluator,
+            OutputEvaluationCriteria,
+            OutputEvaluatorConfig,
+        )
+        from uipath.eval.evaluators.base_evaluator import BaseEvaluatorJustification
+        from uipath.eval.models import EvaluationResult
+
+        class _MinimalEvaluator(
+            BaseOutputEvaluator[
+                OutputEvaluationCriteria,
+                OutputEvaluatorConfig[OutputEvaluationCriteria],
+                BaseEvaluatorJustification,
+            ]
+        ):
+            @classmethod
+            def get_evaluator_id(cls) -> str:
+                return "uipath-minimal-test"
+
+            async def evaluate(self, agent_execution: Any, evaluation_criteria: Any) -> EvaluationResult:  # type: ignore[override]
+                return None  # type: ignore[return-value]
+
+            def validate_evaluation_criteria(self, raw: Any) -> OutputEvaluationCriteria:
+                return OutputEvaluationCriteria.model_validate(raw)
+
+        evaluator = _MinimalEvaluator.model_validate(
+            {
+                "evaluatorConfig": {"name": "minimal"},
+                "id": str(uuid.uuid4()),
+            }
+        )
+        with pytest.raises(UiPathEvaluationError) as exc_info:
+            evaluator._get_full_expected_output(  # type: ignore[arg-type]
+                OutputEvaluationCriteria(expected_output={})  # pyright: ignore[reportCallIssue]
+            )
+        assert "NOT_IMPLEMENTED" in exc_info.value.error_info.code
+
 
 class TestContainsEvaluator:
     """Test ContainsEvaluator.evaluate() method."""

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -843,12 +843,12 @@ class TestListTargetOutputKey:
 
     def test_base_output_evaluator_get_full_expected_output_raises(self) -> None:
         """BaseOutputEvaluator._get_full_expected_output raises NOT_IMPLEMENTED."""
+        from uipath.eval.evaluators.base_evaluator import BaseEvaluatorJustification
         from uipath.eval.evaluators.output_evaluator import (
             BaseOutputEvaluator,
             OutputEvaluationCriteria,
             OutputEvaluatorConfig,
         )
-        from uipath.eval.evaluators.base_evaluator import BaseEvaluatorJustification
         from uipath.eval.models import EvaluationResult
 
         class _MinimalEvaluator(

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -636,7 +636,7 @@ class TestListTargetOutputKey:
         assert (
             not hasattr(result, "_line_by_line_results")
             or result._line_by_line_results is None
-        )  # type: ignore[attr-defined]
+        )
 
     @pytest.mark.asyncio
     async def test_json_similarity_list_keys_perfect_match(self) -> None:

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -862,8 +862,8 @@ class TestListTargetOutputKey:
             def get_evaluator_id(cls) -> str:
                 return "uipath-minimal-test"
 
-            async def evaluate(self, agent_execution: Any, evaluation_criteria: Any) -> EvaluationResult:  # pyright: ignore[reportReturnType]
-                return None  # pyright: ignore[reportReturnType]
+            async def evaluate(self, agent_execution: Any, evaluation_criteria: Any) -> EvaluationResult:
+                return None  # type: ignore[return-value]
 
             def validate_evaluation_criteria(self, raw: Any) -> OutputEvaluationCriteria:
                 return OutputEvaluationCriteria.model_validate(raw)

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -714,7 +714,9 @@ class TestListTargetOutputKey:
         self, mocker: MockerFixture
     ) -> None:
         """Attachment URIs within list-key actual output values are downloaded."""
-        att_uri = "urn:uipath:cas:file:orchestrator:00000000-0000-0000-0000-000000000001"
+        att_uri = (
+            "urn:uipath:cas:file:orchestrator:00000000-0000-0000-0000-000000000001"
+        )
         mocker.patch(
             "uipath.eval.evaluators.output_evaluator.download_attachment_as_string",
             return_value="downloaded_content",
@@ -740,7 +742,9 @@ class TestListTargetOutputKey:
         self, mocker: MockerFixture
     ) -> None:
         """Attachment URI in scalar-key actual output is downloaded."""
-        att_uri = "urn:uipath:cas:file:orchestrator:00000000-0000-0000-0000-000000000002"
+        att_uri = (
+            "urn:uipath:cas:file:orchestrator:00000000-0000-0000-0000-000000000002"
+        )
         mocker.patch(
             "uipath.eval.evaluators.output_evaluator.download_attachment_as_string",
             return_value="file_content",
@@ -862,10 +866,14 @@ class TestListTargetOutputKey:
             def get_evaluator_id(cls) -> str:
                 return "uipath-minimal-test"
 
-            async def evaluate(self, agent_execution: Any, evaluation_criteria: Any) -> EvaluationResult:
+            async def evaluate(
+                self, agent_execution: Any, evaluation_criteria: Any
+            ) -> EvaluationResult:
                 return None  # type: ignore[return-value]
 
-            def validate_evaluation_criteria(self, raw: Any) -> OutputEvaluationCriteria:
+            def validate_evaluation_criteria(
+                self, raw: Any
+            ) -> OutputEvaluationCriteria:
                 return OutputEvaluationCriteria.model_validate(raw)
 
         evaluator = _MinimalEvaluator.model_validate(

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.77"
+version = "2.10.78"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

- Extends `target_output_key` in `OutputEvaluatorConfig` from `str` to `str | list[str]`, allowing multiple output fields to be asserted in a single evaluator config
- When a list is provided, both actual and expected outputs are resolved to a `dict` of the specified keys before comparison
- Line-by-line evaluation is automatically disabled when `target_output_key` is a list
- Attachment URIs within list-key results are downloaded per-value, matching single-key behavior
- Expected output must be a dict (or valid JSON object string) when `target_output_key` is a list — non-dict types raise `INVALID_EXPECTED_OUTPUT`
- Actual output must be a dict when `target_output_key` is a list — non-dict types raise `INVALID_ACTUAL_OUTPUT`
- `_get_expected_output` refactored into helper methods to bring cognitive complexity within the 15-point limit

## Changes

- `output_evaluator.py` — core feature + guards + cognitive complexity refactor
- New sample: `samples/list_target_output_key_test/` — product-lookup agent with ExactMatch + JsonSimilarity evaluators using list keys
- New testcase: `testcases/list-target-output-key-evals/` — e2e CI testcase with assert script
- Tests: `test_evaluator_methods.py` (18 new tests, 100% coverage on `output_evaluator.py`), `test_documentation_examples.py` (1 new doc example test)

## Test plan

- [ ] Run unit tests: `cd packages/uipath && uv run pytest tests/evaluators/test_evaluator_methods.py::TestListTargetOutputKey tests/evaluators/test_documentation_examples.py::TestExactMatchExamples::test_list_target_output_key --no-cov`
- [ ] Run eval locally: `cd packages/uipath/testcases/list-target-output-key-evals && uv run uipath eval main ../../samples/list_target_output_key_test/evaluations/eval-sets/default.json --no-report`
- [ ] CI integration tests will auto-discover and run `list-target-output-key-evals` testcase

🤖 Generated with [Claude Code](https://claude.com/claude-code)