### PR TITLE
feat: add refreshSchemaBeforeCall to cached MCP tools config

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.11.8"
+version = "2.11.9"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -483,9 +483,18 @@ class DynamicToolsMode(str, CaseInsensitiveEnum):
 
 
 class CachedToolsConfig(BaseCfg):
-    """Cached tools configuration: use the tools saved in the agent definition snapshot."""
+    """Cached tools configuration: use the tools saved in the agent definition snapshot.
+
+    When ``refresh_schema_before_call`` is true, the live tool schema is fetched
+    from the MCP server immediately before a tool is invoked. The agent still uses
+    the cached schema to decide which tool to call; the fresh schema is applied only
+    at invocation time.
+    """
 
     type: Literal["cached"] = Field(default="cached", frozen=True)
+    refresh_schema_before_call: bool = Field(
+        default=True, alias="refreshSchemaBeforeCall"
+    )
 
 
 class DynamicToolsConfig(BaseCfg):

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -50,6 +50,7 @@ from uipath.agent.models.agent import (
     AssetRecipient,
     BatchTransformFileExtension,
     BatchTransformWebSearchGrounding,
+    CachedToolsConfig,
     CitationMode,
     CustomAssigneesRecipient,
     DeepRagFileExtension,
@@ -2037,6 +2038,53 @@ class TestAgentBuilderConfig:
         assert tool2.name == "tavily-extract"
         assert tool2.output_schema is not None
         assert "content" in tool2.output_schema["properties"]
+
+    def test_cached_tools_config_refresh_schema_default(self):
+        """CachedToolsConfig defaults refresh_schema_before_call to True."""
+
+        config = CachedToolsConfig()
+        assert config.type == "cached"
+        assert config.refresh_schema_before_call is True
+
+    def test_cached_tools_config_refresh_schema_alias_roundtrip(self):
+        """refresh_schema_before_call parses from and serializes to refreshSchemaBeforeCall."""
+
+        config = TypeAdapter(CachedToolsConfig).validate_python(
+            {"type": "cached", "refreshSchemaBeforeCall": False}
+        )
+        assert config.refresh_schema_before_call is False
+        assert config.model_dump(by_alias=True)["refreshSchemaBeforeCall"] is False
+
+    def test_mcp_resource_with_cached_tools_configuration(self):
+        """AgentMcpResourceConfig parses a cached toolsConfiguration with the refresh flag."""
+
+        json_data = {
+            "$resourceType": "mcp",
+            "folderPath": "solution_folder",
+            "slug": "tavily-mcp",
+            "name": "tavily",
+            "description": "Tavily search tools",
+            "isEnabled": True,
+            "availableTools": [
+                {
+                    "name": "tavily-search",
+                    "description": "Search the web",
+                    "inputSchema": {"type": "object", "properties": {}},
+                }
+            ],
+            "toolsConfiguration": {
+                "discoveryMode": {
+                    "type": "cached",
+                    "refreshSchemaBeforeCall": False,
+                }
+            },
+        }
+
+        mcp_resource = TypeAdapter(AgentMcpResourceConfig).validate_python(json_data)
+        assert mcp_resource.tools_configuration is not None
+        discovery_mode = mcp_resource.tools_configuration.discovery_mode
+        assert isinstance(discovery_mode, CachedToolsConfig)
+        assert discovery_mode.refresh_schema_before_call is False
 
     @pytest.mark.parametrize(
         "recipient_type_int,value,expected_type",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.8"
+version = "2.11.9"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- Add `refreshSchemaBeforeCall` field (default true) to `CachedToolsConfig`.
- Bump version to 2.11.9.
- Add tests for the default value, the `refreshSchemaBeforeCall` alias round-trip, and cached MCP resource parsing.

Related PRs:
- uipath-langchain: https://github.com/UiPath/uipath-langchain-python/pull/915
- Agents: https://github.com/UiPath/Agents/pull/5593
- uipath-agents-python: https://github.com/UiPath/uipath-agents-python/pull/545

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.11.9.dev1017306890",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.11.9.dev1017300000,<2.11.9.dev1017310000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```