### PR TITLE
feat(voice): preserve voice session end detail

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.12.7"
+version = "2.12.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -6,7 +6,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.26, <0.6.0",
-  "uipath-runtime>=0.11.7, <0.12.0",
+  "uipath-runtime>=0.12.1, <0.13.0",
   "uipath-platform>=0.1.91, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/packages/uipath/src/uipath/_cli/_chat/_voice_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_chat/_voice_bridge.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Awaitable, Callable
+from copy import deepcopy
 from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
@@ -87,7 +88,7 @@ class VoiceToolCallSession:
     @property
     def end_detail(self) -> dict[str, Any]:
         """CAS payload from voice_session_ended, preserved for the job runtime."""
-        return self._end_detail
+        return deepcopy(self._end_detail)
 
     async def run(self) -> VoiceSessionEndReason:
         """Connect, dispatch tool calls until session ends, then disconnect.
@@ -221,7 +222,10 @@ class VoiceToolCallSession:
         )
 
     async def _handle_session_ended(self, data: Any = None, *_: Any) -> None:
-        detail = data if isinstance(data, dict) else {}
+        if self._done.is_set():
+            return
+
+        detail = deepcopy(data) if isinstance(data, dict) else {}
         self._end_detail = detail
         logger.info(
             "[Voice] voice_session_ended received "

--- a/packages/uipath/src/uipath/_cli/_chat/_voice_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_chat/_voice_bridge.py
@@ -82,6 +82,12 @@ class VoiceToolCallSession:
         self._done = asyncio.Event()
         self._in_flight: set[asyncio.Task[None]] = set()
         self._end_reason: VoiceSessionEndReason | None = None
+        self._end_detail: dict[str, Any] = {}
+
+    @property
+    def end_detail(self) -> dict[str, Any]:
+        """CAS payload from voice_session_ended, preserved for the job runtime."""
+        return self._end_detail
 
     async def run(self) -> VoiceSessionEndReason:
         """Connect, dispatch tool calls until session ends, then disconnect.
@@ -214,8 +220,16 @@ class VoiceToolCallSession:
             tool_result.is_error,
         )
 
-    async def _handle_session_ended(self, _data: Any, *_: Any) -> None:
-        logger.info("[Voice] voice_session_ended received")
+    async def _handle_session_ended(self, data: Any = None, *_: Any) -> None:
+        detail = data if isinstance(data, dict) else {}
+        self._end_detail = detail
+        logger.info(
+            "[Voice] voice_session_ended received "
+            "(endedBy=%s, callEnded=%s, reason=%s)",
+            detail.get("endedBy"),
+            detail.get("callEnded"),
+            detail.get("reason"),
+        )
         self._end_session(VoiceSessionEndReason.COMPLETED)
 
 

--- a/packages/uipath/tests/cli/chat/test_voice_bridge.py
+++ b/packages/uipath/tests/cli/chat/test_voice_bridge.py
@@ -48,10 +48,12 @@ class TestEndSession:
 
     async def test_session_ended_preserves_payload_opaquely(self) -> None:
         session = _make_session()
-        call_context = {"type": "phone", "id": "CA123", "conversationId": "conv-1"}
         payload = {
-            "callContext": call_context,
-            "conversationId": "conv-1",
+            "callContext": {
+                "type": "phone",
+                "id": "CA123",
+                "conversationId": "conv-1",
+            },
             "endedBy": "agent",
             "callEnded": False,
             "reason": "agent_completed",
@@ -61,9 +63,6 @@ class TestEndSession:
         await session._handle_session_ended(payload)
 
         assert session.end_detail == payload
-        assert session.end_detail["callContext"] == call_context
-        assert session.end_detail["endedBy"] == "agent"
-        assert session.end_detail["callEnded"] is False
         assert session._end_reason == VoiceSessionEndReason.COMPLETED
 
     async def test_session_ended_non_dict_payload_is_empty_detail(self) -> None:

--- a/packages/uipath/tests/cli/chat/test_voice_bridge.py
+++ b/packages/uipath/tests/cli/chat/test_voice_bridge.py
@@ -64,11 +64,27 @@ class TestEndSession:
 
         assert session.end_detail == payload
         assert session._end_reason == VoiceSessionEndReason.COMPLETED
+        returned_detail = session.end_detail
+        returned_detail["reason"] = "mutated"
+        returned_detail["callContext"]["id"] = "CA999"
+        payload["endedBy"] = "system"
+        assert session.end_detail["reason"] == "agent_completed"
+        assert session.end_detail["callContext"]["id"] == "CA123"
+        assert session.end_detail["endedBy"] == "agent"
 
     async def test_session_ended_non_dict_payload_is_empty_detail(self) -> None:
         session = _make_session()
         await session._handle_session_ended("not-a-dict")
         assert session.end_detail == {}
+        assert session._end_reason == VoiceSessionEndReason.COMPLETED
+
+    async def test_late_session_ended_does_not_overwrite_terminal_state(self) -> None:
+        session = _make_session()
+        await session._handle_session_ended({"endedBy": "agent", "callEnded": False})
+
+        await session._handle_session_ended({"endedBy": "system", "callEnded": True})
+
+        assert session.end_detail == {"endedBy": "agent", "callEnded": False}
         assert session._end_reason == VoiceSessionEndReason.COMPLETED
 
     async def test_disconnect_sets_disconnected(self) -> None:

--- a/packages/uipath/tests/cli/chat/test_voice_bridge.py
+++ b/packages/uipath/tests/cli/chat/test_voice_bridge.py
@@ -46,6 +46,32 @@ class TestEndSession:
         await session._handle_session_ended(None)
         assert session._end_reason == VoiceSessionEndReason.COMPLETED
 
+    async def test_session_ended_preserves_payload_opaquely(self) -> None:
+        session = _make_session()
+        call_context = {"type": "phone", "id": "CA123", "conversationId": "conv-1"}
+        payload = {
+            "callContext": call_context,
+            "conversationId": "conv-1",
+            "endedBy": "agent",
+            "callEnded": False,
+            "reason": "agent_completed",
+            "someFutureKey": {"nested": True},
+        }
+
+        await session._handle_session_ended(payload)
+
+        assert session.end_detail == payload
+        assert session.end_detail["callContext"] == call_context
+        assert session.end_detail["endedBy"] == "agent"
+        assert session.end_detail["callEnded"] is False
+        assert session._end_reason == VoiceSessionEndReason.COMPLETED
+
+    async def test_session_ended_non_dict_payload_is_empty_detail(self) -> None:
+        session = _make_session()
+        await session._handle_session_ended("not-a-dict")
+        assert session.end_detail == {}
+        assert session._end_reason == VoiceSessionEndReason.COMPLETED
+
     async def test_disconnect_sets_disconnected(self) -> None:
         session = _make_session()
         await session._handle_disconnect()

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2674,7 +2674,7 @@ requires-dist = [
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
     { name = "uipath-platform", editable = "../uipath-platform" },
-    { name = "uipath-runtime", specifier = ">=0.11.7,<0.12.0" },
+    { name = "uipath-runtime", specifier = ">=0.12.1,<0.13.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2779,16 +2779,16 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.11.7"
+version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/59/a491091f7e9ee3de8741b7658745214706e2adb01b89bf114f0f2dabff53/uipath_runtime-0.11.7.tar.gz", hash = "sha256:8f4b58c444aef31465e66a470cd58300eb9d440bd67e6f6f1ba204bee704680f", size = 231824, upload-time = "2026-07-02T12:53:29.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/0b/6d6bfd912c2ad6978f58646becf3647430ccb087008a8c78dbc33b0b101e/uipath_runtime-0.12.1.tar.gz", hash = "sha256:a63ce739ea53da8479bb0314477f89d42724045ecbd7db3f2a3f0a09ab17a755", size = 235372, upload-time = "2026-07-06T11:14:51.947Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/e5/4bcb8902fc945e1abd560b2adae06d3ac336c58dd036a0ca23bf9cb67ea4/uipath_runtime-0.11.7-py3-none-any.whl", hash = "sha256:18a4632a481eef101cd6f026f2938854c80a8fb24fd749dfe02fe62015eb84e2", size = 91126, upload-time = "2026-07-02T12:53:27.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4c/433de72c4c5869ee26a63f68361b5c62d04bb03e9c7db9a69c0d3db7b458/uipath_runtime-0.12.1-py3-none-any.whl", hash = "sha256:88b014e0c5a50a5b41b2e532bd628eebc91d70ad42b6d3389fdc61b7ae78e0a6", size = 92004, upload-time = "2026-07-06T11:14:50.363Z" },
 ]
 
 [[package]]

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.12.7"
+version = "2.12.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Draft support for AgentInterfaces flow-part-2 voice session outcome plumbing. Not required for AgentInterfaces #1013. This preserves the voice_session_ended payload opaquely on the voice bridge so downstream runtimes can surface callEnded, endedBy, reason, and future CAS fields.