### PR TITLE
chore: replace deprecated gpt-4o-mini model in docs and tests

### DIFF
--- a/packages/uipath-platform/tests/services/test_llm_service.py
+++ b/packages/uipath-platform/tests/services/test_llm_service.py
@@ -126,7 +126,7 @@ class TestOpenAIService:
             "id": "chatcmpl-test123",
             "object": "chat.completion",
             "created": 1234567890,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -300,7 +300,7 @@ class TestOpenAIService:
             "id": "chatcmpl-test123",
             "object": "chat.completion",
             "created": 1234567890,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -473,7 +473,7 @@ class TestNormalizedLlmServiceClaudeFiltering:
             "id": "chatcmpl-test",
             "object": "chat.completion",
             "created": 1234567890,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -487,7 +487,7 @@ class TestNormalizedLlmServiceClaudeFiltering:
 
         await llm_service.chat_completions(
             messages=[{"role": "user", "content": "Hello"}],
-            model="gpt-4o-mini-2024-07-18",
+            model="gpt-4.1-mini-2025-04-14",
             max_tokens=1000,
             temperature=0,
         )

--- a/packages/uipath-platform/tests/services/test_uipath_llm_integration.py
+++ b/packages/uipath-platform/tests/services/test_uipath_llm_integration.py
@@ -231,7 +231,7 @@ class TestUiPathLLMServiceMocked:
             "id": "chatcmpl-123",
             "object": "chat.completion",
             "created": 1677858242,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -290,7 +290,7 @@ class TestUiPathLLMServiceMocked:
             "id": "chatcmpl-456",
             "object": "chat.completion",
             "created": 1677858242,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -384,7 +384,7 @@ class TestUiPathLLMServiceMocked:
             "id": "chatcmpl-raw",
             "object": "chat.completion",
             "created": 1677858242,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -462,7 +462,7 @@ class TestUiPathLLMServiceMocked:
             "id": "chatcmpl-789",
             "object": "chat.completion",
             "created": 1677858242,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,
@@ -543,7 +543,7 @@ class TestUiPathLLMServiceMocked:
             "id": "chatcmpl-abc",
             "object": "chat.completion",
             "created": 1677858242,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.11.9"
+version = "2.11.10"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/samples/csv-processor/.claude/commands/eval.md
+++ b/packages/uipath/samples/csv-processor/.claude/commands/eval.md
@@ -83,7 +83,7 @@ Read the agent's Input/Output schema from entry-points.json to understand the da
   "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
   "evaluatorConfig": {
     "name": "LLMJudgeOutputEvaluator",
-    "model": "gpt-4o-mini-2024-07-18"
+    "model": "gpt-4.1-mini-2025-04-14"
   }
 }
 ```
@@ -151,7 +151,7 @@ Read the agent's Input/Output schema from entry-points.json to understand the da
 - `evaluationCriterias` keys must match entries in `evaluatorRefs`
 - Use `expectedOutput` for most evaluators
 - LLM evaluators need `model` in their config. Available models are defined in the SDK's `ChatModels` class (`uipath.platform.chat.ChatModels`):
-  - `gpt-4o-mini-2024-07-18` (recommended for cost-efficiency)
+  - `gpt-4.1-mini-2025-04-14` (recommended for cost-efficiency)
   - `gpt-4o-2024-08-06` (higher quality, higher cost)
   - `o3-mini-2025-01-31` (latest reasoning model)
   - Model availability varies by region and tenant configuration

--- a/packages/uipath/samples/resource-overrides/.claude/commands/eval.md
+++ b/packages/uipath/samples/resource-overrides/.claude/commands/eval.md
@@ -83,7 +83,7 @@ Read the agent's Input/Output schema from entry-points.json to understand the da
   "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
   "evaluatorConfig": {
     "name": "LLMJudgeOutputEvaluator",
-    "model": "gpt-4o-mini-2024-07-18"
+    "model": "gpt-4.1-mini-2025-04-14"
   }
 }
 ```
@@ -151,7 +151,7 @@ Read the agent's Input/Output schema from entry-points.json to understand the da
 - `evaluationCriterias` keys must match entries in `evaluatorRefs`
 - Use `expectedOutput` for most evaluators
 - LLM evaluators need `model` in their config. Available models are defined in the SDK's `ChatModels` class (`uipath.platform.chat.ChatModels`):
-  - `gpt-4o-mini-2024-07-18` (recommended for cost-efficiency)
+  - `gpt-4.1-mini-2025-04-14` (recommended for cost-efficiency)
   - `gpt-4o-2024-08-06` (higher quality, higher cost)
   - `o3-mini-2025-01-31` (latest reasoning model)
   - Model availability varies by region and tenant configuration

--- a/packages/uipath/src/uipath/_resources/eval.md
+++ b/packages/uipath/src/uipath/_resources/eval.md
@@ -83,7 +83,7 @@ Read the agent's Input/Output schema from entry-points.json to understand the da
   "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
   "evaluatorConfig": {
     "name": "LLMJudgeOutputEvaluator",
-    "model": "gpt-4o-mini-2024-07-18"
+    "model": "gpt-4.1-mini-2025-04-14"
   }
 }
 ```
@@ -151,7 +151,7 @@ Read the agent's Input/Output schema from entry-points.json to understand the da
 - `evaluationCriterias` keys must match entries in `evaluatorRefs`
 - Use `expectedOutput` for most evaluators
 - LLM evaluators need `model` in their config. Available models are defined in the SDK's `ChatModels` class (`uipath.platform.chat.ChatModels`):
-  - `gpt-4o-mini-2024-07-18` (recommended for cost-efficiency)
+  - `gpt-4.1-mini-2025-04-14` (recommended for cost-efficiency)
   - `gpt-4o-2024-08-06` (higher quality, higher cost)
   - `o3-mini-2025-01-31` (latest reasoning model)
   - Model availability varies by region and tenant configuration

--- a/packages/uipath/tests/cli/eval/mocks/test_input_mocker.py
+++ b/packages/uipath/tests/cli/eval/mocks/test_input_mocker.py
@@ -31,7 +31,7 @@ async def test_generate_llm_input_with_model_settings(
         "inputMockingStrategy": {
             "prompt": "Generate a multiplication query with 5 and 7",
             "model": {
-                "model": "gpt-4o-mini-2024-07-18",
+                "model": "gpt-4.1-mini-2025-04-14",
                 "temperature": 0.5,
                 "maxTokens": 150,
             },
@@ -44,7 +44,7 @@ async def test_generate_llm_input_with_model_settings(
 
     assert isinstance(eval_item.input_mocking_strategy, InputMockingStrategy)
     assert isinstance(eval_item.input_mocking_strategy.model, ModelSettings)
-    assert eval_item.input_mocking_strategy.model.model == "gpt-4o-mini-2024-07-18"
+    assert eval_item.input_mocking_strategy.model.model == "gpt-4.1-mini-2025-04-14"
     assert eval_item.input_mocking_strategy.model.temperature == 0.5
     assert eval_item.input_mocking_strategy.model.max_tokens == 150
 
@@ -77,7 +77,7 @@ async def test_generate_llm_input_with_model_settings(
             "id": "response-id",
             "object": "chat.completion",
             "created": 0,
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "choices": [
                 {
                     "index": 0,

--- a/packages/uipath/tests/cli/eval/mocks/test_input_mocker_span.py
+++ b/packages/uipath/tests/cli/eval/mocks/test_input_mocker_span.py
@@ -51,7 +51,7 @@ async def test_simulate_input_span_attributes(httpx_mock: HTTPXMock, monkeypatch
                 "id": "response-id",
                 "object": "chat.completion",
                 "created": 0,
-                "model": "gpt-4o-mini-2024-07-18",
+                "model": "gpt-4.1-mini-2025-04-14",
                 "choices": [
                     {
                         "index": 0,
@@ -75,7 +75,7 @@ async def test_simulate_input_span_attributes(httpx_mock: HTTPXMock, monkeypatch
         mocking_strategy = InputMockingStrategy(
             prompt="Generate a formal greeting for Alice",
             model=ModelSettings(
-                model="gpt-4o-mini-2024-07-18",
+                model="gpt-4.1-mini-2025-04-14",
                 temperature=0.0,
                 maxTokens=150,
             ),
@@ -193,7 +193,7 @@ async def test_simulate_input_span_on_error(httpx_mock: HTTPXMock, monkeypatch):
                 "id": "response-id",
                 "object": "chat.completion",
                 "created": 0,
-                "model": "gpt-4o-mini-2024-07-18",
+                "model": "gpt-4.1-mini-2025-04-14",
                 "choices": [
                     {
                         "index": 0,
@@ -223,7 +223,7 @@ async def test_simulate_input_span_on_error(httpx_mock: HTTPXMock, monkeypatch):
 
         mocking_strategy = InputMockingStrategy(
             prompt="Generate input",
-            model=ModelSettings(model="gpt-4o-mini-2024-07-18"),
+            model=ModelSettings(model="gpt-4.1-mini-2025-04-14"),
         )
 
         input_schema = {

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -2244,7 +2244,7 @@ class TestJustificationHandling:
 
         config = {
             "name": "TestMaxTokensNone",
-            "model": "gpt-4o-mini-2024-07-18",
+            "model": "gpt-4.1-mini-2025-04-14",
             "prompt": "Evaluate the output",
         }
         evaluator = LLMJudgeOutputEvaluator.model_validate(

--- a/packages/uipath/tests/tracing/test_otel_exporters.py
+++ b/packages/uipath/tests/tracing/test_otel_exporters.py
@@ -296,7 +296,7 @@ class TestLangchainExporter(unittest.TestCase):
             "Attributes": {
                 "input.value": '{"messages": [[{"lc": 1, "type": "constructor", "id": ["langchain", "schema", "messages", "HumanMessage"], "kwargs": {"content": "Test content", "type": "human"}}]]}',
                 "output.value": '{"generations": []}',
-                "llm.model_name": "gpt-4o-mini-2024-07-18",
+                "llm.model_name": "gpt-4.1-mini-2025-04-14",
                 "openinference.span.kind": "LLM",
             },
             "Status": 1,
@@ -311,7 +311,7 @@ class TestLangchainExporter(unittest.TestCase):
         attributes = span_data["Attributes"]
         assert isinstance(attributes, dict)
         self.assertIsInstance(attributes, dict)
-        self.assertEqual(attributes["model"], "gpt-4o-mini-2024-07-18")
+        self.assertEqual(attributes["model"], "gpt-4.1-mini-2025-04-14")
         self.assertIn("input", attributes)
         self.assertIn("output", attributes)
 
@@ -322,7 +322,7 @@ class TestLangchainExporter(unittest.TestCase):
         attributes_dict = {
             "input.value": '{"messages": [[{"lc": 1, "type": "constructor", "id": ["langchain", "schema", "messages", "HumanMessage"], "kwargs": {"content": "Test content", "type": "human"}}]]}',
             "output.value": '{"generations": []}',
-            "llm.model_name": "gpt-4o-mini-2024-07-18",
+            "llm.model_name": "gpt-4.1-mini-2025-04-14",
             "openinference.span.kind": "LLM",
         }
         span_data = {
@@ -344,7 +344,7 @@ class TestLangchainExporter(unittest.TestCase):
         attributes_value = span_data["Attributes"]
         assert isinstance(attributes_value, str)
         attributes = json.loads(attributes_value)
-        self.assertEqual(attributes["model"], "gpt-4o-mini-2024-07-18")
+        self.assertEqual(attributes["model"], "gpt-4.1-mini-2025-04-14")
         self.assertIn("input", attributes)
         self.assertIn("output", attributes)
 
@@ -526,7 +526,7 @@ class TestLangchainExporter(unittest.TestCase):
             "Attributes": {
                 "input.value": '{"messages": []}',
                 "output.value": '{"generations": []}',
-                "llm.model_name": "gpt-4o-mini-2024-07-18",
+                "llm.model_name": "gpt-4.1-mini-2025-04-14",
                 "llm.token_count.prompt": 219,
                 "llm.token_count.completion": 66,
                 "llm.token_count.total": 285,
@@ -561,7 +561,7 @@ class TestLangchainExporter(unittest.TestCase):
         self.assertIsInstance(attributes, dict)
 
         # Verify LLM-specific attributes are present
-        self.assertEqual(attributes["model"], "gpt-4o-mini-2024-07-18")
+        self.assertEqual(attributes["model"], "gpt-4.1-mini-2025-04-14")
         self.assertIn("usage", attributes)
         usage = attributes["usage"]
         assert isinstance(usage, dict)

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.9"
+version = "2.11.10"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- swap `gpt-4o-mini-2024-07-18` for `gpt-4.1-mini-2025-04-14` in the bundled `eval.md` resource and sample eval docs
- update test fixtures to the current model

## Why

the `gpt-4o-mini-2024-07-18` model is deprecated, so bundled docs and fixtures should reference a current openai model resolved via `uip codedagent list-models`.