### PR TITLE
feat(remote-a2a): resolve a2a agent via resource-override bindings

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.73"
+version = "0.1.74"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/agenthub/_remote_a2a_service.py
+++ b/packages/uipath-platform/src/uipath/platform/agenthub/_remote_a2a_service.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Any, List
 
 from ..common._base_service import BaseService
+from ..common._bindings import resource_override
 from ..common._config import UiPathApiConfig
 from ..common._execution_context import UiPathExecutionContext
 from ..common._folder_context import FolderContext, header_folder
@@ -149,6 +150,7 @@ class RemoteA2aService(FolderContext, BaseService):
         data = response.json()
         return [RemoteA2aAgent.model_validate(agent) for agent in data.get("value", [])]
 
+    @resource_override(resource_type="remoteA2aAgent", resource_identifier="slug")
     def retrieve(
         self,
         slug: str,
@@ -190,6 +192,7 @@ class RemoteA2aService(FolderContext, BaseService):
         )
         return RemoteA2aAgent.model_validate(response.json())
 
+    @resource_override(resource_type="remoteA2aAgent", resource_identifier="slug")
     async def retrieve_async(
         self,
         slug: str,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-22T12:09:32.9206897Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.73"
+version = "0.1.74"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.11.10"
+version = "2.11.11"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.21, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.73, <0.2.0",
+  "uipath-platform>=0.1.74, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -544,7 +544,6 @@ class AgentA2aResourceConfig(BaseAgentResourceConfig):
     id: str
     slug: str = Field(..., alias="slug")
     folder_path: str = Field(alias="folderPath")
-    a2a_url: str = Field(..., alias="a2aUrl")
     cached_agent_card: Optional[Dict[str, Any]] = Field(
         default=None, alias="cachedAgentCard"
     )

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -3995,7 +3995,6 @@ class TestDataFabricContextConfig:
                     "slug": "philosopher-agent",
                     "description": "A philosophical agent that answers questions with wisdom and philosopher quotes",
                     "folderPath": "shared",
-                    "a2a_url": "https://cloud.uipath.com/a2a/5045dca3",
                     "cachedAgentCard": {
                         "name": "Philosopher Agent",
                         "description": "Philosopher Agent assistant",
@@ -4071,7 +4070,6 @@ class TestDataFabricContextConfig:
         )
         assert a2a_resource.id == "755e2f7d-5a3d-47f3-8e9d-7ff0bf226357"
         assert a2a_resource.folder_path == "shared"
-        assert a2a_resource.a2a_url == "https://cloud.uipath.com/a2a/5045dca3"
 
         # Validate cached agent card is a plain dict
         card = a2a_resource.cached_agent_card
@@ -4110,7 +4108,6 @@ class TestDataFabricContextConfig:
                     "slug": "minimal-a2a",
                     "description": "A minimal A2A agent",
                     "folderPath": "shared",
-                    "a2a_url": "https://cloud.uipath.com/a2a/abc-123",
                 }
             ],
             "features": [],
@@ -4130,7 +4127,6 @@ class TestDataFabricContextConfig:
         assert a2a_resource.name == "Minimal A2A Agent"
         assert a2a_resource.slug == "minimal-a2a"
         assert a2a_resource.folder_path == "shared"
-        assert a2a_resource.a2a_url == "https://cloud.uipath.com/a2a/abc-123"
         assert a2a_resource.cached_agent_card is None
 
     def test_a2a_resource_case_insensitive(self):
@@ -4158,7 +4154,6 @@ class TestDataFabricContextConfig:
                     "slug": "case-test",
                     "description": "Testing case insensitive parsing",
                     "folderPath": "shared",
-                    "a2a_url": "https://cloud.uipath.com/a2a/case-test-id",
                 }
             ],
             "features": [],

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-21T14:10:18.2328398Z"
+exclude-newer = "2026-06-22T12:09:29.4029891Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.10"
+version = "2.11.11"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.73"
+version = "0.1.74"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Resolves the Remote A2A proxy URL through the resource-override binding mechanism instead of a field baked into the agent.json resource, matching how MCP servers are resolved.
- Adds `@resource_override(resource_type="remoteA2aAgent", resource_identifier="slug")` to `RemoteA2aService.retrieve` / `retrieve_async`.
- Removes the `a2a_url` field from `AgentA2aResourceConfig`.
- Updates the A2A model tests to drop `a2a_url`.
- Bumps `uipath` to 2.11.11 and `uipath-platform` to 0.1.74.

Related PRs:
- uipath-langchain-python: https://github.com/UiPath/uipath-langchain-python/pull/931