### PR TITLE
feat(platform): add source=agents baggage to guardrails trace headers

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.78"
+version = "0.1.79"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
@@ -129,7 +129,7 @@ class GuardrailsService(BaseService):
         # the execution source (x-uipath-guardrails-source) and job key headers
         # for licensing/metering correlation. The execution source is read from
         # the execution context, propagated from the runtime context.
-        trace_headers = build_trace_context_headers()
+        trace_headers = build_trace_context_headers(extra_baggage=["source=agents"])
         source_headers: dict[str, str] = {}
         execution_source = self._execution_context.execution_source
         if execution_source:

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.78"
+version = "0.1.79"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.11.13"
+version = "2.11.14"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.21, <0.6.0",
   "uipath-runtime>=0.11.4, <0.12.0",
-  "uipath-platform>=0.1.78, <0.2.0",
+  "uipath-platform>=0.1.79, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.11.13"
+version = "2.11.14"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.78"
+version = "0.1.79"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Passes `extra_baggage=["source=agents"]` to `build_trace_context_headers()` in `GuardrailsService.evaluate_guardrail()` so the server can identify requests originating from the agents runtime
- Bumps `uipath-platform` to 0.1.78 and updates `uipath` dependency accordingly

## Test plan
- [x] Existing guardrails service tests pass (16/16) — no test changes needed since the `extra_baggage` param is an internal detail not asserted by tests
- [x] Verified `build_trace_context_headers` already accepts the `extra_baggage` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)