### PR TITLE
feat(assets): add support for AllowDirectApiAccess

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.65"
+version = "0.1.66"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_assets_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_assets_service.py
@@ -283,13 +283,55 @@ class AssetsService(FolderContext, BaseService):
         else:
             return Asset.model_validate(response.json()["value"][0])
 
-    def _ensure_robot_context(self) -> None:
+    def _resolve_robot_key(
+        self,
+        name: str,
+        *,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return the robot key, or ``None`` if the asset opts into direct API access.
+
+        Raises ``ValueError`` when no robot key is available and ``AllowDirectApiAccess``
+        is not enabled on the asset.
+        """
         try:
-            is_user = self._execution_context.robot_key is not None
+            robot_key = self._execution_context.robot_key
         except ValueError:
-            is_user = False
-        if not is_user:
-            raise ValueError("This method can only be used for robot assets.")
+            robot_key = None
+
+        if robot_key is None:
+            asset = self.retrieve(
+                name=name, folder_key=folder_key, folder_path=folder_path
+            )
+            if not asset.allow_direct_api_access:
+                raise ValueError(
+                    f"No robot key available and 'AllowDirectApiAccess' is disabled for asset '{name}'."
+                )
+        return robot_key
+
+    async def _resolve_robot_key_async(
+        self,
+        name: str,
+        *,
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> Optional[str]:
+        """Async variant of :meth:`_resolve_robot_key`."""
+        try:
+            robot_key = self._execution_context.robot_key
+        except ValueError:
+            robot_key = None
+
+        if robot_key is None:
+            asset = await self.retrieve_async(
+                name=name, folder_key=folder_key, folder_path=folder_path
+            )
+            if not asset.allow_direct_api_access:
+                raise ValueError(
+                    f"No robot key available and 'AllowDirectApiAccess' is disabled for asset '{name}'."
+                )
+        return robot_key
 
     @resource_override(resource_type="asset")
     @traced(
@@ -305,6 +347,10 @@ class AssetsService(FolderContext, BaseService):
         """Get the decrypted password of a Credential asset.
 
         The robot id is retrieved from the execution context (`UIPATH_ROBOT_KEY` environment variable).
+        If no robot key is available, the asset's `AllowDirectApiAccess` flag is checked: when
+        enabled, the credential is fetched without a robot key; otherwise a `ValueError` is raised.
+
+        Related Activity: [Get Credential](https://docs.uipath.com/activities/other/latest/workflow/get-robot-credential)
 
         Args:
             name (str): The name of the credential asset.
@@ -315,10 +361,18 @@ class AssetsService(FolderContext, BaseService):
             Optional[str]: The decrypted credential password.
 
         Raises:
-            ValueError: If called outside a robot context (no `UIPATH_ROBOT_KEY`).
+            ValueError: If no robot key is available and the asset does not have `AllowDirectApiAccess` enabled.
         """
-        self._ensure_robot_context()
-        spec = self._retrieve_spec(name, folder_key=folder_key, folder_path=folder_path)
+        robot_key = self._resolve_robot_key(
+            name, folder_key=folder_key, folder_path=folder_path
+        )
+
+        spec = self._retrieve_credential_spec(
+            name,
+            robot_key=robot_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
         response = self.request(
             spec.method,
             url=spec.endpoint,
@@ -343,6 +397,10 @@ class AssetsService(FolderContext, BaseService):
         """Asynchronously get the decrypted password of a Credential asset.
 
         The robot id is retrieved from the execution context (`UIPATH_ROBOT_KEY` environment variable).
+        If no robot key is available, the asset's `AllowDirectApiAccess` flag is checked: when
+        enabled, the credential is fetched without a robot key; otherwise a `ValueError` is raised.
+
+        Related Activity: [Get Credential](https://docs.uipath.com/activities/other/latest/workflow/get-robot-credential)
 
         Args:
             name (str): The name of the credential asset.
@@ -353,10 +411,18 @@ class AssetsService(FolderContext, BaseService):
             Optional[str]: The decrypted credential password.
 
         Raises:
-            ValueError: If called outside a robot context (no `UIPATH_ROBOT_KEY`).
+            ValueError: If no robot key is available and the asset does not have `AllowDirectApiAccess` enabled.
         """
-        self._ensure_robot_context()
-        spec = self._retrieve_spec(name, folder_key=folder_key, folder_path=folder_path)
+        robot_key = await self._resolve_robot_key_async(
+            name, folder_key=folder_key, folder_path=folder_path
+        )
+
+        spec = self._retrieve_credential_spec(
+            name,
+            robot_key=robot_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
         response = await self.request_async(
             spec.method,
             url=spec.endpoint,
@@ -379,6 +445,8 @@ class AssetsService(FolderContext, BaseService):
         """Get the decrypted value of a Secret asset.
 
         The robot id is retrieved from the execution context (`UIPATH_ROBOT_KEY` environment variable).
+        If no robot key is available, the asset's `AllowDirectApiAccess` flag is checked: when
+        enabled, the secret is fetched without a robot key; otherwise a `ValueError` is raised.
 
         Args:
             name (str): The name of the secret asset.
@@ -389,10 +457,18 @@ class AssetsService(FolderContext, BaseService):
             Optional[str]: The decrypted secret value.
 
         Raises:
-            ValueError: If called outside a robot context (no `UIPATH_ROBOT_KEY`).
+            ValueError: If no robot key is available and the asset does not have `AllowDirectApiAccess` enabled.
         """
-        self._ensure_robot_context()
-        spec = self._retrieve_spec(name, folder_key=folder_key, folder_path=folder_path)
+        robot_key = self._resolve_robot_key(
+            name, folder_key=folder_key, folder_path=folder_path
+        )
+
+        spec = self._retrieve_credential_spec(
+            name,
+            robot_key=robot_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
         response = self.request(
             spec.method,
             url=spec.endpoint,
@@ -415,6 +491,8 @@ class AssetsService(FolderContext, BaseService):
         """Asynchronously get the decrypted value of a Secret asset.
 
         The robot id is retrieved from the execution context (`UIPATH_ROBOT_KEY` environment variable).
+        If no robot key is available, the asset's `AllowDirectApiAccess` flag is checked: when
+        enabled, the secret is fetched without a robot key; otherwise a `ValueError` is raised.
 
         Args:
             name (str): The name of the secret asset.
@@ -425,10 +503,18 @@ class AssetsService(FolderContext, BaseService):
             Optional[str]: The decrypted secret value.
 
         Raises:
-            ValueError: If called outside a robot context (no `UIPATH_ROBOT_KEY`).
+            ValueError: If no robot key is available and the asset does not have `AllowDirectApiAccess` enabled.
         """
-        self._ensure_robot_context()
-        spec = self._retrieve_spec(name, folder_key=folder_key, folder_path=folder_path)
+        robot_key = await self._resolve_robot_key_async(
+            name, folder_key=folder_key, folder_path=folder_path
+        )
+
+        spec = self._retrieve_credential_spec(
+            name,
+            robot_key=robot_key,
+            folder_key=folder_key,
+            folder_path=folder_path,
+        )
         response = await self.request_async(
             spec.method,
             url=spec.endpoint,
@@ -554,6 +640,32 @@ class AssetsService(FolderContext, BaseService):
                 "robotKey": robot_key,
                 "supportsCredentialsProxyDisconnected": True,
             },
+            headers={
+                **header_folder(folder_key, folder_path),
+            },
+        )
+
+    def _retrieve_credential_spec(
+        self,
+        name: str,
+        *,
+        robot_key: Optional[str],
+        folder_key: Optional[str] = None,
+        folder_path: Optional[str] = None,
+    ) -> RequestSpec:
+        body: Dict[str, Any] = {
+            "assetName": name,
+            "supportsCredentialsProxyDisconnected": True,
+        }
+        if robot_key is not None:
+            body["robotKey"] = robot_key
+
+        return RequestSpec(
+            method="POST",
+            endpoint=Endpoint(
+                "/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetRobotAssetByNameForRobotKey"
+            ),
+            json=body,
             headers={
                 **header_folder(folder_key, folder_path),
             },

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/assets.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/assets.py
@@ -47,6 +47,9 @@ class UserAsset(BaseModel):
     connection_data: Optional[CredentialsConnectionData] = Field(
         default=None, alias="ConnectionData"
     )
+    allow_direct_api_access: Optional[bool] = Field(
+        default=None, alias="AllowDirectApiAccess"
+    )
     id: Optional[int] = Field(default=None, alias="Id")
 
 
@@ -73,3 +76,6 @@ class Asset(BaseModel):
     secret_value: Optional[str] = Field(default=None, alias="SecretValue")
     external_name: Optional[str] = Field(default=None, alias="ExternalName")
     credential_store_id: Optional[int] = Field(default=None, alias="CredentialStoreId")
+    allow_direct_api_access: Optional[bool] = Field(
+        default=None, alias="AllowDirectApiAccess"
+    )

--- a/packages/uipath-platform/tests/services/test_assets_service.py
+++ b/packages/uipath-platform/tests/services/test_assets_service.py
@@ -362,19 +362,93 @@ class TestAssetsService:
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.AssetsService.retrieve_credential/{version}"
         )
 
-    def test_retrieve_credential_user_asset(
+    def test_retrieve_credential_no_robot_key_direct_access_disabled(
         self,
-        service: AssetsService,
-        monkeypatch: pytest.MonkeyPatch,
+        httpx_mock: HTTPXMock,
+        base_url: str,
+        org: str,
+        tenant: str,
         config: UiPathApiConfig,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        monkeypatch.delenv("UIPATH_ROBOT_KEY", raising=False)
+        service = AssetsService(
+            config=config,
+            execution_context=UiPathExecutionContext(),
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetFiltered?$filter=Name eq 'Test Credential'&$top=1",
+            status_code=200,
+            json={
+                "value": [
+                    {
+                        "Key": "asset-key",
+                        "Name": "Test Credential",
+                        "ValueType": "Credential",
+                        "AllowDirectApiAccess": False,
+                    }
+                ]
+            },
+        )
+
         with pytest.raises(ValueError):
-            monkeypatch.delenv("UIPATH_ROBOT_KEY", raising=False)
-            service = AssetsService(
-                config=config,
-                execution_context=UiPathExecutionContext(),
-            )
             service.retrieve_credential(name="Test Credential")
+
+    def test_retrieve_credential_no_robot_key_direct_access_enabled(
+        self,
+        httpx_mock: HTTPXMock,
+        base_url: str,
+        org: str,
+        tenant: str,
+        config: UiPathApiConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+
+        monkeypatch.delenv("UIPATH_ROBOT_KEY", raising=False)
+        service = AssetsService(
+            config=config,
+            execution_context=UiPathExecutionContext(),
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetFiltered?$filter=Name eq 'Test Credential'&$top=1",
+            status_code=200,
+            json={
+                "value": [
+                    {
+                        "Key": "asset-key",
+                        "Name": "Test Credential",
+                        "ValueType": "Credential",
+                        "AllowDirectApiAccess": True,
+                    }
+                ]
+            },
+        )
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetRobotAssetByNameForRobotKey",
+            status_code=200,
+            json={
+                "id": 1,
+                "name": "Test Credential",
+                "credential_username": "test-user",
+                "credential_password": "test-password",
+            },
+        )
+
+        credential = service.retrieve_credential(name="Test Credential")
+
+        assert credential == "test-password"
+
+        sent_requests = httpx_mock.get_requests()
+        assert len(sent_requests) == 2
+        credential_request = sent_requests[1]
+        assert credential_request.method == "POST"
+        request_body = json.loads(credential_request.content)
+        assert request_body["assetName"] == "Test Credential"
+        assert request_body["supportsCredentialsProxyDisconnected"] is True
+        assert "robotKey" not in request_body
 
     async def test_retrieve_credential_async(
         self,
@@ -416,6 +490,96 @@ class TestAssetsService:
             sent_request.headers[HEADER_USER_AGENT]
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.AssetsService.retrieve_credential_async/{version}"
         )
+
+    @pytest.mark.anyio
+    async def test_retrieve_credential_async_no_robot_key_direct_access_disabled(
+        self,
+        httpx_mock: HTTPXMock,
+        base_url: str,
+        org: str,
+        tenant: str,
+        config: UiPathApiConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("UIPATH_ROBOT_KEY", raising=False)
+        service = AssetsService(
+            config=config,
+            execution_context=UiPathExecutionContext(),
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetFiltered?$filter=Name eq 'Test Credential'&$top=1",
+            status_code=200,
+            json={
+                "value": [
+                    {
+                        "Key": "asset-key",
+                        "Name": "Test Credential",
+                        "ValueType": "Credential",
+                        "AllowDirectApiAccess": False,
+                    }
+                ]
+            },
+        )
+
+        with pytest.raises(ValueError):
+            await service.retrieve_credential_async(name="Test Credential")
+
+    @pytest.mark.anyio
+    async def test_retrieve_credential_async_no_robot_key_direct_access_enabled(
+        self,
+        httpx_mock: HTTPXMock,
+        base_url: str,
+        org: str,
+        tenant: str,
+        config: UiPathApiConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+
+        monkeypatch.delenv("UIPATH_ROBOT_KEY", raising=False)
+        service = AssetsService(
+            config=config,
+            execution_context=UiPathExecutionContext(),
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetFiltered?$filter=Name eq 'Test Credential'&$top=1",
+            status_code=200,
+            json={
+                "value": [
+                    {
+                        "Key": "asset-key",
+                        "Name": "Test Credential",
+                        "ValueType": "Credential",
+                        "AllowDirectApiAccess": True,
+                    }
+                ]
+            },
+        )
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/orchestrator_/odata/Assets/UiPath.Server.Configuration.OData.GetRobotAssetByNameForRobotKey",
+            status_code=200,
+            json={
+                "id": 1,
+                "name": "Test Credential",
+                "credential_username": "test-user",
+                "credential_password": "test-password",
+            },
+        )
+
+        credential = await service.retrieve_credential_async(name="Test Credential")
+
+        assert credential == "test-password"
+
+        sent_requests = httpx_mock.get_requests()
+        assert len(sent_requests) == 2
+        credential_request = sent_requests[1]
+        assert credential_request.method == "POST"
+        request_body = json.loads(credential_request.content)
+        assert request_body["assetName"] == "Test Credential"
+        assert request_body["supportsCredentialsProxyDisconnected"] is True
+        assert "robotKey" not in request_body
 
     def test_retrieve_secret(
         self,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.65"
+version = "0.1.66"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.10.83"
+version = "2.10.84"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.17, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.65, <0.2.0",
+  "uipath-platform>=0.1.66, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.83"
+version = "2.10.84"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.65"
+version = "0.1.66"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Description

Add support for `AllowDirectApiAccess` for secret and credential assets. If the flag is enabled, then secret retrieval is possible without a robotKey in the execution context

## Development Packages

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-platform==0.1.66.dev1017226762",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-platform>=0.1.66.dev1017220000,<0.1.66.dev1017230000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.10.84.dev1017226762",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.10.84.dev1017220000,<2.10.84.dev1017230000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
uipath-platform = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-platform==0.1.66.dev1017226762"]
```