### PR TITLE
feat(agent): add execution.taskSupport to AgentMcpTool

### DIFF
--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -454,6 +454,22 @@ class AgentContextResourceConfig(BaseAgentResourceConfig):
         return []
 
 
+class McpToolTaskSupport(str, CaseInsensitiveEnum):
+    """Whether an MCP tool may be invoked as a task (MCP 2025-11-25 ``execution.taskSupport``)."""
+
+    FORBIDDEN = "forbidden"
+    OPTIONAL = "optional"
+    REQUIRED = "required"
+
+
+class AgentMcpToolExecution(BaseCfg):
+    """Execution metadata for an MCP tool, mirroring the MCP tool's ``execution`` object."""
+
+    task_support: McpToolTaskSupport = Field(
+        default=McpToolTaskSupport.FORBIDDEN, alias="taskSupport"
+    )
+
+
 class AgentMcpTool(BaseCfg):
     """Agent MCP tool model."""
 
@@ -464,6 +480,9 @@ class AgentMcpTool(BaseCfg):
     argument_properties: Dict[str, AgentToolArgumentProperties] = Field(
         {}, alias="argumentProperties"
     )
+    # MCP 2025-11-25 task support, when the snapshot/server provides it. Absent for older
+    # snapshots, in which case the tool is treated as not task-augmentable.
+    execution: Optional[AgentMcpToolExecution] = Field(None, alias="execution")
 
 
 class DynamicToolsMode(str, CaseInsensitiveEnum):

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -32,6 +32,7 @@ from uipath.agent.models.agent import (
     AgentIxpExtractionResourceConfig,
     AgentIxpVsEscalationResourceConfig,
     AgentMcpResourceConfig,
+    AgentMcpTool,
     AgentMessageRole,
     AgentNumberOperator,
     AgentNumberRule,
@@ -52,6 +53,7 @@ from uipath.agent.models.agent import (
     BatchTransformWebSearchGrounding,
     CitationMode,
     DeepRagFileExtension,
+    McpToolTaskSupport,
     StandardRecipient,
     TaskTitleType,
     TextBuilderTaskTitle,
@@ -2033,6 +2035,30 @@ class TestAgentBuilderConfig:
         assert tool2.name == "tavily-extract"
         assert tool2.output_schema is not None
         assert "content" in tool2.output_schema["properties"]
+
+    def test_mcp_tool_parses_execution_task_support(self):
+        """AgentMcpTool carries the MCP execution.taskSupport signal when present."""
+        tool = AgentMcpTool.model_validate(
+            {
+                "name": "invoke-process",
+                "description": "Run a long-running process",
+                "inputSchema": {"type": "object", "properties": {}},
+                "execution": {"taskSupport": "optional"},
+            }
+        )
+        assert tool.execution is not None
+        assert tool.execution.task_support == McpToolTaskSupport.OPTIONAL
+
+    def test_mcp_tool_without_execution_defaults_to_none(self):
+        """Older snapshots without execution leave it unset (treated as not task-augmentable)."""
+        tool = AgentMcpTool.model_validate(
+            {
+                "name": "echo",
+                "description": "Echo",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        )
+        assert tool.execution is None
 
     @pytest.mark.parametrize(
         "recipient_type_int,value,expected_type",


### PR DESCRIPTION
## Add `execution.taskSupport` to `AgentMcpTool`

MCP 2025-11-25 tools carry an `execution.taskSupport` value (`forbidden` / `optional` / `required`) that says whether a tool may be invoked **as a task** (long-running, poll/await). `AgentMcpTool` didn't model it, so a **cached** agent snapshot couldn't tell a consumer (e.g. the uipath-langchain MCP client) which tools can be driven as tasks — the consumer would have to fall back to dynamic discovery.

### Change
- New `McpToolTaskSupport` enum (`forbidden` / `optional` / `required`) and `AgentMcpToolExecution` model (`task_support`, alias `taskSupport`).
- New optional `execution` field on `AgentMcpTool` (alias `execution`), mirroring the MCP tool's `execution` object so a server `Tool` maps straight into the snapshot.
- Absent on older snapshots → `execution is None` → treated as not task-augmentable (no behavior change for existing agents).

### Why
Enables the uipath-langchain MCP client to gate "call this tool as a task" on the tool's `taskSupport` in the **cached** discovery path (not just dynamic discovery), so a UiPath agent can suspend on a child UiPath job started via an MCP task.

### Testing
- `AgentMcpTool` parses `execution.taskSupport` when present; defaults to `None` when absent.
- mypy clean; full `test_agent.py` (**81**) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
