### PR TITLE
fix(remote-a2a): fall back to folder context when folder_path is missing

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.74"
+version = "0.1.75"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/agenthub/_remote_a2a_service.py
+++ b/packages/uipath-platform/src/uipath/platform/agenthub/_remote_a2a_service.py
@@ -242,6 +242,13 @@ class RemoteA2aService(FolderContext, BaseService):
     def custom_headers(self) -> dict[str, str]:
         return self.folder_headers
 
+    def _resolve_folder_key(self, folder_path: str | None) -> str | None:
+        """Resolve folder key from folder_path, falling back to FolderContext."""
+        if folder_path is not None:
+            return self._folders_service.retrieve_folder_key(folder_path)
+
+        return self._folder_key
+
     def _list_spec(
         self,
         *,
@@ -276,7 +283,7 @@ class RemoteA2aService(FolderContext, BaseService):
         *,
         folder_path: str | None,
     ) -> RequestSpec:
-        folder_key = self._folders_service.retrieve_folder_key(folder_path)
+        folder_key = self._resolve_folder_key(folder_path)
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(f"/agenthub_/api/remote-a2a-agents/{slug}"),

--- a/packages/uipath-platform/tests/services/test_remote_a2a_service.py
+++ b/packages/uipath-platform/tests/services/test_remote_a2a_service.py
@@ -1,0 +1,55 @@
+import pytest
+
+from uipath.platform import UiPathApiConfig, UiPathExecutionContext
+from uipath.platform.agenthub._remote_a2a_service import RemoteA2aService
+from uipath.platform.common.constants import HEADER_FOLDER_KEY
+from uipath.platform.orchestrator._folder_service import FolderService
+
+
+@pytest.fixture
+def folders_service(
+    config: UiPathApiConfig,
+    execution_context: UiPathExecutionContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> FolderService:
+    monkeypatch.setenv("UIPATH_FOLDER_KEY", "context-folder-key")
+    return FolderService(config=config, execution_context=execution_context)
+
+
+@pytest.fixture
+def service(
+    config: UiPathApiConfig,
+    execution_context: UiPathExecutionContext,
+    folders_service: FolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> RemoteA2aService:
+    monkeypatch.setenv("UIPATH_FOLDER_KEY", "context-folder-key")
+    return RemoteA2aService(
+        config=config,
+        execution_context=execution_context,
+        folders_service=folders_service,
+    )
+
+
+class TestRetrieveSpecFolderResolution:
+    def test_falls_back_to_folder_context_when_folder_path_missing(
+        self, service: RemoteA2aService
+    ) -> None:
+        """No folder_path (e.g. local debug) must not raise; it falls back to context."""
+        spec = service._retrieve_spec(slug="weather", folder_path=None)
+
+        assert "remote-a2a-agents/weather" in str(spec.endpoint)
+        assert spec.headers[HEADER_FOLDER_KEY] == "context-folder-key"
+
+    def test_resolves_explicit_folder_path(
+        self, service: RemoteA2aService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            service._folders_service,
+            "retrieve_folder_key",
+            lambda folder_path: "resolved-folder-key",
+        )
+
+        spec = service._retrieve_spec(slug="weather", folder_path="MyFolder")
+
+        assert spec.headers[HEADER_FOLDER_KEY] == "resolved-folder-key"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-22T12:09:32.9206897Z"
+exclude-newer = "2026-06-22T13:55:56.0776194Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.74"
+version = "0.1.75"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.11.11"
+version = "2.11.12"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.21, <0.6.0",
   "uipath-runtime>=0.11.0, <0.12.0",
-  "uipath-platform>=0.1.74, <0.2.0",
+  "uipath-platform>=0.1.75, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-06-22T12:09:29.4029891Z"
+exclude-newer = "2026-06-22T13:56:19.8527915Z"
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.11"
+version = "2.11.12"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.74"
+version = "0.1.75"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- `RemoteA2aService._retrieve_spec` now resolves the folder through a `_resolve_folder_key` helper that mirrors `McpService`: when no `folder_path` is provided it falls back to the `FolderContext` instead of raising `Cannot obtain folder_key without providing folder_path`.
- Enables A2A runs without the `UIPATH_FOLDER_PATH` env var (e.g. `uipath debug` with no `UIPATH_FOLDER_PATH` and no resource override)
- Adds A2A service tests for both the fallback and the explicit-folder paths.
- Bumps `uipath-platform` to 0.1.75 and `uipath` to 2.11.12.