### PR TITLE
feat(guardrails): add enum/text/text-list validator parameter types

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.68"
+version = "0.1.69"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.69"
+version = "0.1.70"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/guardrails.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/guardrails.py
@@ -37,8 +37,43 @@ class NumberParameterValue(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
 
+class EnumParameterValue(BaseModel):
+    """Single-select enum parameter value."""
+
+    parameter_type: Literal["enum"] = Field(alias="$parameterType")
+    id: str
+    value: str
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class TextParameterValue(BaseModel):
+    """Free-text parameter value."""
+
+    parameter_type: Literal["text"] = Field(alias="$parameterType")
+    id: str
+    value: str
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class TextListParameterValue(BaseModel):
+    """List-of-text parameter value."""
+
+    parameter_type: Literal["text-list"] = Field(alias="$parameterType")
+    id: str
+    value: list[str]
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
 ValidatorParameter = Annotated[
-    EnumListParameterValue | MapEnumParameterValue | NumberParameterValue,
+    EnumListParameterValue
+    | MapEnumParameterValue
+    | NumberParameterValue
+    | EnumParameterValue
+    | TextParameterValue
+    | TextListParameterValue,
     Field(discriminator="parameter_type"),
 ]
 

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.69"
+version = "0.1.70"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.68"
+version = "0.1.69"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.68"
+version = "0.1.69"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.69"
+version = "0.1.70"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Adds three new validator parameter primitives to the discriminated `ValidatorParameter` union in `packages/uipath-platform/src/uipath/platform/guardrails/guardrails.py`

| Class | `\$parameterType` | Value type |
|---|---|---|
| `EnumParameterValue` | `enum` | `str` (single-select) |
| `TextParameterValue` | `text` | `str` (free text) |
| `TextListParameterValue` | `text-list` | `list[str]` |

These unblock built-in validators (starting with LLM-as-judge) that need to round-trip these parameter shapes against the UiPath Guardrails backend.

Also bumps `uipath-platform` to **0.1.70** and regenerates the affected `uv.lock` files.

## Test plan
- [x] `pytest tests/services/test_guardrails_decorators.py tests/services/test_guardrails_service.py` — 81 tests pass
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy src tests` — clean