### PR TITLE
fix(eval): emit string justification for coded evaluators

### DIFF
--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -24,6 +24,28 @@ COMPARATOR_MAPPINGS = {
 COMMUNITY_agents_SUFFIX = "-community-agents"
 
 
+def format_explained_tool_calls(explanations: Mapping[str, str]) -> str:
+    """Render an `explained_tool_calls_*` mapping as a human-readable justification.
+
+    The score helpers produce a mapping keyed by tool name with values like
+    "Actual: X, Expected: Y, Score: Z", or a single `_result` sentinel entry
+    describing an empty/short-circuit case. This collapses either shape into a
+    single string suitable for the `justification` field surfaced to users.
+
+    Args:
+        explanations: Mapping of tool name (or `_result`) to its per-tool explanation.
+
+    Returns:
+        A human-readable justification string (empty if there is nothing to explain).
+    """
+    if not explanations:
+        return ""
+    return "; ".join(
+        value if key == "_result" else f"{key} -> {value}"
+        for key, value in explanations.items()
+    )
+
+
 def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
     """Extract the tool call names from execution spans IN ORDER.
 

--- a/packages/uipath/src/uipath/eval/evaluators/json_similarity_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/json_similarity_evaluator.py
@@ -3,6 +3,8 @@
 import math
 from typing import Any, Tuple
 
+from pydantic import computed_field
+
 from ..models import (
     AgentExecution,
     EvaluationResult,
@@ -22,6 +24,12 @@ class JsonSimilarityJustification(BaseEvaluatorJustification):
 
     matched_leaves: float
     total_leaves: float
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def justification(self) -> str:
+        """Human-readable justification derived from the matched JSON leaves."""
+        return f"Matched {self.matched_leaves} of {self.total_leaves} JSON leaf values."
 
 
 class JsonSimilarityEvaluatorConfig(OutputEvaluatorConfig[OutputEvaluationCriteria]):

--- a/packages/uipath/src/uipath/eval/evaluators/tool_call_args_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/tool_call_args_evaluator.py
@@ -1,7 +1,10 @@
 """Tool call order evaluator for validating correct sequence of tool calls."""
 
+from pydantic import computed_field
+
 from .._helpers.evaluators_helpers import (
     extract_tool_calls,
+    format_explained_tool_calls,
     tool_calls_args_score,
 )
 from ..models import AgentExecution, EvaluationResult, NumericEvaluationResult, ToolCall
@@ -33,6 +36,12 @@ class ToolCallArgsEvaluatorJustification(BaseEvaluatorJustification):
     """Justification for the tool call args evaluator."""
 
     explained_tool_calls_args: dict[str, str]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def justification(self) -> str:
+        """Human-readable justification derived from the per-tool arg matches."""
+        return format_explained_tool_calls(self.explained_tool_calls_args)
 
 
 class ToolCallArgsEvaluator(

--- a/packages/uipath/src/uipath/eval/evaluators/tool_call_count_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/tool_call_count_evaluator.py
@@ -2,8 +2,11 @@
 
 from collections import Counter
 
+from pydantic import computed_field
+
 from .._helpers.evaluators_helpers import (
     extract_tool_calls_names,
+    format_explained_tool_calls,
     tool_calls_count_score,
 )
 from ..models import AgentExecution, EvaluationResult, NumericEvaluationResult
@@ -36,6 +39,12 @@ class ToolCallCountEvaluatorJustification(BaseEvaluatorJustification):
     """Justification for the tool call count evaluator."""
 
     explained_tool_calls_count: dict[str, str]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def justification(self) -> str:
+        """Human-readable justification derived from the per-tool counts."""
+        return format_explained_tool_calls(self.explained_tool_calls_count)
 
 
 class ToolCallCountEvaluator(

--- a/packages/uipath/src/uipath/eval/evaluators/tool_call_order_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/tool_call_order_evaluator.py
@@ -1,5 +1,7 @@
 """Tool call order evaluator for validating correct sequence of tool calls."""
 
+from pydantic import computed_field
+
 from .._helpers.evaluators_helpers import (
     extract_tool_calls_names,
     tool_calls_order_score,
@@ -34,6 +36,19 @@ class ToolCallOrderEvaluatorJustification(BaseEvaluatorJustification):
     """Justification for the tool call order evaluator."""
 
     lcs: list[str]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def justification(self) -> str:
+        """Human-readable justification derived from the matched call order."""
+        if not self.lcs:
+            return (
+                "No common ordered subsequence between expected and actual tool calls."
+            )
+        return (
+            "Longest common ordered subsequence between expected and actual "
+            f"tool calls: {self.lcs}."
+        )
 
 
 class ToolCallOrderEvaluator(

--- a/packages/uipath/src/uipath/eval/evaluators/tool_call_output_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/tool_call_output_evaluator.py
@@ -1,7 +1,10 @@
 """Tool call order evaluator for validating correct sequence of tool calls."""
 
+from pydantic import computed_field
+
 from .._helpers.evaluators_helpers import (
     extract_tool_calls_outputs,
+    format_explained_tool_calls,
     tool_calls_output_score,
 )
 from ..models import (
@@ -39,6 +42,12 @@ class ToolCallOutputEvaluatorJustification(BaseEvaluatorJustification):
     """Justification for the tool call output evaluator."""
 
     explained_tool_calls_outputs: dict[str, str]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def justification(self) -> str:
+        """Human-readable justification derived from the per-tool output matches."""
+        return format_explained_tool_calls(self.explained_tool_calls_outputs)
 
 
 class ToolCallOutputEvaluator(


### PR DESCRIPTION
## Problem

Coded evaluators (tool-call count/args/order/output, json-similarity) returned a `null` `justification` in their score output, while the LLM-judge evaluators returned a populated one.

Root cause: each coded evaluator stored its explanation under a per-evaluator key (`explained_tool_calls_count`, `explained_tool_calls_args`, `explained_tool_calls_outputs`, `lcs`, `matched_leaves`/`total_leaves`) and never under a `justification` key. The downstream eval worker reads `details["justification"]`, which therefore always resolved to `null` — even though the structured detail was present.

## Fix

Add a computed `justification: str` field to each of the five coded justification models, derived from the model's existing structured detail via a shared `format_explained_tool_calls` helper. `model_dump()` now emits a string `justification` for every coded evaluator, matching `LLMJudgeJustification`, **without** changing any of the structured fields.

| Evaluator | `justification` now derived from |
|---|---|
| tool-call-count | `explained_tool_calls_count` |
| tool-call-args | `explained_tool_calls_args` |
| tool-call-output | `explained_tool_calls_outputs` |
| tool-call-order | `lcs` |
| json-similarity | `matched_leaves` / `total_leaves` |

The base `BaseEvaluatorJustification` is intentionally left untouched: adding a computed `justification` there collides with `LLMJudgeJustification`'s real `justification` field (pydantic raises `TypeError`). So the computed field lives on each coded subclass instead.

## Verification

- `pytest tests/evaluators tests/cli/eval` — all pass
- `mypy` — clean
- `ruff check` + `ruff format` — clean

## Related

Pairs with a `python-eval-worker` change that stops flattening these structured justifications, so the full object (including this `justification` string) reaches the client as `justificationObject` for per-evaluator-type rendering.