### PR TITLE
chore: consolidate uipath._utils.constants into uipath-platform.common.constants

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.86"
+version = "0.1.87"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/constants.py
+++ b/packages/uipath-platform/src/uipath/platform/common/constants.py
@@ -69,6 +69,9 @@ CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSource
 DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSource"
 GOOGLE_DRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSource"
 ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSource"
+LLMV3Mini_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
+LLMV4_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
+NativeV1_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
 
 
 # Local storage

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.86"
+version = "0.1.87"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.12.1"
+version = "2.12.2"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.26, <0.6.0",
   "uipath-runtime>=0.11.5, <0.12.0",
-  "uipath-platform>=0.1.86, <0.2.0",
+  "uipath-platform>=0.1.87, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/_cli/__init__.py
+++ b/packages/uipath/src/uipath/_cli/__init__.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 from uipath._cli._utils._context import CliContext
 from uipath._utils._logs import setup_logging
-from uipath._utils.constants import DOTENV_FILE
+from uipath.platform.common.constants import DOTENV_FILE
 
 # Windows console uses codepages (e.g. cp1252) that can't encode Unicode
 # characters used by Rich spinners (Braille) and emoji output.

--- a/packages/uipath/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/packages/uipath/src/uipath/_cli/_evals/_progress_reporter.py
@@ -16,11 +16,6 @@ from rich.console import Console
 
 from uipath._cli._utils._console import ConsoleLogger
 from uipath._utils import Endpoint, RequestSpec
-from uipath._utils.constants import (
-    ENV_EVAL_BACKEND_URL,
-    ENV_TENANT_ID,
-    HEADER_INTERNAL_TENANT_ID,
-)
 from uipath.core.events import EventBus
 from uipath.eval.evaluators import (
     BaseEvaluator,
@@ -39,9 +34,12 @@ from uipath.eval.runtime.events import (
 from uipath.platform import UiPath
 from uipath.platform.common import UiPathConfig
 from uipath.platform.common.constants import (
+    ENV_EVAL_BACKEND_URL,
+    ENV_TENANT_ID,
     ENV_UIPATH_AGENT_ID,
     ENV_UIPATH_PROJECT_FILES_SOURCE,
     ENV_UIPATH_PROJECT_ID,
+    HEADER_INTERNAL_TENANT_ID,
 )
 
 logger = logging.getLogger(__name__)

--- a/packages/uipath/src/uipath/_cli/_utils/_common.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_common.py
@@ -13,9 +13,8 @@ from uipath.platform.common import (
     ResourceOverwriteParser,
     UiPathConfig,
 )
-from uipath.platform.common.constants import ENV_BASE_URL
+from uipath.platform.common.constants import ENV_BASE_URL, ENV_UIPATH_ACCESS_TOKEN
 
-from ..._utils.constants import ENV_UIPATH_ACCESS_TOKEN
 from ..models.runtime_schema import EntryPoint
 from ..spinner import Spinner
 from ._console import ConsoleLogger

--- a/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
@@ -8,18 +8,18 @@ from typing import Any, Callable, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from uipath._utils.constants import (
-    ENV_TENANT_ID,
-    HEADER_SW_LOCK_KEY,
-    HEADER_TENANT_ID,
-    PYTHON_CONFIGURATION_FILE,
-    STUDIO_METADATA_FILE,
-)
 from uipath.platform import UiPath
 from uipath.platform.common import (
     ResourceOverwrite,
     ResourceOverwriteParser,
     UiPathConfig,
+)
+from uipath.platform.common.constants import (
+    ENV_TENANT_ID,
+    HEADER_SW_LOCK_KEY,
+    HEADER_TENANT_ID,
+    PYTHON_CONFIGURATION_FILE,
+    STUDIO_METADATA_FILE,
 )
 from uipath.platform.errors import EnrichedException
 from uipath.tracing import traced

--- a/packages/uipath/src/uipath/_utils/_auth.py
+++ b/packages/uipath/src/uipath/_utils/_auth.py
@@ -4,9 +4,8 @@ from os import environ as env
 from pathlib import Path
 from typing import Optional
 
-from uipath.platform.common.constants import DOTENV_FILE
-
-from .constants import (
+from uipath.platform.common.constants import (
+    DOTENV_FILE,
     ENV_BASE_URL,
     ENV_UIPATH_ACCESS_TOKEN,
     ENV_UNATTENDED_USER_ACCESS_TOKEN,

--- a/packages/uipath/src/uipath/_utils/_request_override.py
+++ b/packages/uipath/src/uipath/_utils/_request_override.py
@@ -1,7 +1,11 @@
 from base64 import b64encode
 from typing import Optional
 
-from .constants import HEADER_FOLDER_KEY, HEADER_FOLDER_PATH, HEADER_FOLDER_PATH_ENCODED
+from uipath.platform.common.constants import (
+    HEADER_FOLDER_KEY,
+    HEADER_FOLDER_PATH,
+    HEADER_FOLDER_PATH_ENCODED,
+)
 
 
 def folder_path_header(folder_path: str) -> dict[str, str]:

--- a/packages/uipath/src/uipath/_utils/_user_agent.py
+++ b/packages/uipath/src/uipath/_utils/_user_agent.py
@@ -1,6 +1,6 @@
 import importlib
 
-from .constants import HEADER_USER_AGENT
+from uipath.platform.common.constants import HEADER_USER_AGENT
 
 
 def user_agent_value(specific_component: str) -> str:

--- a/packages/uipath/src/uipath/_utils/constants.py
+++ b/packages/uipath/src/uipath/_utils/constants.py
@@ -1,89 +1,16 @@
-# Environment variables
-DOTENV_FILE = ".env"
-ENV_BASE_URL = "UIPATH_URL"
-ENV_EVAL_BACKEND_URL = "UIPATH_EVAL_BACKEND_URL"
-ENV_UNATTENDED_USER_ACCESS_TOKEN = "UNATTENDED_USER_ACCESS_TOKEN"
-ENV_UIPATH_ACCESS_TOKEN = "UIPATH_ACCESS_TOKEN"
-ENV_FOLDER_KEY = "UIPATH_FOLDER_KEY"
-ENV_FOLDER_PATH = "UIPATH_FOLDER_PATH"
-ENV_JOB_KEY = "UIPATH_JOB_KEY"
-ENV_JOB_ID = "UIPATH_JOB_ID"
-ENV_ROBOT_KEY = "UIPATH_ROBOT_KEY"
-ENV_TENANT_ID = "UIPATH_TENANT_ID"
-ENV_TENANT_NAME = "UIPATH_TENANT_NAME"
-ENV_ORGANIZATION_ID = "UIPATH_ORGANIZATION_ID"
-ENV_TELEMETRY_ENABLED = "UIPATH_TELEMETRY_ENABLED"
-ENV_TRACING_ENABLED = "UIPATH_TRACING_ENABLED"
-ENV_UIPATH_PROJECT_ID = "UIPATH_PROJECT_ID"
-ENV_PROJECT_KEY = "PROJECT_KEY"
-ENV_PROCESS_KEY = "UIPATH_PROCESS_KEY"
-ENV_UIPATH_PROCESS_UUID = "UIPATH_PROCESS_UUID"
-ENV_UIPATH_TRACE_ID = "UIPATH_TRACE_ID"
-ENV_UIPATH_PROCESS_VERSION = "UIPATH_PROCESS_VERSION"
+"""Deprecated alias for ``uipath.platform.common.constants``.
 
-# Headers
-HEADER_AGENTHUB_CONFIG = "x-uipath-agenthub-config"
-HEADER_FOLDER_KEY = "x-uipath-folderkey"
-HEADER_FOLDER_PATH = "x-uipath-folderpath"
-HEADER_FOLDER_PATH_ENCODED = "x-uipath-folderpath-encoded"
-HEADER_INTERNAL_ACCOUNT_ID = "x-uipath-internal-accountid"
-HEADER_INTERNAL_TENANT_ID = "x-uipath-internal-tenantid"
-HEADER_JOB_KEY = "x-uipath-jobkey"
-HEADER_LLMGATEWAY_BYO_CONNECTION_ID = "x-uipath-llmgateway-byoisconnectionid"
-HEADER_PROCESS_KEY = "x-uipath-processkey"
-HEADER_SW_LOCK_KEY = "x-uipath-sw-lockkey"
-HEADER_TENANT_ID = "x-uipath-tenantid"
-HEADER_TRACE_ID = "x-uipath-traceid"
-HEADER_USER_AGENT = "x-uipath-user-agent"
+This module is kept as a backward-compatibility shim so existing imports keep
+working. New code should import from ``uipath.platform.common.constants``.
+"""
 
-# Data sources (request types)
-ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSourceRequest"
+import warnings as _warnings
+
+from uipath.platform.common.constants import *  # noqa: F401,F403
+
+_warnings.warn(
+    "uipath._utils.constants is deprecated and will be removed in a future "
+    "release; import from uipath.platform.common.constants instead.",
+    FutureWarning,
+    stacklevel=2,
 )
-CONFLUENCE_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
-)
-DROPBOX_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
-)
-GOOGLE_DRIVE_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSourceRequest"
-)
-ONEDRIVE_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
-)
-
-# Data sources
-ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSource"
-)
-CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSource"
-DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSource"
-GOOGLE_DRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSource"
-ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSource"
-
-# Preprocessing request types
-LLMV3Mini_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
-LLMV4_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
-NativeV1_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
-
-
-# Local storage
-TEMP_ATTACHMENTS_FOLDER = "uipath_attachments"
-
-# LLM models
-COMMUNITY_agents_SUFFIX = "-community-agents"
-
-# File names
-PYTHON_CONFIGURATION_FILE = "pyproject.toml"
-UIPATH_CONFIG_FILE = "uipath.json"
-UIPATH_BINDINGS_FILE = "bindings.json"
-ENTRY_POINTS_FILE = "entry-points.json"
-STUDIO_METADATA_FILE = "studio_metadata.json"
-
-
-# Folder names
-LEGACY_EVAL_FOLDER = "evals"
-EVALS_FOLDER = "evaluations"
-# Evaluators
-CUSTOM_EVALUATOR_PREFIX = "file://"

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_evaluator_utils.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_evaluator_utils.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, Optional
 
-from ..._utils.constants import COMMUNITY_agents_SUFFIX
+from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
 
 
 def clean_model_name(model: str) -> str:

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_llm_as_judge_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_llm_as_judge_evaluator.py
@@ -8,8 +8,8 @@ from pydantic import Field, field_validator
 from uipath.platform import UiPath
 from uipath.platform.chat import UiPathLlmChatService
 from uipath.platform.chat.llm_gateway import RequiredToolChoice
+from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
 
-from ..._utils.constants import COMMUNITY_agents_SUFFIX
 from .._execution_context import eval_set_run_id_context
 from .._helpers.helpers import is_empty_value
 from .._helpers.output_path import resolve_output_path

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
@@ -9,8 +9,8 @@ from pydantic import Field, field_validator
 from uipath.platform import UiPath
 from uipath.platform.chat import UiPathLlmChatService
 from uipath.platform.chat.llm_gateway import RequiredToolChoice
+from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
 
-from ..._utils.constants import COMMUNITY_agents_SUFFIX
 from .._execution_context import eval_set_run_id_context
 from .._helpers.evaluators_helpers import trace_to_str
 from .._helpers.helpers import is_empty_value

--- a/packages/uipath/src/uipath/telemetry/_track.py
+++ b/packages/uipath/src/uipath/telemetry/_track.py
@@ -9,12 +9,13 @@ from typing import Any, Callable, ClassVar, Dict, Mapping, Optional, Union
 from opentelemetry.sdk._logs import LoggingHandler
 from opentelemetry.util.types import AnyValue
 
-from .._utils.constants import (
+from uipath.platform.common.constants import (
     ENV_BASE_URL,
     ENV_ORGANIZATION_ID,
     ENV_TELEMETRY_ENABLED,
     ENV_TENANT_ID,
 )
+
 from ._constants import (
     _APP_INSIGHTS_EVENT_MARKER_ATTRIBUTE,
     _APP_NAME,

--- a/packages/uipath/tests/sdk/test_utils_constants_shim.py
+++ b/packages/uipath/tests/sdk/test_utils_constants_shim.py
@@ -1,0 +1,80 @@
+"""Regression tests for the uipath._utils.constants deprecation shim.
+
+The shim re-exports from uipath.platform.common.constants and emits a
+FutureWarning so external consumers can migrate. Internal callsites are
+already on the canonical path; these tests pin the shim's behavior so it
+keeps working for downstream code.
+"""
+
+import importlib
+import sys
+import warnings
+
+
+def _reload_shim():
+    """Force a fresh import of the shim so FutureWarning re-fires."""
+    for name in [
+        "uipath._utils.constants",
+        "uipath.platform.common.constants",
+    ]:
+        sys.modules.pop(name, None)
+    return importlib.import_module("uipath._utils.constants")
+
+
+def test_shim_emits_future_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _reload_shim()
+
+    shim_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, FutureWarning)
+        and "uipath._utils.constants" in str(w.message)
+        and "uipath.platform.common.constants" in str(w.message)
+    ]
+    assert len(shim_warnings) == 1, (
+        f"expected exactly one shim FutureWarning, got {len(shim_warnings)}: "
+        f"{[str(w.message) for w in caught]}"
+    )
+
+
+def test_shim_re_exports_canonical_symbols():
+    shim = _reload_shim()
+    canonical = importlib.import_module("uipath.platform.common.constants")
+
+    # Sample a representative set: env vars, headers, mixed-case symbols,
+    # file constants, data-source magic strings.
+    sample = [
+        "DOTENV_FILE",
+        "ENV_BASE_URL",
+        "ENV_TENANT_ID",
+        "HEADER_INTERNAL_TENANT_ID",
+        "HEADER_INTERNAL_ACCOUNT_ID",
+        "HEADER_USER_AGENT",
+        "LLMV3Mini_REQUEST",
+        "LLMV4_REQUEST",
+        "NativeV1_REQUEST",
+        "COMMUNITY_agents_SUFFIX",
+        "PYTHON_CONFIGURATION_FILE",
+        "ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST",
+    ]
+    for name in sample:
+        assert hasattr(shim, name), f"shim missing {name}"
+        assert hasattr(canonical, name), f"canonical missing {name}"
+        assert getattr(shim, name) == getattr(canonical, name), (
+            f"value drift for {name}: shim={getattr(shim, name)!r} "
+            f"canonical={getattr(canonical, name)!r}"
+        )
+
+
+def test_shim_does_not_leak_warnings_module_via_star_import():
+    """The shim binds `warnings` under a private alias to keep it out of
+    `from uipath._utils.constants import *`."""
+    _reload_shim()
+    ns: dict[str, object] = {}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        exec("from uipath._utils.constants import *", ns)
+    assert "warnings" not in ns
+    assert "_warnings" not in ns

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.12.1"
+version = "2.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.86"
+version = "0.1.87"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,4 +10,6 @@ sonar.python.coverage.reportPaths=packages/uipath/coverage.xml,packages/uipath-c
 
 sonar.exclusions=**/samples/**,**/testcases/**,**/template/**,**/_resources/**
 
+sonar.cpd.exclusions=**/__init__.py
+
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Fixes https://github.com/UiPath/uipath-python/issues/1415

## Summary

* `uipath/src/uipath/_utils/constants.py`
* `uipath-platform/src/uipath/platform/common/constants.py` 

have drifted into two near-identical modules. External packages (`uipath-llm-client-python`, `uipath-langchain-python`) import from `uipath.platform.common.constants`; internal `uipath` consumers import from `uipath._utils.constants`. A silent value drift between the two would create hard-to-debug cross-package bugs — same name, different value.

This PR consolidates onto a single source of truth in `uipath-platform`, leaving a thin shim with a deprecation warning at the old path for backward compatibility.

**Version bumps:** uipath-platform 0.1.86 → 0.1.87, uipath 2.12.1 → 2.12.2.

## Follow-ups (not in this PR)
- After enough release cycles, the shim can be deleted outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)