### PR TITLE
fix(eval): match tool-call names via the langchain sanitiser

### DIFF
--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
@@ -12,6 +13,18 @@ from ..models import (
 )
 
 TOOL_NAME_ATTR = "tool.name"
+
+# Mirrors uipath_langchain.agent.tools.utils.sanitize_tool_name. Kept in sync
+# by TestSanitizedNameMatch in tests/evaluators/test_evaluator_helpers.py.
+_TOOL_NAME_DISALLOWED = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _normalize_tool_name(name: str | None) -> str:
+    """Sanitise a tool name the same way the LangChain runtime does."""
+    if not name:
+        return ""
+    return _TOOL_NAME_DISALLOWED.sub("", "_".join(name.split()))[:64]
+
 
 COMPARATOR_MAPPINGS = {
     ">": "gt",
@@ -42,23 +55,27 @@ def _match_key(actual_name: str, actual_id: str | None, expected_key: str) -> bo
     """True when `expected_key` matches either the actual call's `id` or `name`.
 
     Eval-set criteria can be authored against either the tool's stable id or
-    its display name; the scorers accept whichever the author used.
+    its display name; the scorers accept whichever the author used. Name
+    comparison normalises both sides through the LangChain sanitiser so the
+    display name persisted by the editor (``"Web Search"``) matches the
+    sanitised name emitted by the runtime (``"Web_Search"``).
     """
     if actual_id is not None and expected_key == actual_id:
         return True
-    return expected_key == actual_name
+    return _normalize_tool_name(expected_key) == _normalize_tool_name(actual_name)
 
 
 def _calls_match(actual, expected) -> bool:
     """True when an actual ToolCall/ToolOutput matches an expected one.
 
     Prefers id-equality when both sides carry an id; otherwise falls back to
-    name-equality. This keeps the legacy name-keyed behavior intact while
-    making id-keyed eval-sets rename-safe.
+    sanitised-name equality. This keeps the legacy name-keyed behavior intact
+    while closing the display-vs-sanitised mismatch, and makes id-keyed
+    eval-sets rename-safe.
     """
     if actual.id is not None and expected.id is not None:
         return actual.id == expected.id
-    return actual.name == expected.name
+    return _normalize_tool_name(actual.name) == _normalize_tool_name(expected.name)
 
 
 def _parse_tool_args(input_value: Any) -> dict[str, Any]:

--- a/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
+++ b/packages/uipath/src/uipath/eval/_helpers/evaluators_helpers.py
@@ -441,7 +441,14 @@ def tool_calls_count_score(
         expected_comparator,
         expected_count,
     ) in expected_tool_calls_count.items():
-        actual_count = actual_tool_calls_count.get(tool_name, 0.0)
+        # Expected dict keys come from the editor (display name like "Web Search");
+        # actual dict keys come from the runtime span (sanitised "Web_Search").
+        # Try the raw key first (covers id-keyed and already-sanitised criteria),
+        # fall back to the sanitised form so display names still match.
+        actual_count = actual_tool_calls_count.get(
+            tool_name,
+            actual_tool_calls_count.get(_normalize_tool_name(tool_name), 0.0),
+        )
         comparator = f"__{COMPARATOR_MAPPINGS[expected_comparator]}__"
         to_add = float(getattr(actual_count, comparator)(expected_count))
 

--- a/packages/uipath/tests/evaluators/test_evaluator_helpers.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_helpers.py
@@ -1200,3 +1200,36 @@ class TestSanitizedNameMatch:
         actual = ToolOutput(name="Web_Search", output="x")
         expected = ToolOutput(name="Web Search", output="x")
         assert _calls_match(actual, expected) is True
+
+    def test_count_score_display_name_matches_sanitised_actual(self) -> None:
+        """Count scorer must close the same display-vs-sanitised gap.
+
+        ``tool_calls_count_score`` does raw dict lookup, not ``_match_key``,
+        so it needs its own sanitisation fallback. Without it, an editor
+        criterion keyed by ``"Web Search"`` misses the actual counts keyed by
+        ``"Web_Search"`` and scores 0.
+        """
+        actual = {"Web_Search": 2}
+        expected = {"Web Search": ("==", 2)}
+        score, _ = tool_calls_count_score(actual, expected)
+        assert score == 1.0
+
+    def test_count_score_id_keyed_expected_still_wins(self) -> None:
+        """When the editor saves an id-keyed criterion, raw lookup hits first."""
+        actual = {"Web_Search": 1, "uuid-web-1": 1}
+        expected = {"uuid-web-1": (">=", 1)}
+        score, _ = tool_calls_count_score(actual, expected)
+        assert score == 1.0
+
+    def test_count_score_strict_mode_passes_on_display_name(self) -> None:
+        actual = {"Web_Search": 1}
+        expected = {"Web Search": ("==", 1)}
+        score, _ = tool_calls_count_score(actual, expected, strict=True)
+        assert score == 1.0
+
+    def test_count_score_strict_mode_fails_on_count_mismatch(self) -> None:
+        """Sanitisation closes name gap but a wrong count still fails strict."""
+        actual = {"Web_Search": 1}
+        expected = {"Web Search": ("==", 3)}
+        score, _ = tool_calls_count_score(actual, expected, strict=True)
+        assert score == 0.0

--- a/packages/uipath/tests/evaluators/test_evaluator_helpers.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_helpers.py
@@ -1114,3 +1114,89 @@ class TestIdAwareMatching:
         ]
         score, _ = tool_calls_order_score_with_ids(actual, ["get_temp", "get_humidity"])
         assert score == 1.0
+
+
+class TestSanitizedNameMatch:
+    """Sanitised-name fallback in ``_match_key`` and ``_calls_match``.
+
+    The display name the editor persists (``"Web Search"``) must match the
+    sanitised name the LangChain runtime emits as ``tool.name``
+    (``"Web_Search"``). Both sides are normalised through the same regex.
+    """
+
+    def _reference_sanitize(self, name: str) -> str:
+        """Pinned copy of ``uipath_langchain.agent.tools.utils.sanitize_tool_name``.
+
+        Kept here intentionally rather than imported live — ``uipath_langchain``
+        is not a dep of ``uipath`` (wrong direction). If the LangChain
+        sanitiser changes upstream, this copy must be updated together with
+        ``_normalize_tool_name`` in ``evaluators_helpers``.
+        """
+        import re
+
+        trim_whitespaces = "_".join(name.split())
+        sanitized = re.sub(r"[^a-zA-Z0-9_-]", "", trim_whitespaces)
+        return sanitized[:64]
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "Web Search",
+            "Google Sheets / Read",
+            "Add Numbers",
+            "tool with spaces and (parens)",
+            "snake_case_tool",
+            "kebab-case-tool",
+            "alreadySanitised",
+            "  multiple   whitespace  ",
+            "very-long-name-" + "x" * 100,
+            "",
+        ],
+    )
+    def test_normalize_matches_langchain_reference(self, raw: str) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _normalize_tool_name
+
+        assert _normalize_tool_name(raw) == self._reference_sanitize(raw)
+
+    def test_normalize_handles_none(self) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _normalize_tool_name
+
+        assert _normalize_tool_name(None) == ""
+
+    def test_match_key_display_name_vs_sanitised_actual(self) -> None:
+        """Editor saved ``"Web Search"``; runtime emitted ``"Web_Search"``."""
+        from uipath.eval._helpers.evaluators_helpers import _match_key
+
+        assert _match_key("Web_Search", None, "Web Search") is True
+
+    def test_match_key_id_still_wins_when_present(self) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _match_key
+
+        assert _match_key("Web_Search", "uuid-1", "uuid-1") is True
+        assert _match_key("Web_Search", "uuid-1", "Web Search") is True
+
+    def test_match_key_mismatch_after_sanitising(self) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _match_key
+
+        assert _match_key("Web_Search", None, "Image_Search") is False
+
+    def test_calls_match_display_vs_sanitised(self) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _calls_match
+
+        actual = ToolCall(name="Web_Search", args={})
+        expected = ToolCall(name="Web Search", args={})
+        assert _calls_match(actual, expected) is True
+
+    def test_calls_match_id_equality_unchanged(self) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _calls_match
+
+        actual = ToolCall(name="Web_Search", id="uuid-1", args={})
+        expected = ToolCall(name="totally different", id="uuid-1", args={})
+        assert _calls_match(actual, expected) is True
+
+    def test_calls_match_output_display_vs_sanitised(self) -> None:
+        from uipath.eval._helpers.evaluators_helpers import _calls_match
+
+        actual = ToolOutput(name="Web_Search", output="x")
+        expected = ToolOutput(name="Web Search", output="x")
+        assert _calls_match(actual, expected) is True


### PR DESCRIPTION
## Summary
- Closes the display-vs-sanitised gap in tool-call evaluators: the editor persists \"Web Search\" while the runtime emits \"Web_Search\" on the tool span, and the name-equality fallback in `_match_key` / `_calls_match` previously scored 0 on that mismatch.
- Both sides are now normalised through the same algorithm as `uipath_langchain.agent.tools.utils.sanitize_tool_name` before comparing — split-on-whitespace, strip non `[A-Za-z0-9_-]`, truncate to 64 chars.
- Id-equality still wins first when both sides carry an id (#1725 behaviour preserved); this only changes the name-fallback path.

## Context
- Sister fix to #1725 (id-aware match, already merged). Together they cover both rename-safety (id) and the immediate sanitisation gap (this PR).
- Producer-side `tool.id` emission and the flow-workbench id-capture changes are parked in favour of this smaller landing path. Tracked in a follow-up so they can be revived once stable per-tool ids exist on the canvas (today they do not for non-connector tools, and connection-id is ambiguous for N tools sharing one connection like Google Sheets read/write/query).
- Follow-up commit `3d4d3e30` closes the same gap on the count-scorer path (caught in review — `tool_calls_count_score` does raw dict lookup and bypasses `_match_key`).

## Sync hazard
`_normalize_tool_name` mirrors `uipath_langchain.agent.tools.utils.sanitize_tool_name`. `uipath_langchain` cannot be imported here (the dependency edge runs the other way), so the sync is enforced by `TestSanitizedNameMatch._reference_sanitize` — a pinned copy of the langchain algorithm. If the langchain sanitiser changes, both the matcher and the reference test must be updated together. A cleaner long-term fix is to move the sanitiser into a shared package — tracked in the follow-up issue.

## Test plan
- [x] `pytest tests/evaluators/test_evaluator_helpers.py` — passes (83 existing + 21 new)
- [x] `pytest tests/cli/eval/ tests/evaluators/` — 891 passed, full eval surface unchanged
- [x] `ruff check` / `ruff format --check` / `mypy` on touched files — all green
- [x] Hermetic in-process proof (see below)
- [ ] Verify with a real cloud trace once worker is on a release including this fix

## Local verification

`/tmp/sanitiser_proof.py` constructs the failing case in memory — actuals carry the sanitised name (`\"Web_Search\"`), criteria carry the display name (`\"Web Search\"`), neither side has a `tool.id`. The same scorers are then run twice: first with `_normalize_tool_name` monkey-patched to identity (simulating pre-#1733 behaviour), then natively on this branch.

```
Hermetic proof — PR #1733 (sanitised-name match in tool-call evaluators)
  Expected (editor)   :  display name \"Web Search\"
  Actual   (runtime)  :  sanitised   \"Web_Search\"
  Neither side carries a tool.id (display-name-only eval set).

BEFORE #1733 — _normalize_tool_name monkeypatched to identity
────────────────────────────────────────────────────────────
  ✗  tool_calls_count_score          (prod)    score = 0.0
  ✗  tool_calls_order_score_with_ids (prod)    score = 0.0
  ✗  tool_calls_args_score           (prod)    score = 0.0
  ✗  tool_calls_output_score         (prod)    score = 0.0
  ✗  tool_calls_order_score          (legacy)  score = 0.0

AFTER  #1733 — sanitiser active on the branch
────────────────────────────────────────────────────────────
  ✓  tool_calls_count_score          (prod)    score = 1.0
  ✓  tool_calls_order_score_with_ids (prod)    score = 1.0
  ✓  tool_calls_args_score           (prod)    score = 1.0
  ✓  tool_calls_output_score         (prod)    score = 1.0
  ✗  tool_calls_order_score          (legacy)  score = 0.0

Result: 4/4 production scorers flipped 0 → 1.0.
        legacy order_score is unchanged — no prod caller (post-#1725,
        ToolCallOrderEvaluator uses order_score_with_ids which IS in the fix path).
```

All four production scorers (Count / Order / Args / Output) go 0 → 1.0 under sanitisation. The legacy `tool_calls_order_score` is unchanged but has no production caller after #1725 routed `ToolCallOrderEvaluator` through `tool_calls_order_score_with_ids` — that one IS in the fix path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)