### PR TITLE
fix(eval): skip synthesized tool spans in per-call extractors

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.10.82"
+version = "2.11.1"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.11.1"
+version = "2.11.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -29,7 +29,11 @@ COMMUNITY_agents_SUFFIX = "-community-agents"
 def _real_tool_attrs(span: ReadableSpan) -> Mapping[str, Any] | None:
     """Return span.attributes if this is a real tool invocation, else None."""
     attrs = span.attributes
-    if not attrs or attrs.get("tool.synthesized", False) or not attrs.get(TOOL_NAME_ATTR):
+    if (
+        not attrs
+        or attrs.get("tool.synthesized", False)
+        or not attrs.get(TOOL_NAME_ATTR)
+    ):
         return None
     return attrs
 

--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -26,7 +26,7 @@ COMPARATOR_MAPPINGS = {
 COMMUNITY_agents_SUFFIX = "-community-agents"
 
 
-def _real_tool_attrs(span: ReadableSpan) -> Mapping[str, Any] | None:
+def _unsynthesized_tool_attrs(span: ReadableSpan) -> Mapping[str, Any] | None:
     """Return span.attributes if this is a real tool invocation, else None."""
     attrs = span.attributes
     if (
@@ -50,7 +50,7 @@ def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
     tool_calls_names = []
 
     for span in spans:
-        if (attrs := _real_tool_attrs(span)) is not None:
+        if (attrs := _unsynthesized_tool_attrs(span)) is not None:
             tool_calls_names.append(str(attrs[TOOL_NAME_ATTR]))
 
     return tool_calls_names
@@ -68,7 +68,7 @@ def extract_tool_calls(spans: Sequence[ReadableSpan]) -> list[ToolCall]:
     tool_calls = []
 
     for span in spans:
-        if (attrs := _real_tool_attrs(span)) is not None:
+        if (attrs := _unsynthesized_tool_attrs(span)) is not None:
             tool_name = str(attrs[TOOL_NAME_ATTR])
             try:
                 input_value: Any = attrs.get("input.value", {})
@@ -99,7 +99,7 @@ def extract_tool_calls_outputs(spans: Sequence[ReadableSpan]) -> list[ToolOutput
     potential_output_keys = ["content"]
     tool_calls_outputs = []
     for span in spans:
-        if (attrs := _real_tool_attrs(span)) is not None:
+        if (attrs := _unsynthesized_tool_attrs(span)) is not None:
             tool_name = str(attrs[TOOL_NAME_ATTR])
             output = attrs.get("output.value", "")
             final_output = ""

--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -24,19 +24,12 @@ COMPARATOR_MAPPINGS = {
 COMMUNITY_agents_SUFFIX = "-community-agents"
 
 
-def _real_tool_name(span: ReadableSpan) -> str | None:
-    """Return the tool name for a real tool-invocation span, else None.
-
-    Spans synthesized for trajectory rendering (e.g. BPMN ProcessRun/ElementRun
-    container spans) carry tool.name but mark themselves with tool.synthesized
-    so the per-call extractors below can skip them.
-    """
-    if not span.attributes:
+def _real_tool_attrs(span: ReadableSpan) -> Mapping[str, Any] | None:
+    """Return span.attributes if this is a real tool invocation, else None."""
+    attrs = span.attributes
+    if not attrs or attrs.get("tool.synthesized", False) or not attrs.get("tool.name"):
         return None
-    if span.attributes.get("tool.synthesized", False):
-        return None
-    tool_name = span.attributes.get("tool.name")
-    return str(tool_name) if tool_name else None
+    return attrs
 
 
 def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
@@ -51,8 +44,8 @@ def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
     tool_calls_names = []
 
     for span in spans:
-        if tool_name := _real_tool_name(span):
-            tool_calls_names.append(tool_name)
+        if (attrs := _real_tool_attrs(span)) is not None:
+            tool_calls_names.append(str(attrs["tool.name"]))
 
     return tool_calls_names
 
@@ -69,10 +62,10 @@ def extract_tool_calls(spans: Sequence[ReadableSpan]) -> list[ToolCall]:
     tool_calls = []
 
     for span in spans:
-        if tool_name := _real_tool_name(span):
+        if (attrs := _real_tool_attrs(span)) is not None:
+            tool_name = str(attrs["tool.name"])
             try:
-                input_value: Any = span.attributes.get("input.value", {})  # type: ignore[union-attr]
-                # Ensure input_value is a string before parsing
+                input_value: Any = attrs.get("input.value", {})
                 if isinstance(input_value, str):
                     arguments = ast.literal_eval(input_value)
                 elif isinstance(input_value, dict):
@@ -81,7 +74,6 @@ def extract_tool_calls(spans: Sequence[ReadableSpan]) -> list[ToolCall]:
                     arguments = {}
                 tool_calls.append(ToolCall(name=tool_name, args=arguments))
             except (json.JSONDecodeError, SyntaxError, ValueError):
-                # Handle case where input.value is not valid JSON/Python syntax
                 tool_calls.append(ToolCall(name=tool_name, args={}))
 
     return tool_calls
@@ -101,8 +93,9 @@ def extract_tool_calls_outputs(spans: Sequence[ReadableSpan]) -> list[ToolOutput
     potential_output_keys = ["content"]
     tool_calls_outputs = []
     for span in spans:
-        if tool_name := _real_tool_name(span):
-            output = span.attributes.get("output.value", "")  # type: ignore[union-attr]
+        if (attrs := _real_tool_attrs(span)) is not None:
+            tool_name = str(attrs["tool.name"])
+            output = attrs.get("output.value", "")
             final_output = ""
 
             # Handle different output formats

--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -11,6 +11,8 @@ from ..models import (
     ToolOutput,
 )
 
+TOOL_NAME_ATTR = "tool.name"
+
 COMPARATOR_MAPPINGS = {
     ">": "gt",
     "<": "lt",
@@ -27,7 +29,7 @@ COMMUNITY_agents_SUFFIX = "-community-agents"
 def _real_tool_attrs(span: ReadableSpan) -> Mapping[str, Any] | None:
     """Return span.attributes if this is a real tool invocation, else None."""
     attrs = span.attributes
-    if not attrs or attrs.get("tool.synthesized", False) or not attrs.get("tool.name"):
+    if not attrs or attrs.get("tool.synthesized", False) or not attrs.get(TOOL_NAME_ATTR):
         return None
     return attrs
 
@@ -45,7 +47,7 @@ def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
 
     for span in spans:
         if (attrs := _real_tool_attrs(span)) is not None:
-            tool_calls_names.append(str(attrs["tool.name"]))
+            tool_calls_names.append(str(attrs[TOOL_NAME_ATTR]))
 
     return tool_calls_names
 
@@ -63,7 +65,7 @@ def extract_tool_calls(spans: Sequence[ReadableSpan]) -> list[ToolCall]:
 
     for span in spans:
         if (attrs := _real_tool_attrs(span)) is not None:
-            tool_name = str(attrs["tool.name"])
+            tool_name = str(attrs[TOOL_NAME_ATTR])
             try:
                 input_value: Any = attrs.get("input.value", {})
                 if isinstance(input_value, str):
@@ -94,7 +96,7 @@ def extract_tool_calls_outputs(spans: Sequence[ReadableSpan]) -> list[ToolOutput
     tool_calls_outputs = []
     for span in spans:
         if (attrs := _real_tool_attrs(span)) is not None:
-            tool_name = str(attrs["tool.name"])
+            tool_name = str(attrs[TOOL_NAME_ATTR])
             output = attrs.get("output.value", "")
             final_output = ""
 
@@ -472,7 +474,7 @@ def trace_to_str(agent_trace: Sequence[ReadableSpan]) -> str:
     seen_tool_calls = set()
 
     for span in agent_trace:
-        if span.attributes and (tool_name := span.attributes.get("tool.name")):
+        if span.attributes and (tool_name := span.attributes.get(TOOL_NAME_ATTR)):
             # Get span timing information
             start_time = span.start_time
             end_time = span.end_time

--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -24,6 +24,21 @@ COMPARATOR_MAPPINGS = {
 COMMUNITY_agents_SUFFIX = "-community-agents"
 
 
+def _real_tool_name(span: ReadableSpan) -> str | None:
+    """Return the tool name for a real tool-invocation span, else None.
+
+    Spans synthesized for trajectory rendering (e.g. BPMN ProcessRun/ElementRun
+    container spans) carry tool.name but mark themselves with tool.synthesized
+    so the per-call extractors below can skip them.
+    """
+    if not span.attributes:
+        return None
+    if span.attributes.get("tool.synthesized", False):
+        return None
+    tool_name = span.attributes.get("tool.name")
+    return str(tool_name) if tool_name else None
+
+
 def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
     """Extract the tool call names from execution spans IN ORDER.
 
@@ -36,9 +51,8 @@ def extract_tool_calls_names(spans: Sequence[ReadableSpan]) -> list[str]:
     tool_calls_names = []
 
     for span in spans:
-        # Check for tool.name attribute first
-        if span.attributes and (tool_name := span.attributes.get("tool.name")):
-            tool_calls_names.append(str(tool_name))
+        if tool_name := _real_tool_name(span):
+            tool_calls_names.append(tool_name)
 
     return tool_calls_names
 
@@ -55,9 +69,9 @@ def extract_tool_calls(spans: Sequence[ReadableSpan]) -> list[ToolCall]:
     tool_calls = []
 
     for span in spans:
-        if span.attributes and (tool_name := span.attributes.get("tool.name")):
+        if tool_name := _real_tool_name(span):
             try:
-                input_value: Any = span.attributes.get("input.value", {})
+                input_value: Any = span.attributes.get("input.value", {})  # type: ignore[union-attr]
                 # Ensure input_value is a string before parsing
                 if isinstance(input_value, str):
                     arguments = ast.literal_eval(input_value)
@@ -65,10 +79,10 @@ def extract_tool_calls(spans: Sequence[ReadableSpan]) -> list[ToolCall]:
                     arguments = input_value
                 else:
                     arguments = {}
-                tool_calls.append(ToolCall(name=str(tool_name), args=arguments))
+                tool_calls.append(ToolCall(name=tool_name, args=arguments))
             except (json.JSONDecodeError, SyntaxError, ValueError):
                 # Handle case where input.value is not valid JSON/Python syntax
-                tool_calls.append(ToolCall(name=str(tool_name), args={}))
+                tool_calls.append(ToolCall(name=tool_name, args={}))
 
     return tool_calls
 
@@ -87,8 +101,8 @@ def extract_tool_calls_outputs(spans: Sequence[ReadableSpan]) -> list[ToolOutput
     potential_output_keys = ["content"]
     tool_calls_outputs = []
     for span in spans:
-        if span.attributes and (tool_name := span.attributes.get("tool.name")):
-            output = span.attributes.get("output.value", "")
+        if tool_name := _real_tool_name(span):
+            output = span.attributes.get("output.value", "")  # type: ignore[union-attr]
             final_output = ""
 
             # Handle different output formats

--- a/packages/uipath/tests/evaluators/test_evaluator_helpers.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_helpers.py
@@ -681,6 +681,54 @@ class TestExtractionFunctions:
         assert "non_tool_span" not in output_names
         assert len(result) == 3
 
+    def test_extractors_skip_synthesized_tool_spans(self) -> None:
+        """Spans tagged with tool.synthesized=True (BPMN container spans
+        synthesized for trajectory rendering) must be filtered from all three
+        per-call extractors so they don't pollute tool-call evaluator actuals.
+        """
+        from opentelemetry.sdk.trace import ReadableSpan
+
+        synth_process = ReadableSpan(
+            name="Instance: abc",
+            start_time=0,
+            end_time=1,
+            attributes={
+                "tool.name": "FlowExecution",
+                "tool.synthesized": True,
+                "input.value": '{"instanceId": "abc"}',
+                "output.value": "Status: Completed",
+            },
+        )
+        synth_element = ReadableSpan(
+            name="Autonomous Agent",
+            start_time=2,
+            end_time=3,
+            attributes={
+                "tool.name": "ServiceTask: Autonomous Agent",
+                "tool.synthesized": True,
+                "input.value": "{}",
+                "output.value": "Status: Completed",
+            },
+        )
+        real_tool = ReadableSpan(
+            name="Tool call - web_search",
+            start_time=4,
+            end_time=5,
+            attributes={
+                "tool.name": "web_search",
+                "input.value": '{"query": "x"}',
+                "output.value": '{"content": "ok"}',
+            },
+        )
+
+        spans = [synth_process, synth_element, real_tool]
+
+        assert extract_tool_calls_names(spans) == ["web_search"]
+        calls = extract_tool_calls(spans)
+        assert [c.name for c in calls] == ["web_search"]
+        outputs = extract_tool_calls_outputs(spans)
+        assert [o.name for o in outputs] == ["web_search"]
+
     def test_all_extraction_functions_consistent(self, sample_spans: list[Any]) -> None:
         """Test that all extraction functions return consistent results."""
         names = extract_tool_calls_names(sample_spans)

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.1"
+version = "2.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.0"
+version = "2.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Add `_real_tool_name()` predicate that skips spans carrying `tool.synthesized=True`.
- Route `extract_tool_calls_names`, `extract_tool_calls`, `extract_tool_calls_outputs` through it.
- `trace_to_str` is intentionally **unchanged** so trajectory evaluators continue to see the synthesized BPMN container context inside their LLM-judge prompt.

## Why
`Agents/python-eval-worker/workflows/eval/flow_trace.py:flow_spans_to_readable` synthesizes `tool.name` on BPMN `ProcessRun` (whole .flow) and `ElementRun` (e.g. ServiceTask) spans so `trace_to_str()` can render them. The four per-call evaluators (Tool Call Count / Order / Args / Output) share the same `tool.name` filter and end up treating those container spans as tool invocations — so the "Actual" column in a flow-inline-agent run shows `FlowExecution`, `ServiceTask: Autonomous Agent`, and the real tool (`webSearch1`), instead of just the real tool.

This PR closes the gate on the per-call side. The companion PR in `UiPath/Agents` stamps `tool.synthesized=True` on the synthesized attributes; until that lands this is a no-op (nothing in the wild sets the attribute today).

## Type / signature impact
None. `ReadableSpan.attributes` is an open OTel dict; the new key is purely additive. `ToolCall`, `ToolOutput`, all four evaluator config/criteria/justification classes, and every extractor signature are unchanged.

## Test plan
- [x] `pytest tests/evaluators/test_evaluator_helpers.py` — 52 pass, including new `test_extractors_skip_synthesized_tool_spans`
- [x] `pytest tests/cli/eval/` — 437 pass
- [x] `ruff check` + `mypy` on the modified file — clean

## Companion PR
- UiPath/Agents#5584 — stamps `tool.synthesized=True` in `flow_spans_to_readable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)