### PR TITLE
fix(eval): strip restricted temperature for default-only models in mocks

### DIFF
--- a/packages/uipath/src/uipath/eval/mocks/_structured_output.py
+++ b/packages/uipath/src/uipath/eval/mocks/_structured_output.py
@@ -28,6 +28,31 @@ _DEFS_PREFIX = "#/$defs/"
 logger = logging.getLogger(__name__)
 
 
+def _model_supports_only_default_temperature(model: str | None) -> bool:
+    """Return whether ``model`` rejects any non-default ``temperature``.
+
+    The gpt-5 family and the o-series reasoning models only accept the default
+    temperature (1) on the LLM Gateway and return HTTP 400 for any explicit
+    value, including ``0``.
+    """
+    name = (model or "").lower()
+    return name.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def _normalize_completion_kwargs(completion_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Strip parameters a model rejects before calling the gateway.
+
+    Models that only accept the default temperature reject an explicit
+    ``temperature``, so it is dropped here rather than forwarded verbatim
+    (SRE-607465 / PC-4769).
+    """
+    if "temperature" not in completion_kwargs:
+        return completion_kwargs
+    if not _model_supports_only_default_temperature(completion_kwargs.get("model")):
+        return completion_kwargs
+    return {k: v for k, v in completion_kwargs.items() if k != "temperature"}
+
+
 def _inline_defs(
     schema: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -248,6 +273,7 @@ async def generate_structured_output(
     completion_kwargs: dict[str, Any],
 ) -> Any:
     """Generate structured output using the strategy for the requested model."""
+    completion_kwargs = _normalize_completion_kwargs(completion_kwargs)
     strategy = _strategy_for_model(completion_kwargs.get("model"))
     return await strategy.generate(
         llm,

--- a/packages/uipath/tests/cli/eval/mocks/test_structured_output.py
+++ b/packages/uipath/tests/cli/eval/mocks/test_structured_output.py
@@ -293,3 +293,45 @@ async def test_openai_models_prefer_response_format():
     assert result == {"a": 1}
     assert len(llm.calls) == 1
     assert "response_format" in llm.calls[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5-2025-08-07",
+        "gpt-5-mini",
+        "o1-2024-12-17",
+        "o3-mini-2025-01-31",
+    ],
+)
+async def test_default_only_temperature_models_drop_temperature(model: str):
+    # Models like gpt-5 / o-series only accept the default temperature (1); the
+    # LLM gateway returns HTTP 400 when temperature=0 is forwarded (SRE-607465 /
+    # PC-4769). The mock path must strip the restricted temperature before
+    # calling chat_completions.
+    llm = _FakeLLM([_response(SimpleNamespace(content='{"a": 1}', tool_calls=None))])
+    await generate_structured_output(
+        llm,
+        [{"role": "user", "content": "x"}],
+        schema={"type": "object"},
+        response_format_name="OutputSchema",
+        description="d",
+        completion_kwargs={"model": model, "temperature": 0},
+    )
+    assert "temperature" not in llm.calls[0]
+    assert llm.calls[0]["model"] == model
+
+
+@pytest.mark.asyncio
+async def test_standard_models_keep_temperature():
+    llm = _FakeLLM([_response(SimpleNamespace(content='{"a": 1}', tool_calls=None))])
+    await generate_structured_output(
+        llm,
+        [{"role": "user", "content": "x"}],
+        schema={"type": "object"},
+        response_format_name="OutputSchema",
+        description="d",
+        completion_kwargs={"model": "gpt-4.1-mini-2025-04-14", "temperature": 0},
+    )
+    assert llm.calls[0]["temperature"] == 0


### PR DESCRIPTION
## Summary
The eval LLM mock generator forwarded the simulation strategy's `temperature` verbatim to the LLM Gateway. For models that only accept the default temperature (gpt-5 family, o-series reasoning models), an explicit `temperature=0` makes the gateway return HTTP 400 (`Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.`). That error collapses through `UiPathMockResponseGenerationError` → `AgentRuntimeError` into an Unknown-category runtime failure.

This normalizes completion kwargs at the structured-output funnel (`generate_structured_output`), dropping the restricted `temperature` for those models before calling `chat_completions`. Both the LLM mocker and the input mocker route through this funnel, so the path is covered once. Standard models are unaffected.

## Root cause
- `_llm_mocker.py` builds `completion_kwargs` from `ModelSettings` and forwards them to `chat_completions`, which always sends `temperature` in the request body.
- gpt-5 / o-series reject any explicit temperature → HTTP 400.
- Representative job key: `9dc7655c-241d-4a9d-a190-1545df616acc`.

## Changes
- `_structured_output.py`: add `_model_supports_only_default_temperature` + `_normalize_completion_kwargs`, applied once in `generate_structured_output`.
- `test_structured_output.py`: parametrized regression tests for gpt-5/o-series (temperature stripped) and a guard that standard models keep it.

## Not included
Preserving the underlying HTTP error category on `UiPathMockResponseGenerationError` was scoped out: it requires new category plumbing on a shared exception type used across the mocker modules and the runtime's category logic (not localized). The temperature fix removes the miscategorized failures at the source.

## Testing
ruff check + format clean; mypy clean on changed files; `pytest tests/cli/eval/mocks/` = 65 passed.

Refs: SRE-607465, PC-4769
