### PR TITLE
fix(evals): tolerate null evaluatorConfig in evaluator creation

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.81"
+version = "2.10.82"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/eval/evaluators/base_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/base_evaluator.py
@@ -121,6 +121,9 @@ class GenericBaseEvaluator(BaseModel, Generic[T, C, J], ABC):
             ValueError: If types cannot be determined or are inconsistent
         """
         if isinstance(values, dict):
+            # The C# layer sends evaluatorConfig: null when omitted — treat as {}
+            if values.get("evaluatorConfig", {}) is None:
+                values["evaluatorConfig"] = {}
             if "description" in values and "evaluatorConfig" in values:
                 values["evaluatorConfig"]["description"] = values.pop("description")
             if "name" in values and "evaluatorConfig" in values:

--- a/packages/uipath/tests/evaluators/test_evaluator_factory.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_factory.py
@@ -448,3 +448,44 @@ class TestEvaluatorFactoryPropertyAccess:
 
         assert evaluator.name == "UpdatedName"
         assert evaluator.description == "Updated description"
+
+
+class TestNullToleranceInEvaluatorCreation:
+    """Null evaluatorConfig must not break evaluator creation.
+
+    The C# layer (EvaluatorConfigDto) sends explicit JSON nulls for omitted fields,
+    so a payload like {"name": "x", "evaluatorConfig": null} must behave the same
+    as one with an empty config object.
+    """
+
+    def test_null_evaluator_config_with_top_level_name(self) -> None:
+        """evaluatorConfig: null with a top-level name creates the evaluator."""
+        evaluator = EvaluatorFactory.create_evaluator(
+            {
+                "version": "1.0",
+                "id": "TestExactMatch",
+                "name": "evaluator-exact-match",
+                "evaluatorTypeId": "uipath-exact-match",
+                "evaluatorConfig": None,
+            }
+        )
+
+        assert isinstance(evaluator, ExactMatchEvaluator)
+        assert evaluator.name == "evaluator-exact-match"
+        assert evaluator.evaluator_config.default_evaluation_criteria is None
+
+    def test_null_evaluator_config_with_description(self) -> None:
+        """evaluatorConfig: null alongside a top-level description is tolerated."""
+        evaluator = EvaluatorFactory.create_evaluator(
+            {
+                "version": "1.0",
+                "id": "TestToolCallCount",
+                "name": "evaluator-tool-call-count",
+                "description": "counts tool calls",
+                "evaluatorTypeId": "uipath-tool-call-count",
+                "evaluatorConfig": None,
+            }
+        )
+
+        assert isinstance(evaluator, ToolCallCountEvaluator)
+        assert evaluator.description == "counts tool calls"

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.81"
+version = "2.10.82"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Problem

The C# layer (`EvaluatorConfigDto.EvaluatorConfig` is `JsonElement?`) sends `evaluatorConfig: null` when the config is omitted. The name/description merge in `GenericBaseEvaluator.validate_model` then does:

```python
values["evaluatorConfig"]["name"] = values.pop("name")  # None["name"] -> TypeError
```

which crashes with `TypeError: 'NoneType' object does not support item assignment`. Every evaluator fails at creation time, so eval runs die with **0 evals / Failed** before any evaluation executes.

## Fix

Treat a null `evaluatorConfig` as `{}` (3 lines in `validate_model`). Config fields all have defaults (`default_evaluation_criteria` becomes `None`), so the existing criteria fallback chain — per-item criteria → config `default_evaluation_criteria` — keeps working unchanged.

## Testing

- Two regression tests in `tests/evaluators/test_evaluator_factory.py` covering `evaluatorConfig: null` with top-level `name` and `description`
- `pytest tests/evaluators/` — 92 passed
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)