### PR TITLE
feat(core): add EnforcementMode enum to governance contracts

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.18"
+version = "0.5.19"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/governance/__init__.py
+++ b/packages/uipath-core/src/uipath/core/governance/__init__.py
@@ -18,12 +18,13 @@ from .exceptions import (
     GovernanceViolation,
     Severity,
 )
-from .models import Action, AuditRecord, LifecycleHook, RuleEvaluation
+from .models import Action, AuditRecord, EnforcementMode, LifecycleHook, RuleEvaluation
 
 __all__ = [
     # Output models (cross adapter boundary)
     "Action",
     "AuditRecord",
+    "EnforcementMode",
     "LifecycleHook",
     "RuleEvaluation",
     # Config

--- a/packages/uipath-core/src/uipath/core/governance/config.py
+++ b/packages/uipath-core/src/uipath/core/governance/config.py
@@ -1,8 +1,11 @@
 """Governance configuration.
 
 Process-level feature-flag gate that decides whether the Python
-governance checker runs at all. Enforcement mode is per-policy and
-lives in the runtime package alongside the ``/runtime/policy`` client.
+governance checker runs at all. The
+:class:`uipath.core.governance.EnforcementMode` value type is defined
+in :mod:`uipath.core.governance.models`; the per-policy runtime state
+that selects a mode (backend-supplied via the ``/runtime/policy``
+client) lives in the ``uipath-runtime`` package.
 """
 
 from __future__ import annotations

--- a/packages/uipath-core/src/uipath/core/governance/models.py
+++ b/packages/uipath-core/src/uipath/core/governance/models.py
@@ -1,10 +1,17 @@
-"""Shared governance output types.
+"""Shared governance contracts.
 
-These dataclasses cross the adapter boundary — every evaluator
-implementation (native, AGT, composite, …) produces them, and every
-adapter consumes them. They are kept free of policy-input concepts
-(``Rule``/``Check``/``Condition``) so the adapter packages don't
-inherit the native policy model.
+Two groups of types live here, both kept free of policy-input concepts
+(``Rule``/``Check``/``Condition``) so adapter packages don't inherit
+the native policy model:
+
+- **Output types** (:class:`Action`, :class:`LifecycleHook`,
+  :class:`RuleEvaluation`, :class:`AuditRecord`) — cross the adapter
+  boundary at evaluation time: every evaluator implementation (native,
+  AGT, composite, …) produces them, and every adapter consumes them.
+- **Configuration value types** (:class:`EnforcementMode`) — describe
+  governance configuration shared by core, runtime, and consumers. The
+  runtime state that selects an enforcement mode lives in
+  ``uipath-runtime``; only the value type lives here.
 """
 
 from __future__ import annotations
@@ -33,6 +40,14 @@ class LifecycleHook(str, Enum):
     AFTER_MODEL = "after_model"
     TOOL_CALL = "tool_call"
     AFTER_TOOL = "after_tool"
+
+
+class EnforcementMode(str, Enum):
+    """Governance enforcement modes."""
+
+    AUDIT = "audit"  # Evaluate and log; never block.
+    ENFORCE = "enforce"  # Block on DENY rules.
+    DISABLED = "disabled"  # Skip evaluation entirely.
 
 
 @dataclass

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-06T13:38:31.678016Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.18"
+version = "0.5.19"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.18"
+version = "0.5.19"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2659,7 +2659,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.18"
+version = "0.5.19"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },


### PR DESCRIPTION
## Summary
- Moves the `EnforcementMode` value type from `uipath-runtime-python` into `uipath.core.governance` so any governance consumer (adapters, customer code, other packages) can reference it without taking a dependency on `uipath-runtime`.
- Runtime state (`_enforcement_mode` cache, `get_enforcement_mode` / `set_enforcement_mode` / `reset_enforcement_mode`, `UIPATH_GOVERNANCE_MODE` env-var resolution) **stays** in `uipath-runtime` alongside the policy loader that drives it — only the enum itself is shared.
- Updates the misleading module docstring in `uipath.core.governance.config` that previously said enforcement mode lived in the runtime package.
- Bumps `uipath-core` to `0.5.19` so `uipath-runtime` can pin a version floor when it switches to importing the enum from here.

## Follow-up
A separate PR in `uipath-runtime-python` will update `src/uipath/runtime/governance/config.py` to re-export `EnforcementMode` from `uipath.core.governance` instead of redefining it, preventing drift between the two repos.

## Test plan
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` from `packages/uipath-core/` — all pass
- [x] `uv run pytest tests/governance/` — 18/18 pass, `models.py` at 100% coverage
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)