### PR TITLE
ci: force local wheels via uv override in cross-tests

### DIFF
--- a/.github/scripts/write_uv_overrides.py
+++ b/.github/scripts/write_uv_overrides.py
@@ -1,0 +1,45 @@
+"""Write a uv override file forcing the locally built uipath wheels.
+
+Cross-test workflows build uipath-core/uipath-platform/uipath wheels from the PR
+and run them against downstream repos (uipath-langchain-python,
+uipath-integrations-python). Those downstreams cap the uipath version (e.g.
+``uipath<2.11.0``), so a backward-compatible minor bump would fail resolution
+purely on the cap. uv ``override-dependencies`` bypass the declared version
+specifier, so pointing them at the local wheels lets the cross-test exercise the
+real new code regardless of the cap.
+
+The wheels are resolved relative to ``GITHUB_WORKSPACE`` (where the
+``download-artifact`` step places them) rather than the current directory, so the
+script is robust to a step- or job-level ``working-directory``.
+
+The resulting override file path is appended to ``GITHUB_ENV`` as ``UV_OVERRIDE``
+so every subsequent ``uv`` invocation in the job honors it.
+"""
+
+import glob
+import os
+import pathlib
+
+
+def main() -> None:
+    workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
+    wheels = workspace / "wheels"
+
+    lines = []
+    for name in ("uipath", "uipath-core", "uipath-platform"):
+        matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
+        if not matches:
+            raise SystemExit(f"no wheel found for {name} under {wheels / name / 'dist'}")
+        lines.append(f"{name} @ {pathlib.Path(matches[0]).resolve().as_uri()}")
+
+    out = wheels / "overrides.txt"
+    out.write_text("\n".join(lines) + "\n")
+
+    with open(os.environ["GITHUB_ENV"], "a") as fh:
+        fh.write(f"UV_OVERRIDE={out}\n")
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/write_uv_overrides.py
+++ b/.github/scripts/write_uv_overrides.py
@@ -1,16 +1,17 @@
 """Write a uv override file forcing the locally built uipath wheels.
 
-Cross-test workflows build uipath-core/uipath-platform/uipath wheels from the PR
-and run them against downstream repos (uipath-langchain-python,
-uipath-integrations-python). Those downstreams cap the uipath version (e.g.
+Cross-test workflows build uipath wheels from the PR and run them against
+downstream repos (uipath-langchain-python, uipath-integrations-python,
+uipath-runtime-python). Those downstreams cap the uipath* version (e.g.
 ``uipath<2.11.0``), so a backward-compatible minor bump would fail resolution
-purely on the cap. uv ``override-dependencies`` bypass the declared version
+purely on the cap. uv ``override-dependencies`` ignore the declared version
 specifier, so pointing them at the local wheels lets the cross-test exercise the
 real new code regardless of the cap.
 
-The wheels are resolved relative to ``GITHUB_WORKSPACE`` (where the
-``download-artifact`` step places them) rather than the current directory, so the
-script is robust to a step- or job-level ``working-directory``.
+The script is layout-agnostic: it overrides whatever ``uipath*`` wheels exist
+under ``$GITHUB_WORKSPACE/wheels`` (recursively), so it works for the
+three-wheel layout (``wheels/<pkg>/dist/*.whl``) and the single-wheel runtime
+layout (``wheels/*.whl``) alike.
 
 The resulting override file path is appended to ``GITHUB_ENV`` as ``UV_OVERRIDE``
 so every subsequent ``uv`` invocation in the job honors it.
@@ -22,15 +23,19 @@ import pathlib
 
 
 def main() -> None:
-    workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
-    wheels = workspace / "wheels"
+    wheels = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve() / "wheels"
 
     lines = []
-    for name in ("uipath", "uipath-core", "uipath-platform"):
-        matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
-        if not matches:
-            raise SystemExit(f"no wheel found for {name} under {wheels / name / 'dist'}")
-        lines.append(f"{name} @ {pathlib.Path(matches[0]).resolve().as_uri()}")
+    for whl in sorted(glob.glob(str(wheels / "**" / "*.whl"), recursive=True)):
+        # Wheel filename is ``{distribution}-{version}-...whl`` where the
+        # distribution escapes hyphens to underscores (uipath_core -> uipath-core).
+        dist = pathlib.Path(whl).name.split("-", 1)[0].replace("_", "-")
+        if not dist.startswith("uipath"):
+            continue
+        lines.append(f"{dist} @ {pathlib.Path(whl).resolve().as_uri()}")
+
+    if not lines:
+        raise SystemExit(f"no uipath wheels found under {wheels}")
 
     out = wheels / "overrides.txt"
     out.write_text("\n".join(lines) + "\n")

--- a/.github/workflows/test-uipath-integrations.yml
+++ b/.github/workflows/test-uipath-integrations.yml
@@ -102,13 +102,27 @@ jobs:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
 
-      - name: Update uipath packages
+      - name: Override uipath packages with local wheels
         shell: bash
-        working-directory: uipath-integrations-python/packages/${{ matrix.package }}
         run: |
-          uv add ../../../wheels/uipath-core/dist/*.whl --dev
-          uv add ../../../wheels/uipath-platform/dist/*.whl --dev
-          uv add ../../../wheels/uipath/dist/*.whl --dev
+          # Force the freshly built local wheels in via uv override-dependencies
+          # so a backward-compatible minor bump in uipath-python does not break
+          # the cross-test purely on the downstream version cap.
+          PYBIN=$(command -v python || command -v python3)
+          "$PYBIN" - <<'PY'
+          import glob, os, pathlib
+          wheels = pathlib.Path("wheels").resolve()
+          lines = []
+          for name in ("uipath", "uipath-core", "uipath-platform"):
+              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
+              assert matches, f"no wheel found for {name}"
+              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
+          out = wheels / "overrides.txt"
+          out.write_text("\n".join(lines) + "\n")
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              fh.write(f"UV_OVERRIDE={out}\n")
+          print("\n".join(lines))
+          PY
 
       - name: Install dependencies and run tests
         shell: bash
@@ -202,13 +216,27 @@ jobs:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
 
-      - name: Update uipath packages
+      - name: Override uipath packages with local wheels
         shell: bash
-        working-directory: uipath-integrations-python/packages/${{ matrix.package }}
         run: |
-          uv add ../../../wheels/uipath-core/dist/*.whl
-          uv add ../../../wheels/uipath-platform/dist/*.whl
-          uv add ../../../wheels/uipath/dist/*.whl
+          # Force the freshly built local wheels in via uv override-dependencies
+          # so a backward-compatible minor bump in uipath-python does not break
+          # the cross-test purely on the downstream version cap.
+          PYBIN=$(command -v python || command -v python3)
+          "$PYBIN" - <<'PY'
+          import glob, os, pathlib
+          wheels = pathlib.Path("wheels").resolve()
+          lines = []
+          for name in ("uipath", "uipath-core", "uipath-platform"):
+              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
+              assert matches, f"no wheel found for {name}"
+              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
+          out = wheels / "overrides.txt"
+          out.write_text("\n".join(lines) + "\n")
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              fh.write(f"UV_OVERRIDE={out}\n")
+          print("\n".join(lines))
+          PY
 
       - name: Install dependencies
         working-directory: uipath-integrations-python/packages/${{ matrix.package }}

--- a/.github/workflows/test-uipath-integrations.yml
+++ b/.github/workflows/test-uipath-integrations.yml
@@ -102,11 +102,17 @@ jobs:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
 
+      - name: Checkout uipath-python scripts
+        uses: actions/checkout@v4
+        with:
+          path: _scripts
+          sparse-checkout: .github/scripts
+
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
+          "$PYBIN" "$GITHUB_WORKSPACE/_scripts/.github/scripts/write_uv_overrides.py"
 
       - name: Install dependencies and run tests
         shell: bash
@@ -200,11 +206,17 @@ jobs:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
 
+      - name: Checkout uipath-python scripts
+        uses: actions/checkout@v4
+        with:
+          path: _scripts
+          sparse-checkout: .github/scripts
+
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
+          "$PYBIN" "$GITHUB_WORKSPACE/_scripts/.github/scripts/write_uv_overrides.py"
 
       - name: Install dependencies
         working-directory: uipath-integrations-python/packages/${{ matrix.package }}

--- a/.github/workflows/test-uipath-integrations.yml
+++ b/.github/workflows/test-uipath-integrations.yml
@@ -105,24 +105,8 @@ jobs:
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
-          # Force the freshly built local wheels in via uv override-dependencies
-          # so a backward-compatible minor bump in uipath-python does not break
-          # the cross-test purely on the downstream version cap.
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" - <<'PY'
-          import glob, os, pathlib
-          wheels = pathlib.Path("wheels").resolve()
-          lines = []
-          for name in ("uipath", "uipath-core", "uipath-platform"):
-              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
-              assert matches, f"no wheel found for {name}"
-              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
-          out = wheels / "overrides.txt"
-          out.write_text("\n".join(lines) + "\n")
-          with open(os.environ["GITHUB_ENV"], "a") as fh:
-              fh.write(f"UV_OVERRIDE={out}\n")
-          print("\n".join(lines))
-          PY
+          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
 
       - name: Install dependencies and run tests
         shell: bash
@@ -219,24 +203,8 @@ jobs:
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
-          # Force the freshly built local wheels in via uv override-dependencies
-          # so a backward-compatible minor bump in uipath-python does not break
-          # the cross-test purely on the downstream version cap.
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" - <<'PY'
-          import glob, os, pathlib
-          wheels = pathlib.Path("wheels").resolve()
-          lines = []
-          for name in ("uipath", "uipath-core", "uipath-platform"):
-              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
-              assert matches, f"no wheel found for {name}"
-              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
-          out = wheels / "overrides.txt"
-          out.write_text("\n".join(lines) + "\n")
-          with open(os.environ["GITHUB_ENV"], "a") as fh:
-              fh.write(f"UV_OVERRIDE={out}\n")
-          print("\n".join(lines))
-          PY
+          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
 
       - name: Install dependencies
         working-directory: uipath-integrations-python/packages/${{ matrix.package }}

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -75,24 +75,8 @@ jobs:
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
-          # Force the freshly built local wheels in via uv override-dependencies
-          # so a backward-compatible minor bump in uipath-python does not break
-          # the cross-test purely on the downstream version cap.
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" - <<'PY'
-          import glob, os, pathlib
-          wheels = pathlib.Path("wheels").resolve()
-          lines = []
-          for name in ("uipath", "uipath-core", "uipath-platform"):
-              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
-              assert matches, f"no wheel found for {name}"
-              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
-          out = wheels / "overrides.txt"
-          out.write_text("\n".join(lines) + "\n")
-          with open(os.environ["GITHUB_ENV"], "a") as fh:
-              fh.write(f"UV_OVERRIDE={out}\n")
-          print("\n".join(lines))
-          PY
+          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
 
       - name: Run uipath-langchain tests
         working-directory: uipath-langchain-python
@@ -163,24 +147,8 @@ jobs:
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
-          # Force the freshly built local wheels in via uv override-dependencies
-          # so a backward-compatible minor bump in uipath-python does not break
-          # the cross-test purely on the downstream version cap.
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" - <<'PY'
-          import glob, os, pathlib
-          wheels = pathlib.Path("wheels").resolve()
-          lines = []
-          for name in ("uipath", "uipath-core", "uipath-platform"):
-              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
-              assert matches, f"no wheel found for {name}"
-              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
-          out = wheels / "overrides.txt"
-          out.write_text("\n".join(lines) + "\n")
-          with open(os.environ["GITHUB_ENV"], "a") as fh:
-              fh.write(f"UV_OVERRIDE={out}\n")
-          print("\n".join(lines))
-          PY
+          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
 
       - name: Install dependencies
         working-directory: uipath-langchain-python

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -72,11 +72,17 @@ jobs:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
 
+      - name: Checkout uipath-python scripts
+        uses: actions/checkout@v4
+        with:
+          path: _scripts
+          sparse-checkout: .github/scripts
+
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
+          "$PYBIN" "$GITHUB_WORKSPACE/_scripts/.github/scripts/write_uv_overrides.py"
 
       - name: Run uipath-langchain tests
         working-directory: uipath-langchain-python
@@ -144,11 +150,17 @@ jobs:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
 
+      - name: Checkout uipath-python scripts
+        uses: actions/checkout@v4
+        with:
+          path: _scripts
+          sparse-checkout: .github/scripts
+
       - name: Override uipath packages with local wheels
         shell: bash
         run: |
           PYBIN=$(command -v python || command -v python3)
-          "$PYBIN" "$GITHUB_WORKSPACE/.github/scripts/write_uv_overrides.py"
+          "$PYBIN" "$GITHUB_WORKSPACE/_scripts/.github/scripts/write_uv_overrides.py"
 
       - name: Install dependencies
         working-directory: uipath-langchain-python

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -72,13 +72,27 @@ jobs:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
 
-      - name: Update uipath packages
+      - name: Override uipath packages with local wheels
         shell: bash
-        working-directory: uipath-langchain-python
         run: |
-          uv add ../wheels/uipath-core/dist/*.whl --dev
-          uv add ../wheels/uipath-platform/dist/*.whl --dev
-          uv add ../wheels/uipath/dist/*.whl --dev
+          # Force the freshly built local wheels in via uv override-dependencies
+          # so a backward-compatible minor bump in uipath-python does not break
+          # the cross-test purely on the downstream version cap.
+          PYBIN=$(command -v python || command -v python3)
+          "$PYBIN" - <<'PY'
+          import glob, os, pathlib
+          wheels = pathlib.Path("wheels").resolve()
+          lines = []
+          for name in ("uipath", "uipath-core", "uipath-platform"):
+              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
+              assert matches, f"no wheel found for {name}"
+              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
+          out = wheels / "overrides.txt"
+          out.write_text("\n".join(lines) + "\n")
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              fh.write(f"UV_OVERRIDE={out}\n")
+          print("\n".join(lines))
+          PY
 
       - name: Run uipath-langchain tests
         working-directory: uipath-langchain-python
@@ -146,13 +160,27 @@ jobs:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
 
-      - name: Update uipath packages
+      - name: Override uipath packages with local wheels
         shell: bash
-        working-directory: uipath-langchain-python
         run: |
-          uv add ../wheels/uipath-core/dist/*.whl
-          uv add ../wheels/uipath-platform/dist/*.whl
-          uv add ../wheels/uipath/dist/*.whl
+          # Force the freshly built local wheels in via uv override-dependencies
+          # so a backward-compatible minor bump in uipath-python does not break
+          # the cross-test purely on the downstream version cap.
+          PYBIN=$(command -v python || command -v python3)
+          "$PYBIN" - <<'PY'
+          import glob, os, pathlib
+          wheels = pathlib.Path("wheels").resolve()
+          lines = []
+          for name in ("uipath", "uipath-core", "uipath-platform"):
+              matches = glob.glob(str(wheels / name / "dist" / "*.whl"))
+              assert matches, f"no wheel found for {name}"
+              lines.append(f"{name} @ {pathlib.Path(matches[0]).as_uri()}")
+          out = wheels / "overrides.txt"
+          out.write_text("\n".join(lines) + "\n")
+          with open(os.environ["GITHUB_ENV"], "a") as fh:
+              fh.write(f"UV_OVERRIDE={out}\n")
+          print("\n".join(lines))
+          PY
 
       - name: Install dependencies
         working-directory: uipath-langchain-python

--- a/.github/workflows/test-uipath-runtime.yml
+++ b/.github/workflows/test-uipath-runtime.yml
@@ -64,10 +64,17 @@ jobs:
           repository: 'UiPath/uipath-runtime-python'
           path: 'uipath-runtime-python'
 
-      - name: Update uipath-core version
+      - name: Checkout uipath-python scripts
+        uses: actions/checkout@v4
+        with:
+          path: _scripts
+          sparse-checkout: .github/scripts
+
+      - name: Override uipath packages with local wheels
         shell: bash
-        working-directory: uipath-runtime-python
-        run: uv add ../wheels/*.whl --dev
+        run: |
+          PYBIN=$(command -v python || command -v python3)
+          "$PYBIN" "$GITHUB_WORKSPACE/_scripts/.github/scripts/write_uv_overrides.py"
 
       - name: Run uipath-runtime tests
         working-directory: uipath-runtime-python


### PR DESCRIPTION
## Summary
- cross-tests (`uipath-langchain`, `uipath-integrations`) now inject the freshly built wheels via uv `override-dependencies` instead of `uv add`, so a backward-compatible minor bump in uipath-python no longer fails the cross-test purely on the downstream version cap
- the new code is still exercised against the downstream repo, the version pin is just bypassed

## Why

a minor bump (e.g. uipath 2.10 -> 2.11) is outside the downstream `<2.11.0` cap, so `uv add` of the new wheel hits an unsatisfiable resolve and the cross-test fails before testing anything real. overriding decouples the cross-test from the pin while still running the actual new code.