### PR TITLE
fix(platform): add Swagger (type 7) to McpServerType

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.76"
+version = "0.1.77"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/mcp.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/mcp.py
@@ -18,6 +18,7 @@ class McpServerType(IntEnum):
     Remote = 4  # HTTP connection to remote MCP server
     ProcessAssistant = 5  # Dynamic user process assistant
     Platform = 6  # Platform MCP server (e.g: Orchestrator, TestManager)
+    Swagger = 7  # User-provided Swagger/OpenAPI spec exposed as MCP server
 
 
 class McpServerStatus(IntEnum):

--- a/packages/uipath-platform/tests/services/test_mcp_service.py
+++ b/packages/uipath-platform/tests/services/test_mcp_service.py
@@ -551,3 +551,21 @@ class TestMcpService:
                         call_kwargs.kwargs["headers"][HEADER_FOLDER_KEY]
                         == "test-folder-key"
                     )
+
+
+class TestMcpServerType:
+    """Tests for the McpServerType enum and McpServer validation."""
+
+    def test_swagger_type_value(self) -> None:
+        from uipath.platform.orchestrator.mcp import McpServerType
+
+        assert McpServerType.Swagger == 7
+
+    def test_validate_swagger_server(self) -> None:
+        """A Swagger (type=7) server must validate — regression for backend
+        server types newer than the SDK's enum."""
+        server = McpServer.model_validate(
+            {"slug": "contoso-directory", "name": "Employee Directory", "type": 7}
+        )
+        assert server.type == 7
+        assert server.slug == "contoso-directory"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.76"
+version = "0.1.77"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.76"
+version = "0.1.77"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem

The backend exposes a **Swagger** MCP server type — a user-provided Swagger/OpenAPI spec served as an MCP server — with enum value **7**, but `McpServerType` (in `uipath-platform`) stops at `Platform = 6`. `McpService.retrieve_async` validates the Orchestrator response into `McpServer`, so any agent that resolves a Swagger MCP server crashes:

```
pydantic_core.ValidationError: 1 validation error for McpServer
type
  Input should be 0, 1, 2, 3, 4, 5 or 6 [type=enum, input_value=7]
```

This surfaced on a coded agent calling a registered Swagger MCP (an "Employee Directory" OpenAPI server) — `mcp.retrieve_async` failed before tools could be listed.

## Change

Add `Swagger = 7` to `McpServerType`, matching the Orchestrator/AgentHub enum (`UiServer.cs`: `Swagger = 7 // User-provided Swagger/OpenAPI spec exposed as MCP server`).

The MCP client connects via `mcp_url` and does **not** branch on `type`, so accepting the value is sufficient for the server to load its tools — no further handling needed.

## Tests

- `McpServerType.Swagger == 7`
- `McpServer.model_validate({"type": 7, …})` validates (regression for backend server types newer than the SDK enum).
- `uv sync --locked`, `ruff`, `mypy`, and the mcp-service test module pass.

## Versioning

Bumps `uipath-platform` 0.1.76 → 0.1.77 (+ refreshes the editable entry in `uipath`/`uipath-platform` lockfiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELDu3m5eaURJrMVarc8VfY