### PR TITLE
fix(connections): tolerate list body when retrieving a single connection

### DIFF
--- a/packages/uipath-platform/src/uipath/platform/connections/_connections_service.py
+++ b/packages/uipath-platform/src/uipath/platform/connections/_connections_service.py
@@ -69,7 +69,7 @@ class ConnectionsService(BaseService):
         """
         spec = self._retrieve_spec(key)
         response = self.request(spec.method, url=spec.endpoint)
-        return Connection.model_validate(response.json())
+        return self._select_connection(response.json(), key)
 
     @traced(
         name="connections_metadata",
@@ -280,7 +280,7 @@ class ConnectionsService(BaseService):
         """
         spec = self._retrieve_spec(key)
         response = await self.request_async(spec.method, url=spec.endpoint)
-        return Connection.model_validate(response.json())
+        return self._select_connection(response.json(), key)
 
     @traced(
         name="connections_metadata",
@@ -570,6 +570,39 @@ class ConnectionsService(BaseService):
             endpoint=Endpoint(f"/connections_/api/v1/Connections/{key}/token"),
             params={"tokenType": token_type.value},
         )
+
+    def _select_connection(self, data: Any, key: str) -> Connection:
+        """Validate a single-connection retrieve response, tolerating list bodies.
+
+        The Connections endpoint normally returns a single connection object, but it
+        can also answer with a list (e.g. when the key resolves to a filtered
+        collection). Validating a list against the single ``Connection`` model raises
+        ``pydantic_core.ValidationError``; instead, select the connection whose ``id``
+        matches the requested key, falling back to the first entry when none match.
+
+        Args:
+            data: The deserialized JSON body of the retrieve response.
+            key: The connection key that was requested.
+
+        Returns:
+            Connection: The resolved connection.
+
+        Raises:
+            ValueError: If the response is a list but contains no connections.
+        """
+        if isinstance(data, list):
+            if not data:
+                raise ValueError(f"No connection found for key '{key}'.")
+            matched = next(
+                (
+                    item
+                    for item in data
+                    if isinstance(item, dict) and item.get("id") == key
+                ),
+                data[0],
+            )
+            return Connection.model_validate(matched)
+        return Connection.model_validate(data)
 
     def _parse_and_validate_list_response(self, response: Response) -> List[Connection]:
         """Parse and validate the list response from the API.

--- a/packages/uipath-platform/tests/services/test_connections_service.py
+++ b/packages/uipath-platform/tests/services/test_connections_service.py
@@ -94,6 +94,117 @@ class TestConnectionsService:
             == f"UiPath.Python.Sdk/UiPath.Python.Sdk.Activities.ConnectionsService.retrieve/{version}"
         )
 
+    def test_retrieve_selects_matching_connection_from_list_response(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        """Regression (PC-4777): tolerate a list body and select the matching connection.
+
+        The Connections endpoint can answer with a list of connections instead of a
+        single object. Validating that list against the single ``Connection`` model used
+        to raise ``pydantic_core.ValidationError`` (input_type=list); ``retrieve`` must
+        instead pick the connection whose id matches the requested key.
+        """
+        connection_key = "1958b64e-9432-47aa-aaaa-000000000002"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}",
+            status_code=200,
+            json=[
+                {
+                    "id": "1958b64e-9432-47aa-aaaa-000000000001",
+                    "name": "Other Connection",
+                    "elementInstanceId": 101,
+                },
+                {
+                    "id": connection_key,
+                    "name": "Target Connection",
+                    "elementInstanceId": 102,
+                },
+            ],
+        )
+
+        connection = service.retrieve(key=connection_key)
+
+        assert isinstance(connection, Connection)
+        assert connection.id == connection_key
+        assert connection.name == "Target Connection"
+        assert connection.element_instance_id == 102
+
+    @pytest.mark.anyio
+    async def test_retrieve_async_selects_matching_connection_from_list_response(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        """Regression (PC-4777): async retrieve tolerates a list body.
+
+        This is the exact path from SRE-610701: ``invoke_activity_async`` ->
+        ``retrieve_async`` received a list and ``Connection.model_validate`` raised.
+        """
+        connection_key = "1958b64e-9432-47aa-aaaa-000000000002"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}",
+            status_code=200,
+            json=[
+                {
+                    "id": "1958b64e-9432-47aa-aaaa-000000000001",
+                    "name": "Other Connection",
+                    "elementInstanceId": 101,
+                },
+                {
+                    "id": connection_key,
+                    "name": "Target Connection",
+                    "elementInstanceId": 102,
+                },
+            ],
+        )
+
+        connection = await service.retrieve_async(key=connection_key)
+
+        assert isinstance(connection, Connection)
+        assert connection.id == connection_key
+        assert connection.name == "Target Connection"
+        assert connection.element_instance_id == 102
+
+    def test_retrieve_falls_back_to_first_connection_when_no_key_match(
+        self,
+        httpx_mock: HTTPXMock,
+        service: ConnectionsService,
+        base_url: str,
+        org: str,
+        tenant: str,
+    ) -> None:
+        """A list with no id matching the key falls back to the first entry."""
+        connection_key = "unmatched-key"
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/connections_/api/v1/Connections/{connection_key}",
+            status_code=200,
+            json=[
+                {
+                    "id": "first-id",
+                    "name": "First Connection",
+                    "elementInstanceId": 201,
+                },
+                {
+                    "id": "second-id",
+                    "name": "Second Connection",
+                    "elementInstanceId": 202,
+                },
+            ],
+        )
+
+        connection = service.retrieve(key=connection_key)
+
+        assert isinstance(connection, Connection)
+        assert connection.id == "first-id"
+
     def test_metadata(
         self,
         httpx_mock: HTTPXMock,


### PR DESCRIPTION
## Summary

`ConnectionsService.retrieve` / `retrieve_async` validated the `connections_/api/v1/Connections` response against the **single** `Connection` Pydantic model. When the endpoint answers with a **list**, `Connection.model_validate(response.json())` raised:

```
pydantic_core.ValidationError: 1 validation error for Connection
  Input should be a valid dictionary or instance of Connection [type=model_type, input_type=list]
```

In production this surfaced as a generic `AgentRuntimeError` (miscategorized `Unknown`) during tool connection resolution: `integration_tool` -> `invoke_activity_async` -> `retrieve_async` -> `Connection.model_validate(<list>)`.

- **Jira:** [PC-4777](https://uipath.atlassian.net/browse/PC-4777)
- **Incident:** SRE-610701, job `2d3bb528-02b9-402a-96cf-52203b64de4b`

## Root cause

Pinned from the incident traceback to `_connections_service.py` `retrieve_async` (and symmetrically `retrieve`): the response body was a list, but the code validated it as one `Connection`. The dependency call returned HTTP 200 — the platform responded correctly; the defect is purely in how the SDK parses the body.

## Fix

Add a private `_select_connection(data, key)` helper used by both `retrieve` and `retrieve_async`:

- single object -> existing behavior (`Connection.model_validate`)
- list -> select the connection whose `id` matches the requested `key`, falling back to the first entry; raise `ValueError` for an empty list

Method signatures and single-object behavior are unchanged.

## Tests

Added to `tests/services/test_connections_service.py`:

- `test_retrieve_selects_matching_connection_from_list_response`
- `test_retrieve_async_selects_matching_connection_from_list_response`
- `test_retrieve_falls_back_to_first_connection_when_no_key_match`

The first two reproduce the exact PC-4777 `ValidationError` before the fix (red), and pass after.

## Validation

- `uv run ruff check` — pass
- `uv run ruff format --check` — pass
- `uv run mypy src/uipath/platform/connections/_connections_service.py` — pass
- `uv run pytest tests/services/test_connections_service.py` — 63 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PC-4777]: https://uipath.atlassian.net/browse/PC-4777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ