### PR TITLE
feat(resource-catalog): add ENTITY to ResourceType enum

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.61"
+version = "0.1.62"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/resource_catalog/resource_catalog.py
+++ b/packages/uipath-platform/src/uipath/platform/resource_catalog/resource_catalog.py
@@ -22,6 +22,7 @@ class ResourceType(str, Enum):
     CONNECTOR = "connector"
     MCP_SERVER = "mcpserver"
     QUEUE = "queue"
+    ENTITY = "entity"
 
     @classmethod
     def from_string(cls, value: str) -> "ResourceType":

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-06T13:38:31.678016Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.61"
+version = "0.1.62"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/tests/cli/test_create_resources.py
+++ b/packages/uipath/tests/cli/test_create_resources.py
@@ -270,8 +270,39 @@ async def test_unsupported_virtual_kind_is_skipped_with_warning(
     bindings_file, mock_uipath, studio_client
 ):
     """Bindings whose kind the virtual endpoint cannot materialize (e.g.
-    'entity', 'choiceSet', 'webhook') should be skipped with a warning and
+    'choiceSet', 'webhook') should be skipped with a warning and
     never reach create_virtual_resource."""
+    choiceset_binding = {
+        "resource": "choiceSet",
+        "key": "live.good.choiceset.Shared",
+        "value": {
+            "name": {
+                "defaultValue": "live.good.choiceset",
+                "isExpression": False,
+                "displayName": "Name",
+            },
+            "folderPath": {
+                "defaultValue": "Shared",
+                "isExpression": False,
+                "displayName": "Folder Path",
+            },
+        },
+        "metadata": None,
+    }
+    bindings_file(_make_bindings([choiceset_binding]))
+
+    await _run_create_resources(studio_client)
+
+    mock_uipath.resource_catalog.list_by_type_async.assert_not_called()
+    studio_client.create_virtual_resource.assert_not_awaited()
+    studio_client.create_referenced_resource.assert_not_awaited()
+
+
+async def test_entity_binding_catalog_hit_creates_reference(
+    bindings_file, mock_uipath, studio_client
+):
+    """Entity bindings should go through the resource catalog lookup.
+    When found, a referenced resource should be created."""
     entity_binding = {
         "resource": "entity",
         "key": "live.good.entity.Shared",
@@ -290,12 +321,18 @@ async def test_unsupported_virtual_kind_is_skipped_with_warning(
         "metadata": None,
     }
     bindings_file(_make_bindings([entity_binding]))
+    mock_uipath.resource_catalog.list_by_type_async.return_value = _AsyncIterator(
+        [_found_resource(resource_type="entity", resource_sub_type="Native")]
+    )
+    studio_client.create_referenced_resource.return_value = SimpleNamespace(
+        status=Status.ADDED
+    )
 
     await _run_create_resources(studio_client)
 
-    mock_uipath.resource_catalog.list_by_type_async.assert_not_called()
+    mock_uipath.resource_catalog.list_by_type_async.assert_called_once()
+    studio_client.create_referenced_resource.assert_awaited_once()
     studio_client.create_virtual_resource.assert_not_awaited()
-    studio_client.create_referenced_resource.assert_not_awaited()
 
 
 async def test_folder_not_found_falls_back_to_virtual(

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-06T13:38:31.678016Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.61"
+version = "0.1.62"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds `ENTITY = "entity"` to the `ResourceType` enum in `resource_catalog.py`
- Enables entity bindings to go through the resource catalog lookup during `uipath push`
- When an entity is found in the catalog, it is created as a **referenced resource** instead of being skipped or falling back to a virtual resource
- Updates existing test to use `choiceSet` as the unsupported kind example (instead of `entity`)
- Adds new test `test_entity_binding_catalog_hit_creates_reference` to verify entities are properly referenced

## Context
Entity bindings in `bindings.json` were previously skipped during push because the `ResourceType` enum had no `ENTITY` member. This caused `_find_in_resource_catalog` to short-circuit (returning `None`), and since `entity` is also not in the `supported_virtual_kinds` set, the binding was silently skipped.

With this change, folder-level entities declared in bindings can be properly resolved and linked into Studio Web solutions as referenced resources.

## Test plan
- [x] Verified locally: `uip codedagent push` with entity binding creates a referenced resource (`kind = Entity, type = Native`)
- [ ] Existing tests updated to reflect new behavior
- [ ] New test added for entity catalog hit → reference creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)