### PR TITLE
feat(platform): add guardrailName to guardrails validation payload

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.74"
+version = "0.1.75"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.75"
+version = "0.1.76"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
@@ -116,6 +116,7 @@ class GuardrailsService(BaseService):
             "validator": guardrail.validator_type,
             "input": input_data if isinstance(input_data, str) else str(input_data),
             "parameters": parameters,
+            "guardrailName": guardrail.name,
         }
         spec = RequestSpec(
             method="POST",

--- a/packages/uipath-platform/tests/services/test_guardrails_service.py
+++ b/packages/uipath-platform/tests/services/test_guardrails_service.py
@@ -262,15 +262,18 @@ class TestGuardrailsService:
             # Parse the request payload
             request_payload = json.loads(captured_request.content)
 
-            # Verify the payload structure matches the reverted format:
+            # Verify the payload structure:
             # {
             #     "validator": guardrail.validator_type,
             #     "input": input_data,
             #     "parameters": parameters,
+            #     "guardrailName": guardrail.name,
             # }
             assert "validator" in request_payload
             assert "input" in request_payload
             assert "parameters" in request_payload
+            assert "guardrailName" in request_payload
+            assert request_payload["guardrailName"] == "PII detection guardrail"
 
             # Verify validator is a string (not an object)
             assert isinstance(request_payload["validator"], str)

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.74"
+version = "0.1.75"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.75"
+version = "0.1.76"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.21, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.75, <0.2.0",
+  "uipath-platform>=0.1.76, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.21, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.74, <0.2.0",
+  "uipath-platform>=0.1.75, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.75"
+version = "0.1.76"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.74"
+version = "0.1.75"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds `guardrailName` field to the guardrails validation request payload so the server can identify which guardrail is being evaluated
- Bumps `uipath-platform` version to 0.1.74
- Updates tests to verify the new field is present and correct

## Test plan
- [x] Updated `test_guardrails_service.py` to assert `guardrailName` is included in the payload
- [ ] Run full test suite: `cd packages/uipath-platform && pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)