### PR TITLE
fix(core): match AttachmentsProtocol.upload_async to the concrete overloads

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.22"
+version = "0.5.23"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/workspace/protocols.py
+++ b/packages/uipath-core/src/uipath/core/workspace/protocols.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol, overload, runtime_checkable
 from uuid import UUID
 
 
@@ -19,6 +19,28 @@ class AttachmentsProtocol(Protocol):
         folder_path: str | None = None,
     ) -> str:
         """Download an attachment to a local path."""
+
+    # Overloads mirror the concrete AttachmentsService: content XOR source_path,
+    # so the real service is a structural subtype of this protocol.
+    @overload
+    async def upload_async(
+        self,
+        *,
+        name: str,
+        content: str | bytes,
+        folder_key: str | None = None,
+        folder_path: str | None = None,
+    ) -> UUID: ...
+
+    @overload
+    async def upload_async(
+        self,
+        *,
+        name: str,
+        source_path: str,
+        folder_key: str | None = None,
+        folder_path: str | None = None,
+    ) -> UUID: ...
 
     async def upload_async(
         self,

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.22"
+version = "0.5.23"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/tests/services/test_attachments_service.py
+++ b/packages/uipath-platform/tests/services/test_attachments_service.py
@@ -1193,3 +1193,17 @@ class TestAttachmentsService:
         assert upload_request is not None
         assert upload_request.method == "PUT"
         assert upload_request.url == blob_uri_response["BlobFileAccess"]["Uri"]
+
+
+def test_attachments_service_conforms_to_attachments_protocol(
+    service: AttachmentsService,
+) -> None:
+    """AttachmentsService must satisfy AttachmentsProtocol (workspace hydration).
+
+    The static annotation makes mypy verify the upload_async overloads line up;
+    the isinstance check covers the runtime_checkable contract.
+    """
+    from uipath.core.workspace import AttachmentsProtocol
+
+    conforming: AttachmentsProtocol = service
+    assert isinstance(conforming, AttachmentsProtocol)

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.22"
+version = "0.5.23"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2659,7 +2659,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.22"
+version = "0.5.23"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },


### PR DESCRIPTION
## Summary
- redefine `AttachmentsProtocol.upload_async` with `@overload`s (content XOR source_path) so the concrete `AttachmentsService` is a structural subtype, not just a runtime_checkable one
- add a static + runtime conformance test asserting `AttachmentsService` satisfies `AttachmentsProtocol`

## Why

the protocol shipped in #1744 declared a single over-broad `upload_async` (both `content` and `source_path` optional), which the overloaded concrete service does not structurally satisfy. it surfaced only when a consumer passes the real `AttachmentsService` into the runtime's `WorkspaceHydrator` (mypy error), since the protocol's own tests use a conforming fake. the new conformance test guards against this regressing.