### PR TITLE
feat(core): add shared uipath metadata key

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.26"
+version = "0.5.27"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/triggers/__init__.py
+++ b/packages/uipath-core/src/uipath/core/triggers/__init__.py
@@ -6,9 +6,11 @@ __all__ = [
     "UiPathApiTrigger",
     "UiPathIntegrationTrigger",
     "UiPathResumeTriggerName",
+    "UIPATH_METADATA_KEY",
 ]
 
 from uipath.core.triggers.trigger import (
+    UIPATH_METADATA_KEY,
     UiPathApiTrigger,
     UiPathIntegrationTrigger,
     UiPathResumeTrigger,

--- a/packages/uipath-core/src/uipath/core/triggers/trigger.py
+++ b/packages/uipath-core/src/uipath/core/triggers/trigger.py
@@ -6,6 +6,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Reserved key for UiPath-owned metadata embedded in user-visible payloads.
+UIPATH_METADATA_KEY = "__uipath"
+
 
 class UiPathResumeTriggerType(str, Enum):
     """Constants representing different types of resume job triggers in the system."""

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.26"
+version = "0.5.27"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.26"
+version = "0.5.27"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2659,7 +2659,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.26"
+version = "0.5.27"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },


### PR DESCRIPTION
## Summary
- add a shared `UIPATH_METADATA_KEY` constant in `uipath-core`
- export the metadata key from `uipath.core`
- allow downstream packages to share the reserved UiPath metadata payload key

## Development Packages

### uipath-core

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-core==0.5.27.dev1017737031",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-core>=0.5.27.dev1017730000,<0.5.27.dev1017740000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-core = { index = "testpypi" }
```

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.11.16.dev1017737031",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.11.16.dev1017730000,<2.11.16.dev1017740000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
uipath-platform = { index = "testpypi" }
uipath-core = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-platform==0.1.82.dev1017737031", "uipath-core==0.5.27.dev1017737031"]
```

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-platform==0.1.82.dev1017737031",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-platform>=0.1.82.dev1017730000,<0.1.82.dev1017740000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
uipath-core = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-core==0.5.27.dev1017737031"]
```