### PR TITLE
fix(auth): prevent oauth callback token injection

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.81"
+version = "2.10.82"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_auth/_auth_server.py
+++ b/packages/uipath/src/uipath/_cli/_auth/_auth_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import hmac
 import http.server
 import json
 import os
@@ -8,15 +9,6 @@ import time
 
 # Server port
 PORT = 6234
-
-
-# Custom exception for token received
-class TokenReceivedSignal(Exception):
-    """Exception raised when a token is successfully received."""
-
-    def __init__(self, token_data):
-        self.token_data = token_data
-        super().__init__("Token received successfully")
 
 
 def make_request_handler_class(
@@ -29,12 +21,60 @@ def make_request_handler_class(
             # do nothing
             pass
 
-        def do_POST(self):
-            """Handle POST requests to /set_token."""
-            if self.path == "/set_token":
+        def _is_host_allowed(self) -> bool:
+            """Reject requests whose Host header is not loopback.
+
+            Defends against DNS rebinding since the legitimate flow
+            always lands on localhost.
+            """
+            host = self.headers.get("Host", "")
+            hostname = host.rsplit(":", 1)[0]
+            return hostname in ("localhost", "127.0.0.1")
+
+        def _handle_host_error(self) -> bool:
+            """Return True if a host error was identified and handled (403)."""
+            if not self._is_host_allowed():
+                self.send_error(403, "Invalid host")
+                return True
+            return False
+
+        def _state_is_valid(self) -> bool:
+            """Validate the OAuth state supplied."""
+            received = self.headers.get("X-Auth-State", "")
+            return hmac.compare_digest(received, state)
+
+        def _handle_state_error(self) -> bool:
+            """Return True if a state error was identified and handled (403)."""
+            if not self._state_is_valid():
+                self.send_error(403, "Invalid or missing state")
+                return True
+            return False
+
+        def _read_json_body(self):
+            """Read and parse the JSON request body.
+
+            Returns the decoded object, or None if the
+            expected headers are missing or body is malformed.
+            """
+            try:
                 content_length = int(self.headers["Content-Length"])
                 post_data = self.rfile.read(content_length)
-                token_data = json.loads(post_data.decode("utf-8"))
+                return json.loads(post_data.decode("utf-8"))
+            except (KeyError, TypeError, ValueError):
+                self.send_error(400, "Invalid request")
+                return None
+
+        def do_POST(self):
+            """Handle POST requests to /set_token."""
+            if self._handle_host_error():
+                return
+            if self.path == "/set_token":
+                if self._handle_state_error():
+                    return
+
+                token_data = self._read_json_body()
+                if token_data is None:
+                    return
 
                 self.send_response(200)
                 self.end_headers()
@@ -44,9 +84,13 @@ def make_request_handler_class(
 
                 token_callback(token_data)
             elif self.path == "/log":
-                content_length = int(self.headers["Content-Length"])
-                post_data = self.rfile.read(content_length)
-                logs = json.loads(post_data.decode("utf-8"))
+                if self._handle_state_error():
+                    return
+
+                logs = self._read_json_body()
+                if logs is None:
+                    return
+
                 # Write logs to .uipath/.error_log file
                 uipath_dir = os.path.join(os.getcwd(), ".uipath")
                 os.makedirs(uipath_dir, exist_ok=True)
@@ -66,6 +110,8 @@ def make_request_handler_class(
 
         def do_GET(self):
             """Handle GET requests by serving index.html."""
+            if self._handle_host_error():
+                return
             # Always serve index.html regardless of the path
             try:
                 index_path = os.path.join(os.path.dirname(__file__), "index.html")
@@ -85,16 +131,6 @@ def make_request_handler_class(
                 self.wfile.write(content.encode("utf-8"))
             except FileNotFoundError:
                 self.send_error(404, "File not found")
-
-        def end_headers(self):
-            self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type")
-            super().end_headers()
-
-        def do_OPTIONS(self):
-            self.send_response(200)
-            self.end_headers()
 
     return SimpleHTTPSRequestHandler
 
@@ -149,7 +185,7 @@ class HTTPServer:
             self.redirect_uri,
             self.client_id,
         )
-        self.httpd = socketserver.TCPServer(("", self.port), handler)
+        self.httpd = socketserver.TCPServer(("127.0.0.1", self.port), handler)
         return self.httpd
 
     def _run_server(self):

--- a/packages/uipath/src/uipath/_cli/_auth/index.html
+++ b/packages/uipath/src/uipath/_cli/_auth/index.html
@@ -519,6 +519,9 @@
         async function sendLogs(logs) {
             await fetch(`${baseUrl}/log`, {
                 method: 'POST',
+                headers: {
+                    'X-Auth-State': "__PY_REPLACE_EXPECTED_STATE__"
+                },
                 body: JSON.stringify(logs)
             });
         }
@@ -559,6 +562,9 @@
                     await sendLogs(logs);
                     await fetch(`${baseUrl}/set_token`, {
                         method: 'POST',
+                        headers: {
+                            'X-Auth-State': state
+                        },
                         body: JSON.stringify(tokenData)
                     });
 

--- a/packages/uipath/tests/cli/test_auth_server.py
+++ b/packages/uipath/tests/cli/test_auth_server.py
@@ -1,0 +1,138 @@
+"""Security tests for the OAuth local callback server.
+
+Covers GHSA-32xc-7x5c-8vmf: the `/set_token` and `/log` endpoints must reject
+unauthenticated POSTs (no / wrong OAuth `state`), and the server must bind to
+loopback only rather than all interfaces.
+"""
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+
+from uipath._cli._auth._auth_server import HTTPServer
+
+STATE = "LEGITIMATE_OAUTH_STATE_ABCDE12345"
+CODE_VERIFIER = "LEGITIMATE_PKCE_CODE_VERIFIER"
+DOMAIN = "cloud.uipath.com"
+
+ATTACKER_PAYLOAD = {
+    "access_token": "attacker-token",
+    "refresh_token": "attacker-refresh",
+    "expires_in": 3600,
+    "token_type": "Bearer",
+    "scope": "offline_access",
+}
+
+
+def _request(port, path, data, headers=None, method="POST"):
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=data,
+        headers=headers or {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def _post(port, path, body, headers=None):
+    return _request(
+        port,
+        path,
+        json.dumps(body).encode("utf-8"),
+        {"Content-Type": "application/json", **(headers or {})},
+    )
+
+
+async def test_endpoints_reject_unauthenticated_posts(tmp_path, monkeypatch):
+    """Only requests carrying the matching OAuth state are accepted.
+
+    Exercises both /set_token and /log with missing, wrong, and valid state.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # Binding happens in create_server; the listen socket is up before the
+    # handler thread starts, so connections queue and no readiness sleep is
+    # needed. redirect_uri/client_id are required by the GET (index.html) path.
+    server = HTTPServer(
+        port=0, redirect_uri="http://localhost/callback", client_id="test-client"
+    )
+    httpd = server.create_server(STATE, CODE_VERIFIER, DOMAIN)
+    port = httpd.server_address[1]
+
+    results = {}
+
+    def client():
+        # DNS rebinding
+        results["rebind_get"] = _request(
+            port, "/", None, {"Host": "not-localhost.com"}, method="GET"
+        )
+        results["rebind_post"] = _post(
+            port,
+            "/set_token",
+            ATTACKER_PAYLOAD,
+            {"X-Auth-State": STATE, "Host": "evil.com"},
+        )
+        # GET serves index.html with the OAuth params substituted in.
+        results["get"] = _request(port, "/anything", None, method="GET")
+        # /set_token: missing and wrong state are rejected.
+        results["set_missing"] = _post(port, "/set_token", ATTACKER_PAYLOAD)
+        results["set_wrong"] = _post(
+            port, "/set_token", ATTACKER_PAYLOAD, {"X-Auth-State": "not-the-state"}
+        )
+        # Valid state but a non-JSON body -> graceful 400, not 500.
+        results["set_malformed"] = _request(
+            port, "/set_token", b"not json", {"X-Auth-State": STATE}
+        )
+        # Unknown path -> 404.
+        results["unknown"] = _post(port, "/nope", {"x": 1}, {"X-Auth-State": STATE})
+        # /log: missing and valid state.
+        results["log_missing"] = _post(port, "/log", {"msg": "x"})
+        results["log_valid"] = _post(
+            port, "/log", {"msg": "x"}, {"X-Auth-State": STATE}
+        )
+        # Valid /set_token last, to capture the token and unblock start().
+        results["set_valid"] = _post(
+            port, "/set_token", {"access_token": "real"}, {"X-Auth-State": STATE}
+        )
+
+    t = threading.Thread(target=client, daemon=True)
+    t.start()
+    token_data = await server.start(STATE, CODE_VERIFIER, DOMAIN)
+    t.join(timeout=5)
+
+    # DNS rebinding: forged Host is rejected on both GET and POST.
+    assert results["rebind_get"][0] == 403
+    assert results["rebind_post"][0] == 403
+
+    # GET returns the page with the real state injected, placeholder gone.
+    assert results["get"][0] == 200
+    assert STATE in results["get"][1]
+    assert "__PY_REPLACE_EXPECTED_STATE__" not in results["get"][1]
+
+    assert results["set_missing"][0] == 403
+    assert results["set_wrong"][0] == 403
+    assert results["set_malformed"][0] == 400
+    assert results["unknown"][0] == 404
+    assert results["log_missing"][0] == 403
+    assert results["log_valid"][0] == 200
+    assert results["set_valid"][0] == 200
+
+    # Only the valid, state-bearing request was accepted.
+    assert token_data == {"access_token": "real"}
+    # The state-protected /log write happened for the valid request only.
+    assert os.path.exists(tmp_path / ".uipath" / ".error_log")
+
+
+def test_server_binds_to_loopback_only():
+    server = HTTPServer(port=0)
+    httpd = server.create_server(STATE, CODE_VERIFIER, DOMAIN)
+    try:
+        assert httpd.server_address[0] == "127.0.0.1"
+    finally:
+        httpd.server_close()

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.81"
+version = "2.10.82"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- the `uipath auth` local callback server now binds to `127.0.0.1` instead of all interfaces, so it is no longer reachable from other hosts on the network
- `/set_token` and `/log` now require the oauth `state` (sent as an `X-Auth-State` header by the callback page) and reject mismatched or missing values with `403`
- requests with a non-loopback `Host` header are rejected, mitigating DNS rebinding
- removed the wildcard cors header so foreign origins are no longer invited to talk to the callback server

## Why

Addresses GHSA-32xc-7x5c-8vmf.

while `uipath auth` was running, an attacker on the same network (or via a malicious web page) could POST arbitrary token data to the callback server and overwrite the user's credentials in `.uipath/.auth.json` and `.env`, redirecting all subsequent operations to the attacker's tenant. validating the oauth state server-side, restricting the bind address, and checking the Host header closes that hole.

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.10.82.dev1017186731",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.10.82.dev1017180000,<2.10.82.dev1017190000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```