### PR TITLE
docs(core): correct project-type marker and I/O typing for functions/…

### DIFF
--- a/packages/uipath/docs/core/agents.md
+++ b/packages/uipath/docs/core/agents.md
@@ -91,22 +91,24 @@ The example below uses LangChain. Swap `uipath-langchain` for the framework of y
 
 ```
 my-agent/
-├── main.py            # agent logic
+├── main.py            # agent graph
+├── langgraph.json     # graph entry points (framework-specific)
 ├── pyproject.toml     # project metadata and dependencies
-├── uipath.json        # entry point declarations
 ├── entry-points.json  # generated — I/O JSON Schema
 └── bindings.json      # generated — resource binding overrides
 ```
 
-### `uipath.json`
+### `langgraph.json`
 
 ```json
 {
-  "agents": {
-    "agent": "main.py:agent"
+  "graphs": {
+    "agent": "./main.py:graph"
   }
 }
 ```
+
+Declares the agent's graph entry points. The filename is framework-specific — `langgraph.json` for LangChain/LangGraph, `llamaindex.json` for LlamaIndex, and so on. Its presence, together with the framework dependency below, is what marks the project as a coded agent.
 
 ### `pyproject.toml`
 
@@ -120,7 +122,7 @@ requires-python = ">=3.11"
 dependencies = ["uipath>=2.0", "uipath-langchain>=2.0"]
 ```
 
-Standard project metadata and dependencies. The `agents` map in `uipath.json` (above) is what marks the project as a coded agent — `pyproject.toml` needs no UiPath-specific entries.
+Standard metadata plus the framework dependency (`uipath-langchain` here). The framework graph file and this dependency identify the project as a coded agent — `pyproject.toml` needs no UiPath-specific entries, and `uipath.json` carries no agent entry.
 
 ---
 

--- a/packages/uipath/docs/core/agents.md
+++ b/packages/uipath/docs/core/agents.md
@@ -118,18 +118,15 @@ description = "..."
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.11"
 dependencies = ["uipath>=2.0", "uipath-langchain>=2.0"]
-
-[tool.uipath]
-type = "agent"
 ```
 
-`[tool.uipath] type = "agent"` is required — it identifies the project as an agent to the runtime and packaging tools.
+Standard project metadata and dependencies. The `agents` map in `uipath.json` (above) is what marks the project as a coded agent — `pyproject.toml` needs no UiPath-specific entries.
 
 ---
 
 ## Input & Output
 
-Define `Input` and `Output` as Python dataclasses, the same way as [coded functions](./functions.md#input--output):
+Define `Input` and `Output` the same way as [coded functions](./functions.md#input--output) — a stdlib `@dataclass`, a pydantic `BaseModel`, or `pydantic.dataclasses.dataclass`:
 
 ```python
 from dataclasses import dataclass

--- a/packages/uipath/docs/core/functions.md
+++ b/packages/uipath/docs/core/functions.md
@@ -119,14 +119,14 @@ Standard project metadata and dependencies. The `functions` map in `uipath.json`
 | `bindings.json` | Resource binding overrides (assets, connections, buckets) for local development |
 
 /// warning
-`uipath init` executes `main.py` to derive the I/O schema. Re-run it after every change to your `Input` or `Output` models.
+`uipath init` executes your entrypoint Python file(s) (as declared in `uipath.json`, e.g., `main.py`) to derive the I/O schema. Re-run it after every change to your `Input` or `Output` models.
 ///
 
 ---
 
 ## Input & Output
 
-Define `Input` and `Output` as typed Python — a stdlib `@dataclass`, a pydantic `BaseModel`, or `pydantic.dataclasses.dataclass`. The runtime validates against these at invocation time and exports them as JSON Schema for Maestro variable binding. The entry point can be a sync `def` or an `async def` — both are supported.
+Define `Input` and `Output` as typed Python — a stdlib `@dataclass`, a pydantic `BaseModel`, or `pydantic.dataclasses.dataclass`. The runtime uses these type hints to parse the invocation payload and exports them as JSON Schema for Maestro variable binding. The entry point can be a sync `def` or an `async def` — both are supported.
 
 ```python
 from dataclasses import dataclass, field

--- a/packages/uipath/docs/core/functions.md
+++ b/packages/uipath/docs/core/functions.md
@@ -107,29 +107,26 @@ description = "..."
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.11"
 dependencies = ["uipath>=2.0"]
-
-[tool.uipath]
-type = "function"
 ```
 
-`[tool.uipath] type = "function"` is required — it identifies the project as a function to the runtime and packaging tools.
+Standard project metadata and dependencies. The `functions` map in `uipath.json` (above) is what marks the project as a coded function — `pyproject.toml` needs no UiPath-specific entries.
 
 ### Generated files
 
 | File | Purpose |
 |------|---------|
-| `entry-points.json` | Input/output JSON Schema derived from your dataclasses — used by Maestro for variable binding |
+| `entry-points.json` | Input/output JSON Schema derived from your `Input`/`Output` models — used by Maestro for variable binding |
 | `bindings.json` | Resource binding overrides (assets, connections, buckets) for local development |
 
 /// warning
-`uipath init` executes `main.py` to derive the I/O schema. Re-run it after every change to your `Input` or `Output` dataclasses.
+`uipath init` executes `main.py` to derive the I/O schema. Re-run it after every change to your `Input` or `Output` models.
 ///
 
 ---
 
 ## Input & Output
 
-Define `Input` and `Output` as Python dataclasses. The runtime validates against these at invocation time and exports them as JSON Schema for Maestro variable binding.
+Define `Input` and `Output` as typed Python — a stdlib `@dataclass`, a pydantic `BaseModel`, or `pydantic.dataclasses.dataclass`. The runtime validates against these at invocation time and exports them as JSON Schema for Maestro variable binding. The entry point can be a sync `def` or an `async def` — both are supported.
 
 ```python
 from dataclasses import dataclass, field


### PR DESCRIPTION
…agents

The functions/agents guides (added in #1675) claim a `[tool.uipath] type = "function"|"agent"` marker in pyproject.toml is required to identify the project type. It isn't — `uipath new` scaffolds pyproject without it and no sample carries it. The project type is determined by the `functions` / `agents` map in `uipath.json`. Remove the marker from the examples and the "is required" claims.

Also broaden the I/O guidance: Input/Output can be a stdlib @dataclass, a pydantic BaseModel, or pydantic.dataclasses.dataclass (the samples use pydantic), and the entry point may be sync `def` or `async def`.