### PR TITLE
feat: add timer resume time field

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.25"
+version = "0.5.26"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/triggers/trigger.py
+++ b/packages/uipath-core/src/uipath/core/triggers/trigger.py
@@ -1,5 +1,6 @@
 """Module defining resume trigger types and data models."""
 
+from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -87,6 +88,7 @@ class UiPathResumeTrigger(BaseModel):
     integration_resume: UiPathIntegrationTrigger | None = Field(
         default=None, alias="integrationResume"
     )
+    resume_time: datetime | None = Field(default=None, alias="resumeTime")
     folder_path: str | None = Field(default=None, alias="folderPath")
     folder_key: str | None = Field(default=None, alias="folderKey")
     payload: Any | None = Field(default=None, alias="interruptObject", exclude=True)

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.25"
+version = "0.5.26"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.25"
+version = "0.5.26"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2659,7 +2659,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.25"
+version = "0.5.26"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },


### PR DESCRIPTION
## Summary
- add `resumeTime` to core resume trigger payloads

## Development Packages

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-platform==0.1.78.dev1017676994",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-platform>=0.1.78.dev1017670000,<0.1.78.dev1017680000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
uipath-core = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-core==0.5.24.dev1017676994"]
```

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.11.14.dev1017677012",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.11.14.dev1017670000,<2.11.14.dev1017680000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
uipath-platform = { index = "testpypi" }
uipath-core = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-platform==0.1.80.dev1017677012", "uipath-core==0.5.26.dev1017677012"]
```

### uipath-core

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-core==0.5.26.dev1017677012",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-core>=0.5.26.dev1017670000,<0.5.26.dev1017680000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-core = { index = "testpypi" }
```