### PR TITLE
fix(platform): accept v3 string enum values in span converter

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.84"
+version = "0.1.85"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -117,16 +117,30 @@ _SOURCE_BY_INT: dict[int, SpanSource] = {
 _IntEnumT = TypeVar("_IntEnumT")
 
 
-def _enum_from_int(table: dict[int, _IntEnumT], raw: Any) -> Optional[_IntEnumT]:
-    """Map a raw OTEL int attribute to its enum member, or None.
+def _enum_from_raw(table: dict[int, _IntEnumT], raw: Any) -> Optional[_IntEnumT]:
+    """Map a raw OTEL attribute to its StrEnum member, or None.
 
-    Returns None for missing / non-int input — and explicitly for ``bool``,
-    since ``bool`` is an ``int`` subclass (``True == 1``) and would otherwise
-    be coerced to the value-1 member.
+    Accepts both wire forms seen across SDK versions:
+
+    - legacy integer (e.g. ``6``) — looked up in ``table``.
+    - v3 string enum value (e.g. ``"Off"``, the ``StrEnum``'s value) — matched
+      against the table's members. An already-typed ``StrEnum`` member is a
+      ``str`` and is matched here too.
+
+    ``bool`` is rejected up front: it is an ``int`` subclass (``True == 1``) and
+    would otherwise coerce to the value-1 member. Unknown ints/strings return
+    None so callers can apply their own default.
     """
-    if isinstance(raw, bool) or not isinstance(raw, int):
+    if isinstance(raw, bool):
         return None
-    return table.get(raw)
+    if isinstance(raw, int):
+        return table.get(raw)
+    if isinstance(raw, str):
+        for member in table.values():
+            if member == raw:
+                return member
+        return None
+    return None
 
 
 @lru_cache(maxsize=1)
@@ -441,16 +455,17 @@ class _SpanUtils:
         span_type_value = attributes_dict.get("span_type", "OpenTelemetry")
         span_type = str(span_type_value)
 
-        # Top-level fields for internal tracing schema. The int->enum lookups go
-        # through _enum_from_int so they all ignore bools/non-ints identically.
-        execution_type = _enum_from_int(
+        # Top-level fields for internal tracing schema. The enum lookups go
+        # through _enum_from_raw, which accepts both the legacy integer wire form
+        # and the v3 string-enum value (and rejects bools) identically.
+        execution_type = _enum_from_raw(
             _EXECUTION_TYPE_BY_INT, attributes_dict.get("executionType")
         )
         agent_version = attributes_dict.get("agentVersion")
         reference_id = attributes_dict.get("agentId") or attributes_dict.get(
             "referenceId"
         )
-        verbosity_level = _enum_from_int(
+        verbosity_level = _enum_from_raw(
             _VERBOSITY_LEVEL_BY_INT, attributes_dict.get("verbosityLevel")
         )
 
@@ -458,7 +473,7 @@ class _SpanUtils:
         # A real int that isn't a known source is relabeled CodedAgents but
         # logged — v3 ingest rejects raw integers, so it can't be forwarded.
         uipath_source_raw = attributes_dict.get("uipath.source")
-        source = _enum_from_int(_SOURCE_BY_INT, uipath_source_raw)
+        source = _enum_from_raw(_SOURCE_BY_INT, uipath_source_raw)
         if source is None:
             if isinstance(uipath_source_raw, int) and not isinstance(
                 uipath_source_raw, bool

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -120,16 +120,10 @@ _IntEnumT = TypeVar("_IntEnumT")
 def _enum_from_raw(table: dict[int, _IntEnumT], raw: Any) -> Optional[_IntEnumT]:
     """Map a raw OTEL attribute to its StrEnum member, or None.
 
-    Accepts both wire forms seen across SDK versions:
-
-    - legacy integer (e.g. ``6``) — looked up in ``table``.
-    - v3 string enum value (e.g. ``"Off"``, the ``StrEnum``'s value) — matched
-      against the table's members. An already-typed ``StrEnum`` member is a
-      ``str`` and is matched here too.
-
-    ``bool`` is rejected up front: it is an ``int`` subclass (``True == 1``) and
-    would otherwise coerce to the value-1 member. Unknown ints/strings return
-    None so callers can apply their own default.
+    Accepts a legacy int (looked up in ``table``) or the v3 string enum value
+    like ``"Off"`` (which also matches an already-typed member). ``bool`` is
+    rejected (``True == 1`` would match the value-1 member); unknown values
+    return None so callers can apply their own default.
     """
     if isinstance(raw, bool):
         return None

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -252,6 +252,61 @@ class TestOTelToUiPathSpan:
         assert uipath_span.verbosity_level == VerbosityLevel.OFF
         assert span_dict["VerbosityLevel"] == VerbosityLevel.OFF
 
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (6, VerbosityLevel.OFF),  # legacy int
+            ("Off", VerbosityLevel.OFF),  # v3 string value
+            (2, VerbosityLevel.INFORMATION),  # legacy int
+            ("Information", VerbosityLevel.INFORMATION),  # v3 string value
+            ("Nope", None),  # unknown string -> None (server default applies)
+        ],
+    )
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_verbosity_accepts_int_and_string(self, raw, expected) -> None:
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(
+            _make_otel_span({"verbosityLevel": raw})
+        )
+        assert uipath_span.verbosity_level == expected
+        if expected is None:
+            assert "VerbosityLevel" not in uipath_span.to_dict()
+        else:
+            assert uipath_span.to_dict()["VerbosityLevel"] == expected
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (1, ExecutionType.RUNTIME),  # legacy int
+            ("Runtime", ExecutionType.RUNTIME),  # v3 string value
+            (0, ExecutionType.DEBUG),  # legacy int
+            ("Debug", ExecutionType.DEBUG),  # v3 string value
+        ],
+    )
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_execution_type_accepts_int_and_string(self, raw, expected) -> None:
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(
+            _make_otel_span({"executionType": raw})
+        )
+        assert uipath_span.execution_type == expected
+        assert uipath_span.to_dict()["ExecutionType"] == expected
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (1, SpanSource.AGENTS),  # legacy int
+            ("Agents", SpanSource.AGENTS),  # v3 string value
+            (10, SpanSource.CODED_AGENTS),  # legacy int
+            ("CodedAgents", SpanSource.CODED_AGENTS),  # v3 string value
+        ],
+    )
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_source_accepts_int_and_string(self, raw, expected) -> None:
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(
+            _make_otel_span({"uipath.source": raw})
+        )
+        assert uipath_span.source == expected
+        assert uipath_span.to_dict()["Source"] == expected
+
 
 class TestReferenceIdResolution:
     """`reference_id` resolution chain.

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -129,6 +129,26 @@ class TestGuidFieldDefaults:
         assert "TenantId" not in d
 
 
+def _make_otel_span(attributes: dict) -> Mock:
+    """Build a minimal mocked OTEL span carrying the given attributes."""
+    mock_span = Mock(spec=OTelSpan)
+    mock_span.get_span_context.return_value = SpanContext(
+        trace_id=0x123456789ABCDEF0123456789ABCDEF0,
+        span_id=0x0123456789ABCDEF,
+        is_remote=False,
+    )
+    mock_span.name = "test-span"
+    mock_span.parent = None
+    mock_span.status.status_code = StatusCode.OK
+    mock_span.attributes = attributes
+    mock_span.events = []
+    mock_span.links = []
+    now_ns = int(datetime.now().timestamp() * 1e9)
+    mock_span.start_time = now_ns
+    mock_span.end_time = now_ns + 1_000_000
+    return mock_span
+
+
 class TestOTelToUiPathSpan:
     """OTEL attribute -> top-level UiPathSpan field mapping.
 
@@ -214,6 +234,23 @@ class TestOTelToUiPathSpan:
 
         assert uipath_span.verbosity_level is None
         assert "VerbosityLevel" not in span_dict
+
+    @patch.dict(os.environ, {"UIPATH_ORGANIZATION_ID": "test-org"})
+    def test_verbosity_string_value_maps_to_top_level(self) -> None:
+        """v3 producers emit verbosityLevel as the StrEnum value "Off" (string).
+
+        The converter must promote it to the top-level VerbosityLevel field so
+        the LLMOps server can apply its verbosity-Off filter. Before the fix the
+        string was dropped, the field omitted, and the server defaulted the span
+        to Information (2) — leaking the AgentDefinition span into the trace.
+        """
+        mock_span = _make_otel_span({"verbosityLevel": "Off"})
+
+        uipath_span = _SpanUtils.otel_span_to_uipath_span(mock_span)
+        span_dict = uipath_span.to_dict()
+
+        assert uipath_span.verbosity_level == VerbosityLevel.OFF
+        assert span_dict["VerbosityLevel"] == VerbosityLevel.OFF
 
 
 class TestReferenceIdResolution:

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -129,7 +129,7 @@ class TestGuidFieldDefaults:
         assert "TenantId" not in d
 
 
-def _make_otel_span(attributes: dict) -> Mock:
+def _make_otel_span(attributes: dict[str, object]) -> Mock:
     """Build a minimal mocked OTEL span carrying the given attributes."""
     mock_span = Mock(spec=OTelSpan)
     mock_span.get_span_context.return_value = SpanContext(

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.84"
+version = "0.1.85"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.84"
+version = "0.1.85"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Motivation

PR #1684 turned `VerbosityLevel`/`ExecutionType`/`SpanSource` into `StrEnum`s, so v3 producers now emit the **string** value (e.g. `verbosityLevel="Off"`). The converter's int-only `_enum_from_int` dropped those strings — the top-level `VerbosityLevel` was omitted, the LLMOps server defaulted the span to `Information`, and its verbosity-Off filter leaked the `AgentDefinition` span into traces. This restores promotion for **both** the legacy integer and the v3 string wire forms, so verbosity-Off spans are filtered again.

## How this bug was introduced

The verbosity-Off filter relies on a two-step chain that #1684 split apart:

1. **#1627** added `VerbosityLevel` as an `IntEnum` and the converter step that *promotes* the OTEL attribute `verbosityLevel` up to the top-level `VerbosityLevel` field the LLMOps server filters on.
2. **#1684** (the StrEnum migration) flipped `IntEnum → StrEnum` **and**, in the same commit, added the int-only `_enum_from_int` lookup. The public enum now produces the **string** `"Off"`, but the converter only accepts `int` — so the SDK can no longer round-trip its own public enum. `_enum_from_int("Off")` returns `None` → top-level `VerbosityLevel` omitted → server defaults the span to `Information (2)` → the internal `AgentDefinition` span leaks past the filter.

The producer is unchanged and blameless: agents-python sets `verbosity_level=VerbosityLevel.OFF` on the AgentDefinition span (`spans_schema/agent.py`) — deliberately, so the server's verbosity-Off filter hides that internal blueprint span. It imports the SDK's *public* `VerbosityLevel`; #1684 changed that enum underneath it, flipping the same line from emitting `6` to emitting `"Off"`.

### Why it shipped despite agents-python pinning the old SDK

#1684 is two independent halves in two packages, and agents-python pins them differently:

| Half | Package | First in | agents-python constraint |
|---|---|---|---|
| **The bug** — StrEnum + int-only converter (`_span_utils.py`) | `uipath-platform` | `0.1.81` | `>=0.1.79,<0.2.0` — **floating range** |
| Routing — export switched to `/api/Traces/v3/spans` | `uipath` | `2.11.15` | `==2.11.14` — **hard pin** |

agents-python hard-pins `uipath` (so its committed lock misses the v3-routing half), but the verbosity bug lives entirely in `uipath-platform`, which it only constrains with a floating range — and `uipath 2.11.14` itself merely requires `uipath-platform>=0.1.79,<0.2.0` (a loose upper bound). So although the committed `uv.lock` resolves platform to a safe `0.1.79` (still `IntEnum`), **any non-frozen re-resolve** — a fresh container build, `uv sync` without `--frozen`, or `uv lock --upgrade` — pulls the latest matching `uipath-platform` (`0.1.81`+, now `0.1.84`): StrEnum + broken converter. The leak then appears with **no change to agents-python's own code**. That matches what alpha showed — v3 span-ingest traffic jumped ~10× the day after #1684 merged, and the leaking `AgentDefinition` spans came from deployed coded agents on a re-resolved build.

> agents-python's own test still asserts the old world (`assert VerbosityLevel.OFF == 6`), which is why it didn't catch the flip — tracked as a follow-up below.


## Summary

- Replace `_enum_from_int` (int-only) with **`_enum_from_raw`** — accepts the legacy `int`, the v3 `StrEnum` string value, and an already-typed member; still rejects `bool` (it's an `int` subclass, `True == 1`). Unknown ints/strings return `None` so callers apply their own default.
- Repoint all three call sites: `executionType`, `verbosityLevel`, `uipath.source` (+ updated comment).
- Tests: regression test (`verbosityLevel="Off"` → top-level `VerbosityLevel.OFF`) and parametrized int-and-string contract guards for all three enums (incl. unknown-string → `None`, and unset → key omitted).
- Bump `uipath-platform` `0.1.84` → `0.1.85` (+ `uv.lock`).

## Tests performed

Run from `packages/uipath-platform` (documented via showboat):

- **Regression** — `test_verbosity_string_value_maps_to_top_level`: **1 passed**.
- **Contract guards** — `test_verbosity_accepts_int_and_string` / `test_execution_type_accepts_int_and_string` / `test_source_accepts_int_and_string`: **13 parametrized cases passed** (int + string wire forms per enum).
- **Full converter class** (`TestOTelToUiPathSpan`): **16 passed** (new tests + pre-existing back-compat guards).
- **Full package suite**: **1375 passed, 11 skipped**.
- **Quality gates**: `ruff check` + `ruff format --check` + `mypy src tests` — all clean.

Also exercised end-to-end: built into a coded-agent package, deployed to alpha (`joetest`/`ToBeDeleted`) as a Serverless process — job **Successful**, spans ingested correctly (no regression on the int wire form).

## Validated in OR - no AgentDefinition Span

<img width="343" height="358" alt="image" src="https://github.com/user-attachments/assets/6d0912f7-11e7-4a5d-ba75-012b5508e72a" />


## Test plan

- [ ] CI green on the branch
- [ ] Reviewer confirms backward compatibility: legacy integer wire form (`6` → `Off`, `1` → `Runtime`/`Agents`) unchanged
- [ ] Reviewer confirms unset `verbosityLevel` still omits the top-level key (no wire-format change)
- [ ] Follow-up (separate PR): agents-python canary `assert VerbosityLevel.OFF == 6` → `== "Off"`
- [ ] Follow-up (separate repo): `llm-observability` server read-side fallback to honor `Attributes.verbosityLevel == "Off"` for spans already persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)


