### PR TITLE
chore(platform): bump version 0.1.83 → 0.1.84

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.83"
+version = "0.1.84"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.83"
+version = "0.1.84"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.83"
+version = "0.1.84"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Trivial version bump on `uipath-platform` from `0.1.83` → `0.1.84`. `0.1.83` is already published on PyPI; the next platform wheel needs a fresh version number so any forthcoming metadata change can publish without colliding.

## Changes

| File | Change |
|------|--------|
| `packages/uipath-platform/pyproject.toml` | version `0.1.83 → 0.1.84` |
| `packages/uipath-platform/uv.lock` | resolved version refresh |
| `packages/uipath/uv.lock` | transitive refresh for the editable platform dep |

## Test plan

- [x] `uv sync --locked` passes on all three packages
- [x] No source changes — no test/lint impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)