### PR TITLE
fix(agent-models): add a2aUrl to AgentA2aResourceConfig

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.11.9"
+version = "2.11.10"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -544,6 +544,7 @@ class AgentA2aResourceConfig(BaseAgentResourceConfig):
     id: str
     slug: str = Field(..., alias="slug")
     folder_path: str = Field(alias="folderPath")
+    a2a_url: str = Field(..., alias="a2aUrl")
     cached_agent_card: Optional[Dict[str, Any]] = Field(
         default=None, alias="cachedAgentCard"
     )

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -3995,6 +3995,7 @@ class TestDataFabricContextConfig:
                     "slug": "philosopher-agent",
                     "description": "A philosophical agent that answers questions with wisdom and philosopher quotes",
                     "folderPath": "shared",
+                    "a2a_url": "https://cloud.uipath.com/a2a/5045dca3",
                     "cachedAgentCard": {
                         "name": "Philosopher Agent",
                         "description": "Philosopher Agent assistant",
@@ -4070,6 +4071,7 @@ class TestDataFabricContextConfig:
         )
         assert a2a_resource.id == "755e2f7d-5a3d-47f3-8e9d-7ff0bf226357"
         assert a2a_resource.folder_path == "shared"
+        assert a2a_resource.a2a_url == "https://cloud.uipath.com/a2a/5045dca3"
 
         # Validate cached agent card is a plain dict
         card = a2a_resource.cached_agent_card
@@ -4108,6 +4110,7 @@ class TestDataFabricContextConfig:
                     "slug": "minimal-a2a",
                     "description": "A minimal A2A agent",
                     "folderPath": "shared",
+                    "a2a_url": "https://cloud.uipath.com/a2a/abc-123",
                 }
             ],
             "features": [],
@@ -4127,6 +4130,7 @@ class TestDataFabricContextConfig:
         assert a2a_resource.name == "Minimal A2A Agent"
         assert a2a_resource.slug == "minimal-a2a"
         assert a2a_resource.folder_path == "shared"
+        assert a2a_resource.a2a_url == "https://cloud.uipath.com/a2a/abc-123"
         assert a2a_resource.cached_agent_card is None
 
     def test_a2a_resource_case_insensitive(self):
@@ -4154,6 +4158,7 @@ class TestDataFabricContextConfig:
                     "slug": "case-test",
                     "description": "Testing case insensitive parsing",
                     "folderPath": "shared",
+                    "a2a_url": "https://cloud.uipath.com/a2a/case-test-id",
                 }
             ],
             "features": [],

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-21T14:10:18.2328398Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.9"
+version = "2.11.10"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
- adds an `a2a_url` field (alias `a2aUrl`) to `AgentA2aResourceConfig` so the UiPath-hosted A2A proxy URL is preserved when the agent definition is parsed.