### PR TITLE
feat(eval): add SimulateComponentMocker for per-component API-based simulation

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.11.7"
+version = "2.11.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/samples/simulate-component-agent/input.json
+++ b/packages/uipath/samples/simulate-component-agent/input.json
@@ -1,0 +1,4 @@
+{
+  "city": "London",
+  "days": 3
+}

--- a/packages/uipath/samples/simulate-component-agent/main.py
+++ b/packages/uipath/samples/simulate-component-agent/main.py
@@ -1,0 +1,118 @@
+"""Weather forecast agent demonstrating per-component simulation.
+
+This sample shows the new ``components`` simulation format where each tool
+has its own simulation strategy and instructions, routed to the
+simulate-component API instead of a local LLM.
+
+Run with real tools (no weather API — returns hardcoded defaults):
+    uipath run main -f input.json
+
+Run with per-component simulation (routes each tool call to the API):
+    uipath run main -f input.json --simulation "$(cat simulation.json)"
+"""
+
+from pydantic import BaseModel
+from pydantic.dataclasses import dataclass
+
+from uipath.eval.mocks import mockable
+from uipath.tracing import traced
+
+# ---------------------------------------------------------------------------
+# Input / Output models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WeatherInput:
+    city: str
+    days: int = 3
+
+
+class CurrentWeather(BaseModel):
+    city: str
+    temperature: float  # Celsius
+    condition: str
+    humidity: int  # percent
+
+
+class ForecastDay(BaseModel):
+    date: str  # YYYY-MM-DD
+    high: float
+    low: float
+    condition: str
+
+
+class WeatherReport(BaseModel):
+    current: CurrentWeather
+    forecast: list[ForecastDay]
+    summary: str
+
+
+# ---------------------------------------------------------------------------
+# Mockable tool functions
+# ---------------------------------------------------------------------------
+
+
+@traced(name="get_current_weather", span_type="tool")
+@mockable()
+async def get_current_weather(city: str) -> CurrentWeather:
+    """Fetch current weather conditions for a city from an external weather API.
+
+    Args:
+        city: Name of the city (e.g. "London", "New York").
+
+    Returns:
+        CurrentWeather with temperature, condition, and humidity.
+    """
+    # Real implementation would call a weather API such as OpenWeatherMap.
+    # Returns hardcoded defaults when not simulated.
+    return CurrentWeather(city=city, temperature=20.0, condition="unknown", humidity=50)
+
+
+@traced(name="get_forecast", span_type="tool")
+@mockable()
+async def get_forecast(city: str, days: int = 3) -> list[ForecastDay]:
+    """Retrieve a multi-day weather forecast for a city.
+
+    Args:
+        city: Name of the city.
+        days: Number of forecast days to retrieve (default: 3).
+
+    Returns:
+        List of ForecastDay objects, one per requested day.
+    """
+    # Real implementation would call a forecast API.
+    # Returns an empty list when not simulated.
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Agent entry point
+# ---------------------------------------------------------------------------
+
+
+@traced(name="main")
+async def main(input: WeatherInput) -> WeatherReport:
+    """Fetch current weather and forecast for a city and produce a report.
+
+    Args:
+        input: WeatherInput with city name and number of forecast days.
+
+    Returns:
+        WeatherReport combining current conditions, forecast, and a summary.
+    """
+    current = await get_current_weather(input.city)
+    forecast = await get_forecast(input.city, input.days)
+
+    issues = []
+    if current.humidity > 80:
+        issues.append("high humidity")
+    if current.temperature < 0:
+        issues.append("freezing temperatures")
+
+    alert = f" Alerts: {', '.join(issues)}." if issues else ""
+    summary = (
+        f"{input.city}: {current.temperature}°C, {current.condition}."
+        f" {len(forecast)}-day forecast available.{alert}"
+    )
+    return WeatherReport(current=current, forecast=forecast, summary=summary)

--- a/packages/uipath/samples/simulate-component-agent/pyproject.toml
+++ b/packages/uipath/samples/simulate-component-agent/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "simulate-component-agent"
+version = "0.0.1"
+description = "Weather forecast agent demonstrating per-component simulation"
+authors = [{ name = "UiPath", email = "python-sdk@uipath.com" }]
+dependencies = [
+    "uipath",
+]
+requires-python = ">=3.11"
+
+[dependency-groups]
+dev = [
+    "uipath-dev",
+]
+
+[tool.uv.sources]
+uipath = { path = "../..", editable = true }

--- a/packages/uipath/samples/simulate-component-agent/simulation.json
+++ b/packages/uipath/samples/simulate-component-agent/simulation.json
@@ -1,0 +1,73 @@
+{
+  "enabled": true,
+  "components": [
+    {
+      "componentId": "get_current_weather",
+      "componentType": "tool",
+      "simulationStrategy": 0,
+      "simulationInstruction": "Return realistic current weather for the given city. Use typical seasonal temperatures for the Northern Hemisphere in winter. the humidity should always be 70%",
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string"
+          },
+          "temperature": {
+            "type": "number",
+            "description": "Temperature in Celsius"
+          },
+          "condition": {
+            "type": "string",
+            "description": "e.g. cloudy, rainy, sunny"
+          },
+          "humidity": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        },
+        "required": [
+          "city",
+          "temperature",
+          "condition",
+          "humidity"
+        ]
+      }
+    },
+    {
+      "componentId": "get_forecast",
+      "componentType": "tool",
+      "simulationStrategy": 0,
+      "simulationInstruction": "Return a realistic multi-day weather forecast for the given city.",
+      "outputSchema": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "description": "YYYY-MM-DD"
+            },
+            "high": {
+              "type": "number",
+              "description": "High temperature in Celsius"
+            },
+            "low": {
+              "type": "number",
+              "description": "Low temperature in Celsius"
+            },
+            "condition": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "date",
+            "high",
+            "low",
+            "condition"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/uipath/samples/simulate-component-agent/uipath.json
+++ b/packages/uipath/samples/simulate-component-agent/uipath.json
@@ -1,0 +1,6 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "functions": {
+    "main": "main.py:main"
+  }
+}

--- a/packages/uipath/src/uipath/eval/mocks/__init__.py
+++ b/packages/uipath/src/uipath/eval/mocks/__init__.py
@@ -6,13 +6,31 @@ from ._mock_runtime import (
     build_mocking_context,
     build_mocking_context_from_dict,
 )
-from ._types import ExampleCall, MockingContext, SimulationConfig
+from ._types import (
+    ComponentSimulationConfig,
+    ExampleCall,
+    MockingContext,
+    RuleOperator,
+    SimulationAnswer,
+    SimulationAnswerType,
+    SimulationBehavior,
+    SimulationCondition,
+    SimulationConfig,
+    SimulationStrategy,
+)
 from .mockable import mockable
 
 __all__ = [
+    "ComponentSimulationConfig",
     "ExampleCall",
     "MockingContext",
+    "RuleOperator",
+    "SimulationAnswer",
+    "SimulationAnswerType",
+    "SimulationBehavior",
+    "SimulationCondition",
     "SimulationConfig",
+    "SimulationStrategy",
     "UiPathMockRuntime",
     "build_mocking_context",
     "build_mocking_context_from_dict",

--- a/packages/uipath/src/uipath/eval/mocks/_mock_context.py
+++ b/packages/uipath/src/uipath/eval/mocks/_mock_context.py
@@ -43,17 +43,25 @@ def is_tool_simulated(tool_name: str) -> bool:
         to be simulated, False otherwise.
     """
     ctx = mocking_context.get()
-    strategy = ctx.strategy if ctx else None
-    if strategy is None:
+    if ctx is None:
         return False
 
     normalized_tool_name = _normalize_tool_name(tool_name)
 
+    if ctx.components is not None:
+        return any(
+            _normalize_tool_name(c.component_id) == normalized_tool_name
+            for c in ctx.components
+        )
+
+    strategy = ctx.strategy
+    if strategy is None:
+        return False
+
     if isinstance(strategy, LLMMockingStrategy):
-        simulated_names = [
+        return normalized_tool_name in [
             _normalize_tool_name(t.name) for t in strategy.tools_to_simulate
         ]
-        return normalized_tool_name in simulated_names
     elif isinstance(strategy, MockitoMockingStrategy):
         return any(
             _normalize_tool_name(b.function) == normalized_tool_name
@@ -69,7 +77,13 @@ async def get_mocked_response(
     invocation: tuple[tuple[Any, ...], dict[str, Any]],
 ) -> Any:
     """Get a mocked response."""
+    import sys
+
     mocker = mocker_context.get()
+    print(
+        f"[simulate-component] get_mocked_response called for '{func.__name__}', mocker={type(mocker).__name__ if mocker else None}",
+        file=sys.stderr,
+    )
     if mocker is None:
         raise UiPathNoMockFoundError()
     else:

--- a/packages/uipath/src/uipath/eval/mocks/_mock_context.py
+++ b/packages/uipath/src/uipath/eval/mocks/_mock_context.py
@@ -48,7 +48,7 @@ def is_tool_simulated(tool_name: str) -> bool:
 
     normalized_tool_name = _normalize_tool_name(tool_name)
 
-    if ctx.components is not None:
+    if ctx.components:
         return any(
             _normalize_tool_name(c.component_id) == normalized_tool_name
             for c in ctx.components
@@ -77,13 +77,7 @@ async def get_mocked_response(
     invocation: tuple[tuple[Any, ...], dict[str, Any]],
 ) -> Any:
     """Get a mocked response."""
-    import sys
-
     mocker = mocker_context.get()
-    print(
-        f"[simulate-component] get_mocked_response called for '{func.__name__}', mocker={type(mocker).__name__ if mocker else None}",
-        file=sys.stderr,
-    )
     if mocker is None:
         raise UiPathNoMockFoundError()
     else:

--- a/packages/uipath/src/uipath/eval/mocks/_mock_runtime.py
+++ b/packages/uipath/src/uipath/eval/mocks/_mock_runtime.py
@@ -144,12 +144,6 @@ def set_execution_context(
         if context and (context.strategy or context.components):
             mocker = MockerFactory.create(context)
             mocker_context.set(mocker)
-            import sys
-
-            print(
-                f"[simulate-component] mocker set: {type(mocker).__name__}",
-                file=sys.stderr,
-            )
             logger.info(
                 "simulate-component: mocker created (%s)", type(mocker).__name__
             )

--- a/packages/uipath/src/uipath/eval/mocks/_mock_runtime.py
+++ b/packages/uipath/src/uipath/eval/mocks/_mock_runtime.py
@@ -37,16 +37,32 @@ logger = logging.getLogger(__name__)
 def build_mocking_context(
     config: SimulationConfig, agent_model: str | None = None
 ) -> MockingContext | None:
-    """Build a MockingContext from a validated SimulationConfig.
+    """Build a MockingContext from a validated SimulationConfig."""
+    if not config.enabled:
+        return None
 
-    Args:
-        config: Validated simulation config.
-        agent_model: Optional agent model name to use as fallback.
+    # New per-component format → routes to simulate-component API
+    if config.components:
+        from uipath.platform.common._config import UiPathConfig
 
-    Returns:
-        MockingContext if enabled and tools are specified, None otherwise.
-    """
-    if not config.enabled or not config.tools_to_simulate:
+        workload_id = (
+            getattr(UiPathConfig, "agent_id", None)
+            or getattr(UiPathConfig, "project_id", None)
+            or str(uuid.uuid4())
+        )
+        logger.debug(
+            f"Loaded simulation config for {len(config.components)} component(s)"
+        )
+        return MockingContext(
+            strategy=None,
+            name="debug-simulation",
+            inputs={},
+            components=config.components,
+            workload_id=workload_id,
+        )
+
+    # Legacy format (toolsToSimulate + instructions) → routes to local LLM mocker
+    if not config.tools_to_simulate:
         return None
 
     model = (
@@ -125,12 +141,22 @@ def set_execution_context(
     mocking_context.set(context)
 
     try:
-        if context and context.strategy:
-            mocker_context.set(MockerFactory.create(context))
+        if context and (context.strategy or context.components):
+            mocker = MockerFactory.create(context)
+            mocker_context.set(mocker)
+            import sys
+
+            print(
+                f"[simulate-component] mocker set: {type(mocker).__name__}",
+                file=sys.stderr,
+            )
+            logger.info(
+                "simulate-component: mocker created (%s)", type(mocker).__name__
+            )
         else:
             mocker_context.set(None)
     except Exception:
-        logger.warning("Failed to create mocker.")
+        logger.warning("Failed to create mocker.", exc_info=True)
         mocker_context.set(None)
 
     span_collector_context.set(span_collector)

--- a/packages/uipath/src/uipath/eval/mocks/_mocker_factory.py
+++ b/packages/uipath/src/uipath/eval/mocks/_mocker_factory.py
@@ -3,6 +3,7 @@
 from ._llm_mocker import LLMMocker
 from ._mocker import Mocker
 from ._mockito_mocker import MockitoMocker
+from ._simulate_component_mocker import SimulateComponentMocker
 from ._types import (
     LLMMockingStrategy,
     MockingContext,
@@ -16,6 +17,8 @@ class MockerFactory:
     @staticmethod
     def create(context: MockingContext) -> Mocker:
         """Create a mocker instance."""
+        if context.components:
+            return SimulateComponentMocker(context)
         match context.strategy:
             case LLMMockingStrategy():
                 return LLMMocker(context)

--- a/packages/uipath/src/uipath/eval/mocks/_simulate_component_mocker.py
+++ b/packages/uipath/src/uipath/eval/mocks/_simulate_component_mocker.py
@@ -1,0 +1,143 @@
+"""Mocker that routes tool calls through the simulate-component API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, cast
+
+from pydantic import TypeAdapter
+
+from uipath.platform.chat._llm_gateway_service import _cleanup_schema
+
+from .._execution_context import execution_id_context, span_collector_context
+from ._llm_mocker import LLMMocker
+from ._mocker import (
+    Mocker,
+    R,
+    T,
+    UiPathMockResponseGenerationError,
+    UiPathNoMockFoundError,
+)
+from ._simulate_component_service import _create_simulate_component_service
+from ._types import ComponentSimulationConfig, MockingContext
+
+logger = logging.getLogger(__name__)
+
+
+class SimulateComponentMocker(Mocker):
+    """Routes each tool call to the simulate-component API based on per-component config."""
+
+    def __init__(self, context: MockingContext) -> None:
+        self._context = context
+        self._components: dict[str, ComponentSimulationConfig] = {
+            c.component_id: c for c in (context.components or [])
+        }
+        self._normalized: dict[str, ComponentSimulationConfig] = {
+            c.component_id.replace("_", " "): c for c in (context.components or [])
+        }
+        self._workload_id = context.workload_id or ""
+
+    def _find_component(self, tool_name: str) -> ComponentSimulationConfig | None:
+        return self._components.get(tool_name) or self._normalized.get(
+            tool_name.replace("_", " ")
+        )
+
+    async def response(
+        self,
+        func: Callable[[T], R],
+        params: dict[str, Any],
+        invocation: tuple[tuple[Any, ...], dict[str, Any]],
+    ) -> R:
+        tool_name = params.get("name") or func.__name__
+        component = self._find_component(tool_name)
+
+        if component is None:
+            raise UiPathNoMockFoundError(f"No simulation config for '{tool_name}'.")
+
+        args, kwargs = invocation
+
+        return_type: Any = func.__annotations__.get("return", None) or Any
+        raw_output_schema = (
+            params.get("output_schema") or TypeAdapter(return_type).json_schema()
+        )
+        output_schema = component.output_schema or _cleanup_schema(raw_output_schema)
+        input_payload = {"args": list(args), "kwargs": kwargs}
+        input_schema = component.input_schema or params.get("input_schema")
+
+        execution_history = self._build_execution_history()
+        trace_id, parent_span_id = self._get_span_context()
+        workload_info = {
+            "name": self._context.name,
+            "userInput": self._context.inputs,
+        }
+
+        example_calls = [
+            {"id": ex.id, "input": ex.input, "output": ex.output}
+            for ex in (params.get("example_calls") or [])
+        ]
+
+        payload: dict[str, Any] = {
+            "workloadId": self._workload_id,
+            "componentId": component.component_id,
+            "componentType": component.component_type or "tool",
+            "componentDescription": component.component_description
+            or params.get("description"),
+            "input": input_payload,
+            "inputSchema": input_schema,
+            "outputSchema": output_schema,
+            "simulationInstruction": component.simulation_instruction,
+            "simulationStrategy": int(component.simulation_strategy),
+            "mockValue": component.mock_value,
+            "behaviors": (
+                [b.model_dump() for b in component.behaviors]
+                if component.behaviors
+                else None
+            ),
+            "exampleCalls": example_calls or None,
+            "executionHistory": execution_history or None,
+            "workloadInfo": workload_info,
+            "traceId": trace_id,
+            "parentSpanId": parent_span_id,
+        }
+
+        logger.info("simulate-component: calling API for '%s'", tool_name)
+        try:
+            service = _create_simulate_component_service()
+            result = await service.simulate(payload)
+        except Exception as e:
+            logger.error(
+                "simulate-component: API call failed for '%s': %s", tool_name, e
+            )
+            raise UiPathMockResponseGenerationError(
+                f"simulate-component API call failed for '{tool_name}'"
+            ) from e
+
+        status = result.get("status")
+        if status == 1:  # Completed
+            logger.info("simulate-component: '%s' simulated successfully", tool_name)
+            return cast(R, result.get("simulatedOutput"))
+
+        error = result.get("error") or {}
+        error_message = error.get("message", f"Simulation failed for '{tool_name}'")
+        logger.error("simulate-component: '%s' failed — %s", tool_name, error_message)
+        raise UiPathMockResponseGenerationError(error_message)
+
+    def _build_execution_history(self) -> str | None:
+        span_collector = span_collector_context.get()
+        execution_id = execution_id_context.get()
+        if span_collector and execution_id:
+            spans = span_collector.get_spans(execution_id)
+            return LLMMocker.spans_to_llm_context(spans) if spans else None
+        return None
+
+    @staticmethod
+    def _get_span_context() -> tuple[str | None, str | None]:
+        """Return (traceId, parentSpanId) from the current OTel span, or (None, None)."""
+        from opentelemetry import trace
+
+        span_ctx = trace.get_current_span().get_span_context()
+        if not span_ctx.is_valid:
+            return None, None
+        trace_id = f"{span_ctx.trace_id:032x}"
+        span_id = f"{span_ctx.span_id:016x}"
+        return trace_id, span_id

--- a/packages/uipath/src/uipath/eval/mocks/_simulate_component_service.py
+++ b/packages/uipath/src/uipath/eval/mocks/_simulate_component_service.py
@@ -1,0 +1,37 @@
+"""Service for calling the simulate-component API."""
+
+from typing import Any
+
+from uipath._utils import Endpoint
+from uipath.platform.common import BaseService
+
+
+class SimulateComponentService(BaseService):
+    async def simulate(self, payload: dict[str, Any]) -> dict[str, Any]:
+        from uipath.platform.common import UiPathConfig
+
+        headers: dict[str, str] = {}
+        if UiPathConfig.tenant_id:
+            headers["X-UiPath-Internal-TenantId"] = UiPathConfig.tenant_id
+        if UiPathConfig.organization_id:
+            headers["X-UiPath-Internal-AccountId"] = UiPathConfig.organization_id
+
+        response = await self.request_async(
+            "POST",
+            url=Endpoint(
+                "/agentsruntime_/api/execution/simulations/simulate-component"
+            ),
+            json=payload,
+            headers=headers,
+        )
+        return response.json()
+
+
+def _create_simulate_component_service() -> SimulateComponentService:
+    from uipath.platform import UiPath
+
+    uipath = UiPath()
+    return SimulateComponentService(
+        config=uipath._config,
+        execution_context=uipath._execution_context,
+    )

--- a/packages/uipath/src/uipath/eval/mocks/_types.py
+++ b/packages/uipath/src/uipath/eval/mocks/_types.py
@@ -121,18 +121,133 @@ class UnknownMockingStrategy(BaseMockingStrategy):
 MockingStrategy = Union[KnownMockingStrategy, UnknownMockingStrategy]
 
 
+# ---------------------------------------------------------------------------
+# Per-component simulation types — mirror the simulate-component API contract
+# ---------------------------------------------------------------------------
+
+
+class SimulationStrategy(int, Enum):
+    """Simulation strategy matching the simulate-component API.
+
+    Integer values are part of the cross-language API contract — do not reorder.
+    """
+
+    LLM = 0
+    MOCKITO = 1
+    STATIC = 2
+
+
+class RuleOperator(int, Enum):
+    """Comparison operator for Mockito condition matching.
+
+    Integer values are part of the cross-language API contract — do not reorder.
+    """
+
+    EQ = 0
+    NE = 1
+    GT = 2
+    GTE = 3
+    LT = 4
+    LTE = 5
+    CONTAINS = 6
+
+
+class SimulationAnswerType(int, Enum):
+    """Answer type for a Mockito simulation behavior.
+
+    Integer values are part of the cross-language API contract — do not reorder.
+    """
+
+    RETURN = 0
+    RAISE = 1
+
+
+class SimulationAnswer(BaseModel):
+    type: SimulationAnswerType = SimulationAnswerType.RETURN
+    value: Any = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class SimulationCondition(BaseModel):
+    field: str
+    op: RuleOperator = RuleOperator.EQ
+    value: Any = None
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class SimulationBehavior(BaseModel):
+    when: list[SimulationCondition] | None = None
+    then: list[SimulationAnswer]
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+
+class ComponentSimulationConfig(BaseModel):
+    """Per-component simulation config matching the simulate-component API request schema.
+
+    Runtime-injected fields (workloadId, runId, input, traceId, parentSpanId,
+    folderKey) are supplied at call time. inputSchema and outputSchema can be
+    overridden here; if omitted they are derived from the function annotations.
+    """
+
+    component_id: str = Field(..., alias="componentId")
+    component_type: str | None = Field(None, alias="componentType")
+    component_description: str | None = Field(None, alias="componentDescription")
+    simulation_instruction: str | None = Field(None, alias="simulationInstruction")
+    simulation_strategy: SimulationStrategy = Field(
+        SimulationStrategy.LLM, alias="simulationStrategy"
+    )
+    mock_value: Any = Field(None, alias="mockValue")
+    behaviors: list[SimulationBehavior] | None = None
+    input_schema: dict[str, Any] | None = Field(None, alias="inputSchema")
+    output_schema: dict[str, Any] | None = Field(None, alias="outputSchema")
+
+    model_config = ConfigDict(
+        validate_by_name=True, validate_by_alias=True, extra="allow"
+    )
+
+
 class MockingContext(BaseModel):
     """Execution context for mocking, holding strategy and inputs."""
 
     strategy: MockingStrategy | None
     inputs: dict[str, Any] = Field(default_factory=lambda: {})
     name: str = Field(default="debug")
+    # When set, SimulateComponentMocker routes each tool call to the simulate-component API.
+    components: list[ComponentSimulationConfig] | None = None
+    workload_id: str | None = None
 
 
 class SimulationConfig(BaseModel):
-    """Top-level schema for simulation.json / --simulation flag."""
+    """Top-level schema for simulation.json / --simulation flag.
+
+    New format (routes to simulate-component API):
+        {
+            "enabled": true,
+            "components": [
+                {
+                    "componentId": "my_tool",
+                    "componentType": "tool",
+                    "simulationStrategy": 0,
+                    "simulationInstruction": "Simulate this tool by..."
+                }
+            ]
+        }
+
+    Legacy format (routes to local LLM mocker):
+        {
+            "enabled": true,
+            "toolsToSimulate": [{"name": "my_tool"}],
+            "instructions": "Simulate these tools by..."
+        }
+    """
 
     enabled: bool = True
+    # New per-component format — when non-empty, routes to simulate-component API.
+    components: list[ComponentSimulationConfig] = Field(default_factory=list)
+    # Legacy flat format — used when components is empty; routes to local LLM mocker.
     tools_to_simulate: list[ToolSimulation] = Field(
         default_factory=list, alias="toolsToSimulate"
     )

--- a/packages/uipath/tests/cli/eval/mocks/test_simulate_component.py
+++ b/packages/uipath/tests/cli/eval/mocks/test_simulate_component.py
@@ -1,0 +1,442 @@
+"""Tests for SimulateComponentMocker and SimulateComponentService."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from pytest_httpx import HTTPXMock
+
+from uipath.eval.mocks._mock_context import is_tool_simulated
+from uipath.eval.mocks._mock_runtime import (
+    clear_execution_context,
+    set_execution_context,
+)
+from uipath.eval.mocks._mocker import (
+    UiPathMockResponseGenerationError,
+)
+from uipath.eval.mocks._simulate_component_mocker import SimulateComponentMocker
+from uipath.eval.mocks._simulate_component_service import (
+    SimulateComponentService,
+    _create_simulate_component_service,
+)
+from uipath.eval.mocks._types import (
+    ComponentSimulationConfig,
+    MockingContext,
+    SimulationStrategy,
+    UnknownMockingStrategy,
+)
+from uipath.eval.mocks.mockable import mockable
+
+_mock_span_collector = MagicMock()
+
+BASE_URL = "https://example.com"
+_SIMULATE_PATH = (
+    "uipath.eval.mocks._simulate_component_mocker._create_simulate_component_service"
+)
+
+
+def _make_context(
+    component_id: str = "my_tool",
+    strategy: SimulationStrategy = SimulationStrategy.LLM,
+    instruction: str = "simulate it",
+    workload_id: str = "wl-123",
+) -> MockingContext:
+    return MockingContext(
+        strategy=None,
+        name="test-run",
+        inputs={"q": "hello"},
+        workload_id=workload_id,
+        components=[
+            ComponentSimulationConfig(
+                component_id=component_id,
+                component_type="tool",
+                simulation_strategy=strategy,
+                simulation_instruction=instruction,
+            )
+        ],
+    )
+
+
+def _make_service_mock(result: dict[str, Any]) -> MagicMock:
+    svc = MagicMock()
+    svc.simulate = AsyncMock(return_value=result)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# is_tool_simulated with components format
+# ---------------------------------------------------------------------------
+
+
+class TestIsToolSimulatedWithComponents:
+    def setup_method(self):
+        clear_execution_context()
+
+    def teardown_method(self):
+        clear_execution_context()
+
+    def test_returns_true_for_listed_component(self):
+        set_execution_context(_make_context("search_tool"), _mock_span_collector, "x")
+        assert is_tool_simulated("search_tool") is True
+
+    def test_returns_false_for_unlisted_component(self):
+        set_execution_context(_make_context("search_tool"), _mock_span_collector, "x")
+        assert is_tool_simulated("other_tool") is False
+
+    def test_underscore_space_normalisation(self):
+        ctx = MockingContext(
+            strategy=None,
+            name="run",
+            inputs={},
+            components=[
+                ComponentSimulationConfig(
+                    component_id="web search",
+                    simulation_strategy=SimulationStrategy.LLM,
+                )
+            ],
+        )
+        set_execution_context(ctx, _mock_span_collector, "x")
+        assert is_tool_simulated("web_search") is True
+
+    def test_returns_false_when_components_list_is_empty(self):
+        ctx = MockingContext(strategy=None, name="run", inputs={}, components=[])
+        set_execution_context(ctx, _mock_span_collector, "x")
+        # components is set but empty — MockerFactory won't create a mocker (components is not None)
+        # is_tool_simulated: ctx.components is not None → iterates empty list → False
+        assert is_tool_simulated("any_tool") is False
+
+
+# ---------------------------------------------------------------------------
+# SimulateComponentMocker._find_component
+# ---------------------------------------------------------------------------
+
+
+class TestFindComponent:
+    def test_finds_by_exact_id(self):
+        mocker = SimulateComponentMocker(_make_context("my_tool"))
+        assert mocker._find_component("my_tool") is not None
+
+    def test_finds_by_underscore_to_space_normalisation(self):
+        ctx = MockingContext(
+            strategy=None,
+            name="run",
+            inputs={},
+            components=[
+                ComponentSimulationConfig(
+                    component_id="web search",
+                    simulation_strategy=SimulationStrategy.LLM,
+                )
+            ],
+        )
+        mocker = SimulateComponentMocker(ctx)
+        assert mocker._find_component("web_search") is not None
+
+    def test_returns_none_for_unknown_tool(self):
+        mocker = SimulateComponentMocker(_make_context("my_tool"))
+        assert mocker._find_component("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# SimulateComponentMocker.response — success path
+# ---------------------------------------------------------------------------
+
+
+class TestSimulateComponentMockerResponse:
+    @pytest.mark.asyncio
+    async def test_returns_simulated_output_on_status_1(self):
+        ctx = _make_context("my_tool")
+        svc_mock = _make_service_mock({"status": 1, "simulatedOutput": "hello"})
+
+        @mockable()
+        async def my_tool() -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-1")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            result = await my_tool()
+
+        assert result == "hello"
+        clear_execution_context()
+
+    @pytest.mark.asyncio
+    async def test_raises_generation_error_on_non_1_status(self):
+        ctx = _make_context("my_tool")
+        svc_mock = _make_service_mock(
+            {"status": 2, "error": {"message": "LLM timeout"}}
+        )
+
+        @mockable()
+        async def my_tool() -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-2")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            with pytest.raises(UiPathMockResponseGenerationError, match="LLM timeout"):
+                await my_tool()
+
+        clear_execution_context()
+
+    @pytest.mark.asyncio
+    async def test_raises_generic_error_when_error_message_missing(self):
+        ctx = _make_context("my_tool")
+        svc_mock = _make_service_mock({"status": 0, "error": {}})
+
+        @mockable()
+        async def my_tool() -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-3")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            with pytest.raises(
+                UiPathMockResponseGenerationError, match="Simulation failed"
+            ):
+                await my_tool()
+
+        clear_execution_context()
+
+    @pytest.mark.asyncio
+    async def test_raises_generation_error_when_api_throws(self):
+        ctx = _make_context("my_tool")
+        svc_mock = MagicMock()
+        svc_mock.simulate = AsyncMock(side_effect=RuntimeError("network error"))
+
+        @mockable()
+        async def my_tool() -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-4")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            with pytest.raises(
+                UiPathMockResponseGenerationError,
+                match="simulate-component API call failed",
+            ):
+                await my_tool()
+
+        clear_execution_context()
+
+    @pytest.mark.asyncio
+    async def test_raises_no_mock_found_for_unconfigured_tool(self):
+        ctx = _make_context("my_tool")
+
+        @mockable()
+        async def other_tool() -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-5")
+        # other_tool is not in components → falls through to real function
+        with pytest.raises(NotImplementedError):
+            await other_tool()
+
+        clear_execution_context()
+
+
+# ---------------------------------------------------------------------------
+# Payload construction
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadConstruction:
+    @pytest.mark.asyncio
+    async def test_payload_fields_sent_to_service(self):
+        ctx = _make_context("my_tool", instruction="Do something", workload_id="wl-99")
+        captured: list[dict[str, Any]] = []
+
+        async def _capture(payload, **kwargs):
+            captured.append(payload)
+            return {"status": 1, "simulatedOutput": "ok"}
+
+        svc_mock = MagicMock()
+        svc_mock.simulate = _capture
+
+        @mockable()
+        async def my_tool(x: int) -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-6")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            await my_tool(x=42)
+
+        assert len(captured) == 1
+        p = captured[0]
+        assert p["workloadId"] == "wl-99"
+        assert p["componentId"] == "my_tool"
+        assert p["componentType"] == "tool"
+        assert p["simulationInstruction"] == "Do something"
+        assert p["simulationStrategy"] == int(SimulationStrategy.LLM)
+        assert p["workloadInfo"] == {"name": "test-run", "userInput": {"q": "hello"}}
+
+        clear_execution_context()
+
+    @pytest.mark.asyncio
+    async def test_sync_mockable_also_works(self):
+        ctx = _make_context("sync_tool")
+        svc_mock = _make_service_mock({"status": 1, "simulatedOutput": 42})
+
+        @mockable()
+        def sync_tool() -> int:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-7")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            result = sync_tool()
+
+        assert result == 42
+        clear_execution_context()
+
+    @pytest.mark.asyncio
+    async def test_payload_uses_configured_component_id_not_invoked_name(self):
+        """componentId in payload must be the configured ID, not the normalised call name."""
+        ctx = MockingContext(
+            strategy=None,
+            name="run",
+            inputs={},
+            components=[
+                ComponentSimulationConfig(
+                    component_id="web search",
+                    simulation_strategy=SimulationStrategy.LLM,
+                )
+            ],
+        )
+        captured: list[dict[str, Any]] = []
+
+        async def _capture(payload, **kwargs):
+            captured.append(payload)
+            return {"status": 1, "simulatedOutput": "ok"}
+
+        svc_mock = MagicMock()
+        svc_mock.simulate = _capture
+
+        @mockable()
+        async def web_search() -> str:
+            raise NotImplementedError()
+
+        set_execution_context(ctx, _mock_span_collector, "exec-8")
+        with patch(_SIMULATE_PATH, return_value=svc_mock):
+            await web_search()
+
+        assert captured[0]["componentId"] == "web search"
+        clear_execution_context()
+
+
+# ---------------------------------------------------------------------------
+# _build_execution_history — uncovered branch (no context vars set)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExecutionHistory:
+    def test_returns_none_when_context_vars_not_set(self):
+        clear_execution_context()
+        mocker = SimulateComponentMocker(_make_context())
+        assert mocker._build_execution_history() is None
+
+    def test_returns_none_when_spans_empty(self):
+        from uipath.eval._execution_context import (
+            execution_id_context,
+            span_collector_context,
+        )
+
+        span_collector = MagicMock()
+        span_collector.get_spans = MagicMock(return_value=[])
+        span_collector_context.set(span_collector)
+        execution_id_context.set("exec-id")
+
+        mocker = SimulateComponentMocker(_make_context())
+        assert mocker._build_execution_history() is None
+
+        clear_execution_context()
+
+
+# ---------------------------------------------------------------------------
+# MockerFactory — unknown strategy raises ValueError
+# ---------------------------------------------------------------------------
+
+
+class TestMockerFactory:
+    def test_raises_for_unknown_strategy(self):
+        from uipath.eval.mocks._mocker_factory import MockerFactory
+
+        ctx = MockingContext(
+            strategy=UnknownMockingStrategy(type="future_strategy"),
+            name="test",
+            inputs={},
+            components=None,
+        )
+        with pytest.raises(ValueError, match="Unknown mocking strategy"):
+            MockerFactory.create(ctx)
+
+    def test_raises_for_none_strategy_and_no_components(self):
+        from uipath.eval.mocks._mocker_factory import MockerFactory
+
+        ctx = MockingContext(strategy=None, name="test", inputs={}, components=None)
+        with pytest.raises(ValueError, match="Unknown mocking strategy"):
+            MockerFactory.create(ctx)
+
+
+# ---------------------------------------------------------------------------
+# is_tool_simulated — unknown strategy falls through to False
+# ---------------------------------------------------------------------------
+
+
+class TestIsToolSimulatedUnknownStrategy:
+    def setup_method(self):
+        clear_execution_context()
+
+    def teardown_method(self):
+        clear_execution_context()
+
+    def test_returns_false_for_unknown_strategy(self):
+
+        ctx = MockingContext(
+            strategy=UnknownMockingStrategy(type="future_strategy"),
+            name="test",
+            inputs={},
+            components=None,
+        )
+        set_execution_context(ctx, _mock_span_collector, "x")
+        assert is_tool_simulated("any_tool") is False
+
+
+# ---------------------------------------------------------------------------
+# SimulateComponentService — actual HTTP call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+async def test_simulate_component_service_http_call(
+    httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch
+):
+    monkeypatch.setenv("UIPATH_URL", "https://example.com/myorg/mytenant")
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "token")
+
+    httpx_mock.add_response(
+        url="https://example.com/myorg/mytenant/agentsruntime_/api/execution/simulations/simulate-component",
+        method="POST",
+        json={"status": 1, "simulatedOutput": "result"},
+    )
+
+    service = _create_simulate_component_service()
+    assert isinstance(service, SimulateComponentService)
+
+    result = await service.simulate({"componentId": "my_tool"})
+    assert result == {"status": 1, "simulatedOutput": "result"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+async def test_simulate_component_service_no_headers(
+    httpx_mock: HTTPXMock, monkeypatch: MonkeyPatch
+):
+    monkeypatch.setenv("UIPATH_URL", "https://example.com/myorg/mytenant")
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "token")
+
+    httpx_mock.add_response(
+        url="https://example.com/myorg/mytenant/agentsruntime_/api/execution/simulations/simulate-component",
+        method="POST",
+        json={"status": 0, "error": {"message": "boom"}},
+    )
+
+    service = _create_simulate_component_service()
+    result = await service.simulate({"componentId": "my_tool"})
+    assert result["status"] == 0

--- a/packages/uipath/tests/cli/test_debug_simulation.py
+++ b/packages/uipath/tests/cli/test_debug_simulation.py
@@ -82,11 +82,12 @@ class TestLoadSimulationConfig:
             assert result is not None
             assert isinstance(result, MockingContext)
             assert result.name == "debug-simulation"
-            assert result.strategy is not None
+            # Legacy format routes to local LLM mocker via strategy
+            assert result.components is None or len(result.components) == 0
             assert isinstance(result.strategy, LLMMockingStrategy)
-            assert result.strategy.prompt == valid_simulation_config["instructions"]
             assert len(result.strategy.tools_to_simulate) == 3
             assert result.strategy.tools_to_simulate[0].name == "Web Reader"
+            assert result.strategy.prompt == valid_simulation_config["instructions"]
 
     def test_returns_none_when_disabled(
         self, temp_dir: str, disabled_simulation_config: dict[str, Any]
@@ -421,6 +422,34 @@ class TestSimulationConfigFields:
             result = load_simulation_config()
             # Should load successfully since enabled defaults to true
             assert result is not None
+
+    def test_new_format_loads_components(self, temp_dir: str):
+        """Test that new per-component format routes to API-based mocker (components set)."""
+        config = {
+            "enabled": True,
+            "components": [
+                {
+                    "componentId": "my_tool",
+                    "componentType": "tool",
+                    "simulationStrategy": 0,
+                    "simulationInstruction": "Simulate this tool",
+                }
+            ],
+        }
+        simulation_path = Path(temp_dir) / "simulation.json"
+        with open(simulation_path, "w", encoding="utf-8") as f:
+            json.dump(config, f)
+
+        with patch(f"{MOCK_RUNTIME_PATCH_PATH}.Path.cwd", return_value=Path(temp_dir)):
+            result = load_simulation_config()
+
+            assert result is not None
+            assert isinstance(result, MockingContext)
+            # New format: components set, strategy is None
+            assert result.components is not None
+            assert len(result.components) == 1
+            assert result.components[0].component_id == "my_tool"
+            assert result.strategy is None
 
     def test_handles_tool_name_normalization(self, temp_dir: str):
         """Test that tool names with underscores work correctly."""

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.7"
+version = "2.11.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

- Adds a new `components` format to `simulation.json` that routes each tool call to the
  `/agentsruntime_/api/execution/simulations/simulate-component` API instead of the local LLM mocker
- Introduces `SimulateComponentMocker`, `SimulateComponentService`, and 7 new types
  (`SimulationStrategy`, `RuleOperator`, `SimulationAnswerType`, `SimulationAnswer`,
  `SimulationCondition`, `SimulationBehavior`, `ComponentSimulationConfig`) mirroring the API contract
- Legacy format (`toolsToSimulate` + `instructions`) is fully preserved — no breaking changes

## Design decisions

- Endpoint uses `agentsruntime_` service prefix, which means `UIPATH_SERVICE_URL_AGENTSRUNTIME`
  env var can redirect to a local service for development
- `componentId` in the payload uses the **configured** component ID (not the normalised invoked name)
  to ensure server-side simulation rules match correctly
- Empty `components: []` does not activate the API mocker (truthiness check, not `is not None`)

## Test plan

- [ ] Existing simulation tests pass (`pytest tests/cli/test_debug_simulation.py`)
- [ ] New tests in `tests/cli/eval/mocks/test_simulate_component.py` all pass (coverage 100%)
- [ ] `ruff check .` passes with no errors
- [ ] `mypy` passes with no errors
- [ ] Manual: run `uipath debug` with a `simulation.json` using the new `components` format and
      verify the API call is made to `agentsruntime_/api/execution/simulations/simulate-component`
- [ ] Manual: verify legacy `toolsToSimulate` format still routes to the local LLM mocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)


```
ANIPIK--FFQTDV0N47:simulate-component-agent anipik$ uv run uipath run main -f input.json --simulation "$(cat simulation.json)"  
Resource overwrites config file not found: __uipath/uipath.json
▶ START 
[simulate-component] mocker set: SimulateComponentMocker
simulate-component: mocker created (SimulateComponentMocker)
[simulate-component] get_mocked_response called for 'get_current_weather', mocker=SimulateComponentMocker
simulate-component: calling API for 'get_current_weather'
HTTP Request: POST https://alpha.uipath.com/agentsurt/DefaultTenant/agentsruntime_/api/execution/simulations/simulate-component "HTTP/1.1 200 OK"
simulate-component: 'get_current_weather' simulated successfully
[simulate-component] get_mocked_response called for 'get_forecast', mocker=SimulateComponentMocker
simulate-component: calling API for 'get_forecast'
HTTP Request: POST https://alpha.uipath.com/agentsurt/DefaultTenant/agentsruntime_/api/execution/simulations/simulate-component "HTTP/1.1 200 OK"
simulate-component: 'get_forecast' simulated successfully
● END
output
├── current (dict)
│   ├── city: London
│   ├── temperature: 6.5
│   ├── condition: cloudy
│   └── humidity: 70
├── forecast (list, 3 items)
│   ├── #0 (dict)
│   │   ├── date: 2024-01-15
│   │   ├── high: 8.0
│   │   ├── low: 3.0
│   │   └── condition: Partly cloudy
│   ├── #1 (dict)
│   │   ├── date: 2024-01-16
│   │   ├── high: 6.0
│   │   ├── low: 2.0
│   │   └── condition: Light rain
│   └── #2 (dict)
│       ├── date: 2024-01-17
│       ├── high: 7.0
│       ├── low: 4.0
│       └── condition: Overcast
└── summary: London: 6.5°C, cloudy. 3-day forecast available.
✓  Successful execution.
'id' field not present in uipath.json
```