### PR TITLE
refactor(platform): add uipath.platform.constants as the single source of truth

### DIFF
--- a/packages/uipath-platform/README.md
+++ b/packages/uipath-platform/README.md
@@ -1,3 +1,18 @@
 # UiPath Platform
 
 Python SDK for interacting programmatically with UiPath services.
+
+## Constants
+
+`uipath.platform.constants` is the single source of truth for the string
+constants shared across the SDK — environment-variable names, HTTP headers,
+file/folder names, and data-source identifiers. It lives directly under
+`uipath.platform` (the package's `__init__` resolves its heavy exports lazily),
+so it can be imported without pulling in the service layer.
+
+```python
+from uipath.platform.constants import ENV_BASE_URL, HEADER_FOLDER_KEY
+```
+
+> `uipath.platform.common.constants` re-exports these for backward
+> compatibility and is deprecated.

--- a/packages/uipath-platform/README.md
+++ b/packages/uipath-platform/README.md
@@ -1,18 +1,3 @@
 # UiPath Platform
 
 Python SDK for interacting programmatically with UiPath services.
-
-## Constants
-
-`uipath.platform.constants` is the single source of truth for the string
-constants shared across the SDK — environment-variable names, HTTP headers,
-file/folder names, and data-source identifiers. It lives directly under
-`uipath.platform` (the package's `__init__` resolves its heavy exports lazily),
-so it can be imported without pulling in the service layer.
-
-```python
-from uipath.platform.constants import ENV_BASE_URL, HEADER_FOLDER_KEY
-```
-
-> `uipath.platform.common.constants` re-exports these for backward
-> compatibility and is deprecated.

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.1.88"
+version = "0.1.89"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/__init__.py
@@ -34,7 +34,33 @@ Exception classes are available in the `errors` module and should be imported ex
 ```
 """
 
-from ._uipath import UiPath
-from .common import UiPathApiConfig, UiPathExecutionContext
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._uipath import UiPath
+    from .common import UiPathApiConfig, UiPathExecutionContext
 
 __all__ = ["UiPathApiConfig", "UiPath", "UiPathExecutionContext"]
+
+
+def __getattr__(name: str):
+    """Lazily resolve top-level exports (PEP 562).
+
+    Keeps this package's ``__init__`` cheap so lightweight submodules such as
+    ``uipath.platform.constants`` can be imported without pulling in the
+    ``UiPath`` facade and the full service layer. The heavy import happens only
+    when ``UiPath`` (or a config type) is actually accessed.
+    """
+    if name == "UiPath":
+        from ._uipath import UiPath
+
+        return UiPath
+    if name in ("UiPathApiConfig", "UiPathExecutionContext"):
+        from . import common
+
+        return getattr(common, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/packages/uipath-platform/src/uipath/platform/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/__init__.py
@@ -44,9 +44,7 @@ __all__ = ["UiPathApiConfig", "UiPath", "UiPathExecutionContext"]
 
 
 def __getattr__(name: str):
-    """Lazily resolve top-level exports (PEP 562).
-
-    Keeps this package's ``__init__`` cheap so lightweight submodules such as
+    """Keeps this package's ``__init__`` cheap so lightweight submodules such as
     ``uipath.platform.constants`` can be imported without pulling in the
     ``UiPath`` facade and the full service layer. The heavy import happens only
     when ``UiPath`` (or a config type) is actually accessed.

--- a/packages/uipath-platform/src/uipath/platform/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/__init__.py
@@ -44,7 +44,9 @@ __all__ = ["UiPathApiConfig", "UiPath", "UiPathExecutionContext"]
 
 
 def __getattr__(name: str):
-    """Keeps this package's ``__init__`` cheap so lightweight submodules such as
+    """Resolve top-level exports on demand.
+
+    Keeps this package's ``__init__`` cheap so lightweight submodules such as
     ``uipath.platform.constants`` can be imported without pulling in the
     ``UiPath`` facade and the full service layer. The heavy import happens only
     when ``UiPath`` (or a config type) is actually accessed.

--- a/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
+++ b/packages/uipath-platform/src/uipath/platform/action_center/_tasks_service.py
@@ -5,16 +5,17 @@ from typing import Any, Dict, List, Optional
 
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import (
+    ENV_TENANT_ID,
+    HEADER_TENANT_ID,
+)
+
 from ..common._base_service import BaseService
 from ..common._bindings import resource_override
 from ..common._config import UiPathApiConfig, UiPathConfig
 from ..common._execution_context import UiPathExecutionContext
 from ..common._folder_context import FolderContext, header_folder
 from ..common._models import Endpoint, RequestSpec
-from ..common.constants import (
-    ENV_TENANT_ID,
-    HEADER_TENANT_ID,
-)
 from .task_schema import TaskSchema
 from .tasks import Task, TaskRecipient, TaskRecipientType
 

--- a/packages/uipath-platform/src/uipath/platform/chat/_llm_gateway_service.py
+++ b/packages/uipath-platform/src/uipath/platform/chat/_llm_gateway_service.py
@@ -22,12 +22,13 @@ from opentelemetry import trace
 from pydantic import BaseModel
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import HEADER_AGENTHUB_CONFIG
+
 from ..common._base_service import BaseService
 from ..common._config import UiPathApiConfig
 from ..common._endpoints_manager import EndpointManager
 from ..common._execution_context import UiPathExecutionContext
 from ..common._models import Endpoint
-from ..common.constants import HEADER_AGENTHUB_CONFIG
 from .llm_gateway import (
     ChatCompletion,
     SpecificToolChoice,

--- a/packages/uipath-platform/src/uipath/platform/common/_base_service.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_base_service.py
@@ -20,6 +20,8 @@ from tenacity import (
     stop_after_attempt,
 )
 
+from uipath.platform.constants import HEADER_USER_AGENT
+
 from ..errors import EnrichedException
 from ._config import UiPathApiConfig
 from ._execution_context import UiPathExecutionContext
@@ -27,7 +29,6 @@ from ._http_config import get_httpx_client_kwargs
 from ._service_url_overrides import inject_routing_headers, resolve_service_url
 from ._url import UiPathUrl
 from ._user_agent import user_agent_value
-from .constants import HEADER_USER_AGENT
 from .retry import (
     MAX_RETRY_ATTEMPTS,
     is_retryable_platform_exception,

--- a/packages/uipath-platform/src/uipath/platform/common/_config.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_config.py
@@ -36,13 +36,13 @@ class ConfigurationManager:
 
     @property
     def bindings_file_path(self) -> Path:
-        from uipath.platform.common.constants import UIPATH_BINDINGS_FILE
+        from uipath.platform.constants import UIPATH_BINDINGS_FILE
 
         return Path(UIPATH_BINDINGS_FILE)
 
     @property
     def config_file_path(self) -> Path:
-        from uipath.platform.common.constants import (
+        from uipath.platform.constants import (
             ENV_UIPATH_CONFIG_PATH,
             UIPATH_CONFIG_FILE,
         )
@@ -51,97 +51,97 @@ class ConfigurationManager:
 
     @property
     def config_file_name(self) -> str:
-        from uipath.platform.common.constants import UIPATH_CONFIG_FILE
+        from uipath.platform.constants import UIPATH_CONFIG_FILE
 
         return UIPATH_CONFIG_FILE
 
     @property
     def project_id(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_PROJECT_ID
+        from uipath.platform.constants import ENV_UIPATH_PROJECT_ID
 
         return os.getenv(ENV_UIPATH_PROJECT_ID, None)
 
     @property
     def agent_id(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_AGENT_ID
+        from uipath.platform.constants import ENV_UIPATH_AGENT_ID
 
         return os.getenv(ENV_UIPATH_AGENT_ID) or self.project_id
 
     @property
     def cloud_user_id(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_CLOUD_USER_ID
+        from uipath.platform.constants import ENV_UIPATH_CLOUD_USER_ID
 
         return os.getenv(ENV_UIPATH_CLOUD_USER_ID, None)
 
     @property
     def project_files_source(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_PROJECT_FILES_SOURCE
+        from uipath.platform.constants import ENV_UIPATH_PROJECT_FILES_SOURCE
 
         return os.getenv(ENV_UIPATH_PROJECT_FILES_SOURCE, None)
 
     @property
     def project_key(self) -> str | None:
-        from uipath.platform.common.constants import ENV_PROJECT_KEY
+        from uipath.platform.constants import ENV_PROJECT_KEY
 
         return os.getenv(ENV_PROJECT_KEY, None)
 
     @property
     def tenant_name(self) -> str | None:
-        from uipath.platform.common.constants import ENV_TENANT_NAME
+        from uipath.platform.constants import ENV_TENANT_NAME
 
         return os.getenv(ENV_TENANT_NAME, None)
 
     @property
     def tenant_id(self) -> str | None:
-        from uipath.platform.common.constants import ENV_TENANT_ID
+        from uipath.platform.constants import ENV_TENANT_ID
 
         return os.getenv(ENV_TENANT_ID, None)
 
     @property
     def organization_id(self) -> str | None:
-        from uipath.platform.common.constants import ENV_ORGANIZATION_ID
+        from uipath.platform.constants import ENV_ORGANIZATION_ID
 
         return os.getenv(ENV_ORGANIZATION_ID, None)
 
     @property
     def base_url(self) -> str | None:
-        from uipath.platform.common.constants import ENV_BASE_URL
+        from uipath.platform.constants import ENV_BASE_URL
 
         return os.getenv(ENV_BASE_URL, None)
 
     @property
     def folder_key(self) -> str | None:
-        from uipath.platform.common.constants import ENV_FOLDER_KEY
+        from uipath.platform.constants import ENV_FOLDER_KEY
 
         return os.getenv(ENV_FOLDER_KEY, None)
 
     @property
     def folder_path(self) -> str | None:
-        from uipath.platform.common.constants import ENV_FOLDER_PATH
+        from uipath.platform.constants import ENV_FOLDER_PATH
 
         return os.getenv(ENV_FOLDER_PATH, None)
 
     @property
     def process_key(self) -> str | None:
-        from uipath.platform.common.constants import ENV_PROCESS_KEY
+        from uipath.platform.constants import ENV_PROCESS_KEY
 
         return os.getenv(ENV_PROCESS_KEY, None)
 
     @property
     def process_uuid(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_PROCESS_UUID
+        from uipath.platform.constants import ENV_UIPATH_PROCESS_UUID
 
         return os.getenv(ENV_UIPATH_PROCESS_UUID, None)
 
     @property
     def trace_id(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_TRACE_ID
+        from uipath.platform.constants import ENV_UIPATH_TRACE_ID
 
         return os.getenv(ENV_UIPATH_TRACE_ID, None)
 
     @property
     def process_version(self) -> str | None:
-        from uipath.platform.common.constants import ENV_UIPATH_PROCESS_VERSION
+        from uipath.platform.constants import ENV_UIPATH_PROCESS_VERSION
 
         return os.getenv(ENV_UIPATH_PROCESS_VERSION, None)
 
@@ -151,39 +151,39 @@ class ConfigurationManager:
 
     @property
     def job_key(self) -> str | None:
-        from uipath.platform.common.constants import ENV_JOB_KEY
+        from uipath.platform.constants import ENV_JOB_KEY
 
         return os.getenv(ENV_JOB_KEY, None)
 
     @property
     def has_legacy_eval_folder(self) -> bool:
-        from uipath.platform.common.constants import LEGACY_EVAL_FOLDER
+        from uipath.platform.constants import LEGACY_EVAL_FOLDER
 
         eval_path = Path(os.getcwd()) / LEGACY_EVAL_FOLDER
         return eval_path.exists() and eval_path.is_dir()
 
     @property
     def has_eval_folder(self) -> bool:
-        from uipath.platform.common.constants import EVALS_FOLDER
+        from uipath.platform.constants import EVALS_FOLDER
 
         coded_eval_path = Path(os.getcwd()) / EVALS_FOLDER
         return coded_eval_path.exists() and coded_eval_path.is_dir()
 
     @property
     def entry_points_file_path(self) -> Path:
-        from uipath.platform.common.constants import ENTRY_POINTS_FILE
+        from uipath.platform.constants import ENTRY_POINTS_FILE
 
         return Path(ENTRY_POINTS_FILE)
 
     @property
     def uiproj_file_path(self) -> Path:
-        from uipath.platform.common.constants import UIPROJ_FILE
+        from uipath.platform.constants import UIPROJ_FILE
 
         return Path(UIPROJ_FILE)
 
     @property
     def studio_metadata_file_path(self) -> Path:
-        from uipath.platform.common.constants import STUDIO_METADATA_FILE
+        from uipath.platform.constants import STUDIO_METADATA_FILE
 
         return Path(".uipath", STUDIO_METADATA_FILE)
 
@@ -198,7 +198,7 @@ class ConfigurationManager:
 
     @property
     def is_tracing_enabled(self) -> bool:
-        from uipath.platform.common.constants import ENV_TRACING_ENABLED
+        from uipath.platform.constants import ENV_TRACING_ENABLED
 
         return os.getenv(ENV_TRACING_ENABLED, "true").lower() == "true"
 

--- a/packages/uipath-platform/src/uipath/platform/common/_execution_context.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_execution_context.py
@@ -1,7 +1,7 @@
 from contextvars import ContextVar, Token
 from os import environ as env
 
-from uipath.platform.common.constants import ENV_JOB_ID, ENV_JOB_KEY, ENV_ROBOT_KEY
+from uipath.platform.constants import ENV_JOB_ID, ENV_JOB_KEY, ENV_ROBOT_KEY
 
 _execution_source: ContextVar[str | None] = ContextVar("execution_source", default=None)
 

--- a/packages/uipath-platform/src/uipath/platform/common/_external_application_service.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_external_application_service.py
@@ -5,10 +5,11 @@ from urllib.parse import urlparse
 import httpx
 from httpx import HTTPStatusError
 
+from uipath.platform.constants import ENV_BASE_URL
+
 from ..errors import EnrichedException
 from ..identity import IdentityService
 from .auth import TokenData
-from .constants import ENV_BASE_URL
 
 
 class ExternalApplicationService:

--- a/packages/uipath-platform/src/uipath/platform/common/_folder_context.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_folder_context.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 from os import environ as env
 from typing import Any, Optional
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_FOLDER_KEY,
     ENV_FOLDER_PATH,
     HEADER_FOLDER_KEY,

--- a/packages/uipath-platform/src/uipath/platform/common/_http_config.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_http_config.py
@@ -66,8 +66,9 @@ def get_httpx_client_kwargs(
     ca_bundle = get_ca_bundle_path()
     client_kwargs["verify"] = create_ssl_context(ca_bundle) if ca_bundle else False
 
+    from uipath.platform.constants import HEADER_LICENSING_CONTEXT
+
     from ._config import UiPathConfig
-    from .constants import HEADER_LICENSING_CONTEXT
 
     merged_headers: Dict[str, str] = {}
     licensing_context = UiPathConfig.licensing_context

--- a/packages/uipath-platform/src/uipath/platform/common/_job_context.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_job_context.py
@@ -1,5 +1,6 @@
+from uipath.platform.constants import HEADER_JOB_KEY
+
 from ._config import UiPathConfig
-from .constants import HEADER_JOB_KEY
 
 
 def header_job_key() -> dict[str, str]:

--- a/packages/uipath-platform/src/uipath/platform/common/_service_url_overrides.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_service_url_overrides.py
@@ -14,8 +14,12 @@ layer is bypassed.
 
 import os
 
+from uipath.platform.constants import (
+    HEADER_INTERNAL_ACCOUNT_ID,
+    HEADER_INTERNAL_TENANT_ID,
+)
+
 from ._config import UiPathConfig
-from .constants import HEADER_INTERNAL_ACCOUNT_ID, HEADER_INTERNAL_TENANT_ID
 
 
 def resolve_service_url(endpoint_path: str) -> str | None:

--- a/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_span_utils.py
@@ -15,7 +15,7 @@ from opentelemetry.trace import StatusCode
 from pydantic import BaseModel, ConfigDict, Field
 from uipath.core.serialization import serialize_json
 
-from .constants import (
+from uipath.platform.constants import (
     ENV_FOLDER_KEY,
     ENV_JOB_KEY,
     ENV_ORGANIZATION_ID,

--- a/packages/uipath-platform/src/uipath/platform/common/_user_agent.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_user_agent.py
@@ -1,6 +1,6 @@
 import importlib
 
-from .constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 
 
 def user_agent_value(specific_component: str) -> str:

--- a/packages/uipath-platform/src/uipath/platform/common/auth.py
+++ b/packages/uipath-platform/src/uipath/platform/common/auth.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_UIPATH_ACCESS_TOKEN,
     ENV_UNATTENDED_USER_ACCESS_TOKEN,

--- a/packages/uipath-platform/src/uipath/platform/common/constants.py
+++ b/packages/uipath-platform/src/uipath/platform/common/constants.py
@@ -1,96 +1,16 @@
-"""Constants."""
+"""Deprecated alias for ``uipath.platform.constants``.
 
-# Environment variables
-DOTENV_FILE = ".env"
-ENV_BASE_URL = "UIPATH_URL"
-ENV_EVAL_BACKEND_URL = "UIPATH_EVAL_BACKEND_URL"
-ENV_UNATTENDED_USER_ACCESS_TOKEN = "UNATTENDED_USER_ACCESS_TOKEN"
-ENV_UIPATH_ACCESS_TOKEN = "UIPATH_ACCESS_TOKEN"
-ENV_FOLDER_KEY = "UIPATH_FOLDER_KEY"
-ENV_FOLDER_PATH = "UIPATH_FOLDER_PATH"
-ENV_JOB_KEY = "UIPATH_JOB_KEY"
-ENV_JOB_ID = "UIPATH_JOB_ID"
-ENV_ROBOT_KEY = "UIPATH_ROBOT_KEY"
-ENV_TENANT_ID = "UIPATH_TENANT_ID"
-ENV_TENANT_NAME = "UIPATH_TENANT_NAME"
-ENV_ORGANIZATION_ID = "UIPATH_ORGANIZATION_ID"
-ENV_TELEMETRY_ENABLED = "UIPATH_TELEMETRY_ENABLED"
-ENV_TRACING_ENABLED = "UIPATH_TRACING_ENABLED"
-ENV_UIPATH_PROJECT_ID = "UIPATH_PROJECT_ID"
-ENV_UIPATH_AGENT_ID = "UIPATH_AGENT_ID"
-ENV_UIPATH_CLOUD_USER_ID = "UIPATH_CLOUD_USER_ID"
-ENV_UIPATH_PROJECT_FILES_SOURCE = "UIPATH_PROJECT_FILES_SOURCE"
-ENV_PROJECT_KEY = "PROJECT_KEY"
-ENV_PROCESS_KEY = "UIPATH_PROCESS_KEY"
-ENV_UIPATH_PROCESS_UUID = "UIPATH_PROCESS_UUID"
-ENV_UIPATH_TRACE_ID = "UIPATH_TRACE_ID"
-ENV_UIPATH_PROCESS_VERSION = "UIPATH_PROCESS_VERSION"
-ENV_UIPATH_CONFIG_PATH = "UIPATH_CONFIG_PATH"
+This module is kept as a backward-compatibility shim so existing imports keep
+working. New code should import from ``uipath.platform.constants``.
+"""
 
-# Headers
-HEADER_FOLDER_KEY = "x-uipath-folderkey"
-HEADER_FOLDER_PATH = "x-uipath-folderpath"
-HEADER_FOLDER_PATH_ENCODED = "x-uipath-folderpath-encoded"
-HEADER_USER_AGENT = "x-uipath-user-agent"
-HEADER_TENANT_ID = "x-uipath-tenantid"
-HEADER_INTERNAL_TENANT_ID = "x-uipath-internal-tenantid"
-HEADER_INTERNAL_ACCOUNT_ID = "x-uipath-internal-accountid"
-HEADER_JOB_KEY = "x-uipath-jobkey"
-HEADER_PROCESS_KEY = "x-uipath-processkey"
-HEADER_TRACE_ID = "x-uipath-traceid"
-HEADER_AGENTHUB_CONFIG = "x-uipath-agenthub-config"
-HEADER_GUARDRAILS_SOURCE = "x-uipath-guardrails-source"
-HEADER_LLMGATEWAY_BYO_CONNECTION_ID = "x-uipath-llmgateway-byoisconnectionid"
-HEADER_SW_LOCK_KEY = "x-uipath-sw-lockkey"
-HEADER_LICENSING_CONTEXT = "x-uipath-licensing-context"
+import warnings as _warnings
 
-# Data sources (request types)
-ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSourceRequest"
+from uipath.platform.constants import *  # noqa: F401,F403
+
+_warnings.warn(
+    "uipath.platform.common.constants is deprecated and will be removed in a "
+    "future release; import from uipath.platform.constants instead.",
+    FutureWarning,
+    stacklevel=2,
 )
-CONFLUENCE_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
-)
-DROPBOX_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
-)
-GOOGLE_DRIVE_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSourceRequest"
-)
-ONEDRIVE_DATA_SOURCE_REQUEST = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
-)
-
-# Data sources
-ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
-    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSource"
-)
-CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSource"
-DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSource"
-GOOGLE_DRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSource"
-ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSource"
-LLMV3Mini_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
-LLMV4_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
-NativeV1_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
-
-
-# Local storage
-TEMP_ATTACHMENTS_FOLDER = "uipath_attachments"
-
-# LLM models
-COMMUNITY_agents_SUFFIX = "-community-agents"
-
-# File names
-PYTHON_CONFIGURATION_FILE = "pyproject.toml"
-UIPATH_CONFIG_FILE = "uipath.json"
-UIPATH_BINDINGS_FILE = "bindings.json"
-ENTRY_POINTS_FILE = "entry-points.json"
-STUDIO_METADATA_FILE = "studio_metadata.json"
-UIPROJ_FILE = "project.uiproj"
-
-
-# Folder names
-LEGACY_EVAL_FOLDER = "evals"
-EVALS_FOLDER = "evaluations"
-# Evaluators
-CUSTOM_EVALUATOR_PREFIX = "file://"

--- a/packages/uipath-platform/src/uipath/platform/constants/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/constants/__init__.py
@@ -1,0 +1,105 @@
+"""Constants.
+
+Single source of truth for constants shared across the UiPath SDK packages.
+Lives directly under ``uipath.platform`` (sibling to ``common``) so it can be
+imported cheaply — ``uipath.platform``'s ``__init__`` resolves its heavy
+exports lazily, so importing this module does not pull in the service layer.
+
+``uipath.platform.common.constants`` and ``uipath._utils.constants`` re-export
+from here.
+"""
+
+# Environment variables
+DOTENV_FILE = ".env"
+ENV_BASE_URL = "UIPATH_URL"
+ENV_EVAL_BACKEND_URL = "UIPATH_EVAL_BACKEND_URL"
+ENV_UNATTENDED_USER_ACCESS_TOKEN = "UNATTENDED_USER_ACCESS_TOKEN"
+ENV_UIPATH_ACCESS_TOKEN = "UIPATH_ACCESS_TOKEN"
+ENV_FOLDER_KEY = "UIPATH_FOLDER_KEY"
+ENV_FOLDER_PATH = "UIPATH_FOLDER_PATH"
+ENV_JOB_KEY = "UIPATH_JOB_KEY"
+ENV_JOB_ID = "UIPATH_JOB_ID"
+ENV_ROBOT_KEY = "UIPATH_ROBOT_KEY"
+ENV_TENANT_ID = "UIPATH_TENANT_ID"
+ENV_TENANT_NAME = "UIPATH_TENANT_NAME"
+ENV_ORGANIZATION_ID = "UIPATH_ORGANIZATION_ID"
+ENV_TELEMETRY_ENABLED = "UIPATH_TELEMETRY_ENABLED"
+ENV_TRACING_ENABLED = "UIPATH_TRACING_ENABLED"
+ENV_UIPATH_PROJECT_ID = "UIPATH_PROJECT_ID"
+ENV_UIPATH_AGENT_ID = "UIPATH_AGENT_ID"
+ENV_UIPATH_CLOUD_USER_ID = "UIPATH_CLOUD_USER_ID"
+ENV_UIPATH_PROJECT_FILES_SOURCE = "UIPATH_PROJECT_FILES_SOURCE"
+ENV_PROJECT_KEY = "PROJECT_KEY"
+ENV_PROCESS_KEY = "UIPATH_PROCESS_KEY"
+ENV_UIPATH_PROCESS_UUID = "UIPATH_PROCESS_UUID"
+ENV_UIPATH_TRACE_ID = "UIPATH_TRACE_ID"
+ENV_UIPATH_PROCESS_VERSION = "UIPATH_PROCESS_VERSION"
+ENV_UIPATH_CONFIG_PATH = "UIPATH_CONFIG_PATH"
+
+# Headers
+HEADER_FOLDER_KEY = "x-uipath-folderkey"
+HEADER_FOLDER_PATH = "x-uipath-folderpath"
+HEADER_FOLDER_PATH_ENCODED = "x-uipath-folderpath-encoded"
+HEADER_USER_AGENT = "x-uipath-user-agent"
+HEADER_TENANT_ID = "x-uipath-tenantid"
+HEADER_INTERNAL_TENANT_ID = "x-uipath-internal-tenantid"
+HEADER_INTERNAL_ACCOUNT_ID = "x-uipath-internal-accountid"
+HEADER_JOB_KEY = "x-uipath-jobkey"
+HEADER_PROCESS_KEY = "x-uipath-processkey"
+HEADER_TRACE_ID = "x-uipath-traceid"
+HEADER_AGENTHUB_CONFIG = "x-uipath-agenthub-config"
+HEADER_GUARDRAILS_SOURCE = "x-uipath-guardrails-source"
+HEADER_LLMGATEWAY_BYO_CONNECTION_ID = "x-uipath-llmgateway-byoisconnectionid"
+HEADER_SW_LOCK_KEY = "x-uipath-sw-lockkey"
+HEADER_LICENSING_CONTEXT = "x-uipath-licensing-context"
+
+# Data sources (request types)
+ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSourceRequest"
+)
+CONFLUENCE_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSourceRequest"
+)
+DROPBOX_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSourceRequest"
+)
+GOOGLE_DRIVE_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSourceRequest"
+)
+ONEDRIVE_DATA_SOURCE_REQUEST = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSourceRequest"
+)
+
+# Data sources
+ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE = (
+    "#UiPath.Vdbs.Domain.Api.V20Models.StorageBucketDataSource"
+)
+CONFLUENCE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.ConfluenceDataSource"
+DROPBOX_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.DropboxDataSource"
+GOOGLE_DRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.GoogleDriveDataSource"
+ONEDRIVE_DATA_SOURCE = "#UiPath.Vdbs.Domain.Api.V20Models.OneDriveDataSource"
+LLMV3Mini_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV3MiniPreProcessingRequest"
+LLMV4_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.LLMV4PreProcessingRequest"
+NativeV1_REQUEST = "#UiPath.Vdbs.Domain.Api.V20Models.NativeV1PreProcessingRequest"
+
+
+# Local storage
+TEMP_ATTACHMENTS_FOLDER = "uipath_attachments"
+
+# LLM models
+COMMUNITY_agents_SUFFIX = "-community-agents"
+
+# File names
+PYTHON_CONFIGURATION_FILE = "pyproject.toml"
+UIPATH_CONFIG_FILE = "uipath.json"
+UIPATH_BINDINGS_FILE = "bindings.json"
+ENTRY_POINTS_FILE = "entry-points.json"
+STUDIO_METADATA_FILE = "studio_metadata.json"
+UIPROJ_FILE = "project.uiproj"
+
+
+# Folder names
+LEGACY_EVAL_FOLDER = "evals"
+EVALS_FOLDER = "evaluations"
+# Evaluators
+CUSTOM_EVALUATOR_PREFIX = "file://"

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/_context_grounding_service.py
@@ -6,6 +6,10 @@ from pydantic import Field, TypeAdapter
 from typing_extensions import deprecated
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import (
+    ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE,
+)
+
 from ..common._base_service import BaseService
 from ..common._bindings import resource_override
 from ..common._config import UiPathApiConfig
@@ -14,9 +18,6 @@ from ..common._folder_context import FolderContext, header_folder
 from ..common._http_config import get_httpx_client_kwargs
 from ..common._job_context import header_job_key
 from ..common._models import Endpoint, RequestSpec
-from ..common.constants import (
-    ORCHESTRATOR_STORAGE_BUCKET_DATA_SOURCE,
-)
 from ..errors import (
     BatchTransformFailedException,
     BatchTransformNotCompleteException,

--- a/packages/uipath-platform/src/uipath/platform/context_grounding/context_grounding_payloads.py
+++ b/packages/uipath-platform/src/uipath/platform/context_grounding/context_grounding_payloads.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     CONFLUENCE_DATA_SOURCE_REQUEST,
     DROPBOX_DATA_SOURCE_REQUEST,
     GOOGLE_DRIVE_DATA_SOURCE_REQUEST,

--- a/packages/uipath-platform/src/uipath/platform/entities/_entity_schema_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entity_schema_service.py
@@ -11,11 +11,12 @@ from typing import Any, Dict, List, Optional
 
 from httpx import Response
 
+from uipath.platform.constants import HEADER_FOLDER_KEY
+
 from ..common._base_service import BaseService
 from ..common._config import UiPathApiConfig
 from ..common._execution_context import UiPathExecutionContext
 from ..common._models import Endpoint, RequestSpec
-from ..common.constants import HEADER_FOLDER_KEY
 from ..orchestrator._folder_service import FolderService
 from .entities import (
     ENTITY_FIELD_CONSTRAINT_DEFAULTS,

--- a/packages/uipath-platform/src/uipath/platform/governance/_governance_service.py
+++ b/packages/uipath-platform/src/uipath/platform/governance/_governance_service.py
@@ -29,13 +29,14 @@ from uipath.core.governance import (
     PolicyResponse,
 )
 
+from uipath.platform.constants import HEADER_INTERNAL_TENANT_ID
+
 from ..common._base_service import BaseService, resolve_trace_id
 from ..common._config import UiPathConfig
 from ..common._service_url_overrides import (
     inject_routing_headers,
     resolve_service_url,
 )
-from ..common.constants import HEADER_INTERNAL_TENANT_ID
 
 # The agenticgovernance_ ingress lives at a separate org-scoped path that
 # uses the organization UUID (not the slug exposed by ``UIPATH_URL``).

--- a/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
@@ -8,13 +8,14 @@ from uipath.core.guardrails import (
 )
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import HEADER_GUARDRAILS_SOURCE
+
 from ..chat.llm_trace_context import build_trace_context_headers
 from ..common._base_service import BaseService
 from ..common._config import UiPathApiConfig
 from ..common._execution_context import UiPathExecutionContext
 from ..common._job_context import header_job_key
 from ..common._models import Endpoint, RequestSpec
-from ..common.constants import HEADER_GUARDRAILS_SOURCE
 from ..errors import EnrichedException
 from .guardrails import BuiltInValidatorGuardrail
 

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_attachments_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_attachments_service.py
@@ -12,6 +12,8 @@ from httpx import Response
 from httpx._types import RequestContent
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import TEMP_ATTACHMENTS_FOLDER
+
 from ..attachments import Attachment, AttachmentMode, BlobFileAccessInfo
 from ..common._base_service import BaseService
 from ..common._config import UiPathApiConfig
@@ -19,7 +21,6 @@ from ..common._execution_context import UiPathExecutionContext
 from ..common._folder_context import FolderContext, header_folder
 from ..common._http_config import get_httpx_client_kwargs
 from ..common._models import Endpoint, RequestSpec
-from ..common.constants import TEMP_ATTACHMENTS_FOLDER
 
 
 def _upload_attachment_input_processor(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_jobs_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_jobs_service.py
@@ -7,13 +7,14 @@ from typing import Any, Dict, List, Optional, Union, cast, overload
 
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import TEMP_ATTACHMENTS_FOLDER
+
 from ..common._base_service import BaseService
 from ..common._bindings import resource_override
 from ..common._config import UiPathApiConfig
 from ..common._execution_context import UiPathExecutionContext
 from ..common._folder_context import FolderContext, header_folder
 from ..common._models import Endpoint, RequestSpec
-from ..common.constants import TEMP_ATTACHMENTS_FOLDER
 from ..common.paging import PagedResult
 from ..common.validation import validate_pagination_params
 from ..errors import EnrichedException

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_processes_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_processes_service.py
@@ -7,6 +7,8 @@ from opentelemetry import trace
 from opentelemetry.trace import format_span_id
 from uipath.core.tracing import traced
 
+from uipath.platform.constants import ENV_JOB_KEY, HEADER_JOB_KEY
+
 from ..attachments import Attachment
 from ..common._base_service import BaseService
 from ..common._bindings import resource_override
@@ -15,7 +17,6 @@ from ..common._execution_context import UiPathExecutionContext
 from ..common._folder_context import FolderContext, header_folder
 from ..common._models import Endpoint, RequestSpec
 from ..common._span_utils import _SpanUtils
-from ..common.constants import ENV_JOB_KEY, HEADER_JOB_KEY
 from ._attachments_service import AttachmentsService
 from .job import Job
 

--- a/packages/uipath-platform/tests/common/test_config_env_vars.py
+++ b/packages/uipath-platform/tests/common/test_config_env_vars.py
@@ -1,22 +1,70 @@
+from pathlib import Path
+
 import pytest
 
 from uipath.platform.common._config import UiPathConfig
+from uipath.platform.constants import (
+    ENTRY_POINTS_FILE,
+    ENV_BASE_URL,
+    ENV_FOLDER_KEY,
+    ENV_FOLDER_PATH,
+    ENV_JOB_KEY,
+    ENV_ORGANIZATION_ID,
+    ENV_PROCESS_KEY,
+    ENV_PROJECT_KEY,
+    ENV_TENANT_ID,
+    ENV_TENANT_NAME,
+    ENV_TRACING_ENABLED,
+    ENV_UIPATH_AGENT_ID,
+    ENV_UIPATH_CLOUD_USER_ID,
+    ENV_UIPATH_CONFIG_PATH,
+    ENV_UIPATH_PROCESS_UUID,
+    ENV_UIPATH_PROCESS_VERSION,
+    ENV_UIPATH_PROJECT_FILES_SOURCE,
+    ENV_UIPATH_PROJECT_ID,
+    ENV_UIPATH_TRACE_ID,
+    EVALS_FOLDER,
+    LEGACY_EVAL_FOLDER,
+    STUDIO_METADATA_FILE,
+    UIPATH_BINDINGS_FILE,
+    UIPATH_CONFIG_FILE,
+    UIPROJ_FILE,
+)
+
+# Every env var read by ConfigurationManager properties. Cleared before each
+# test so "returns None when unset" assertions don't pick up the real
+# environment.
+_ENV_VARS = (
+    ENV_UIPATH_PROJECT_ID,
+    ENV_UIPATH_AGENT_ID,
+    ENV_UIPATH_CLOUD_USER_ID,
+    ENV_UIPATH_PROJECT_FILES_SOURCE,
+    ENV_PROJECT_KEY,
+    ENV_TENANT_NAME,
+    ENV_TENANT_ID,
+    ENV_ORGANIZATION_ID,
+    ENV_BASE_URL,
+    ENV_FOLDER_KEY,
+    ENV_FOLDER_PATH,
+    ENV_PROCESS_KEY,
+    ENV_UIPATH_PROCESS_UUID,
+    ENV_UIPATH_TRACE_ID,
+    ENV_UIPATH_PROCESS_VERSION,
+    ENV_JOB_KEY,
+    ENV_UIPATH_CONFIG_PATH,
+    ENV_TRACING_ENABLED,
+)
 
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch):
-    for var in (
-        "UIPATH_PROJECT_ID",
-        "UIPATH_AGENT_ID",
-        "UIPATH_CLOUD_USER_ID",
-        "UIPATH_PROJECT_FILES_SOURCE",
-    ):
+    for var in _ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
 
 class TestProjectId:
     def test_reads_env_var(self, monkeypatch):
-        monkeypatch.setenv("UIPATH_PROJECT_ID", "file-source-id")
+        monkeypatch.setenv(ENV_UIPATH_PROJECT_ID, "file-source-id")
         assert UiPathConfig.project_id == "file-source-id"
 
     def test_returns_none_when_unset(self):
@@ -25,12 +73,12 @@ class TestProjectId:
 
 class TestAgentId:
     def test_returns_explicit_agent_id_when_set(self, monkeypatch):
-        monkeypatch.setenv("UIPATH_PROJECT_ID", "debug-project-guid")
-        monkeypatch.setenv("UIPATH_AGENT_ID", "real-agent-id")
+        monkeypatch.setenv(ENV_UIPATH_PROJECT_ID, "debug-project-guid")
+        monkeypatch.setenv(ENV_UIPATH_AGENT_ID, "real-agent-id")
         assert UiPathConfig.agent_id == "real-agent-id"
 
     def test_falls_back_to_project_id_when_agent_id_unset(self, monkeypatch):
-        monkeypatch.setenv("UIPATH_PROJECT_ID", "cloud-project-id")
+        monkeypatch.setenv(ENV_UIPATH_PROJECT_ID, "cloud-project-id")
         assert UiPathConfig.agent_id == "cloud-project-id"
 
     def test_returns_none_when_neither_set(self):
@@ -39,7 +87,7 @@ class TestAgentId:
 
 class TestCloudUserId:
     def test_returns_value_when_set(self, monkeypatch):
-        monkeypatch.setenv("UIPATH_CLOUD_USER_ID", "user-guid")
+        monkeypatch.setenv(ENV_UIPATH_CLOUD_USER_ID, "user-guid")
         assert UiPathConfig.cloud_user_id == "user-guid"
 
     def test_returns_none_when_unset(self):
@@ -48,8 +96,97 @@ class TestCloudUserId:
 
 class TestProjectFilesSource:
     def test_returns_value_when_set(self, monkeypatch):
-        monkeypatch.setenv("UIPATH_PROJECT_FILES_SOURCE", "Local")
+        monkeypatch.setenv(ENV_UIPATH_PROJECT_FILES_SOURCE, "Local")
         assert UiPathConfig.project_files_source == "Local"
 
     def test_returns_none_when_unset(self):
         assert UiPathConfig.project_files_source is None
+
+
+@pytest.mark.parametrize(
+    ("prop", "env_var", "value"),
+    [
+        ("project_key", ENV_PROJECT_KEY, "proj-key"),
+        ("tenant_name", ENV_TENANT_NAME, "my-tenant"),
+        ("tenant_id", ENV_TENANT_ID, "tenant-guid"),
+        ("organization_id", ENV_ORGANIZATION_ID, "org-guid"),
+        ("base_url", ENV_BASE_URL, "https://cloud.uipath.com/org/tenant"),
+        ("folder_key", ENV_FOLDER_KEY, "folder-guid"),
+        ("folder_path", ENV_FOLDER_PATH, "Shared/My Folder"),
+        ("process_key", ENV_PROCESS_KEY, "process-key"),
+        ("process_uuid", ENV_UIPATH_PROCESS_UUID, "process-uuid"),
+        ("trace_id", ENV_UIPATH_TRACE_ID, "trace-id"),
+        ("process_version", ENV_UIPATH_PROCESS_VERSION, "1.2.3"),
+        ("job_key", ENV_JOB_KEY, "job-guid"),
+    ],
+)
+class TestOptionalEnvVarProperties:
+    def test_returns_value_when_set(self, monkeypatch, prop, env_var, value):
+        monkeypatch.setenv(env_var, value)
+        assert getattr(UiPathConfig, prop) == value
+
+    def test_returns_none_when_unset(self, monkeypatch, prop, env_var, value):
+        assert getattr(UiPathConfig, prop) is None
+
+
+class TestFileNameProperties:
+    def test_config_file_name(self):
+        assert UiPathConfig.config_file_name == UIPATH_CONFIG_FILE
+
+    def test_bindings_file_path(self):
+        assert UiPathConfig.bindings_file_path == Path(UIPATH_BINDINGS_FILE)
+
+    def test_entry_points_file_path(self):
+        assert UiPathConfig.entry_points_file_path == Path(ENTRY_POINTS_FILE)
+
+    def test_uiproj_file_path(self):
+        assert UiPathConfig.uiproj_file_path == Path(UIPROJ_FILE)
+
+    def test_studio_metadata_file_path(self):
+        assert UiPathConfig.studio_metadata_file_path == Path(
+            ".uipath", STUDIO_METADATA_FILE
+        )
+
+    def test_config_file_path_defaults_to_config_file(self):
+        assert UiPathConfig.config_file_path == Path(UIPATH_CONFIG_FILE)
+
+    def test_config_file_path_honors_override(self, monkeypatch):
+        monkeypatch.setenv(ENV_UIPATH_CONFIG_PATH, "custom/config.json")
+        assert UiPathConfig.config_file_path == Path("custom/config.json")
+
+
+class TestIsStudioProject:
+    def test_true_when_project_id_set(self, monkeypatch):
+        monkeypatch.setenv(ENV_UIPATH_PROJECT_ID, "some-id")
+        assert UiPathConfig.is_studio_project is True
+
+    def test_false_when_project_id_unset(self):
+        assert UiPathConfig.is_studio_project is False
+
+
+class TestIsTracingEnabled:
+    def test_defaults_to_true_when_unset(self):
+        assert UiPathConfig.is_tracing_enabled is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE"])
+    def test_false_when_disabled(self, monkeypatch, value):
+        monkeypatch.setenv(ENV_TRACING_ENABLED, value)
+        assert UiPathConfig.is_tracing_enabled is False
+
+    def test_true_when_explicitly_enabled(self, monkeypatch):
+        monkeypatch.setenv(ENV_TRACING_ENABLED, "true")
+        assert UiPathConfig.is_tracing_enabled is True
+
+
+class TestEvalFolderDetection:
+    def test_has_legacy_eval_folder(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        assert UiPathConfig.has_legacy_eval_folder is False
+        (tmp_path / LEGACY_EVAL_FOLDER).mkdir()
+        assert UiPathConfig.has_legacy_eval_folder is True
+
+    def test_has_eval_folder(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        assert UiPathConfig.has_eval_folder is False
+        (tmp_path / EVALS_FOLDER).mkdir()
+        assert UiPathConfig.has_eval_folder is True

--- a/packages/uipath-platform/tests/common/test_constants_invariants.py
+++ b/packages/uipath-platform/tests/common/test_constants_invariants.py
@@ -1,0 +1,25 @@
+"""Structural invariants for the canonical constants module.
+
+Exercises ``uipath.platform.constants`` (the source of truth) directly.
+Asserts structural contracts, not literal values — a literal-mirror test would
+just restate the module.
+"""
+
+import uipath.platform.constants as constants
+
+
+def _public_constants() -> dict[str, object]:
+    return {n: getattr(constants, n) for n in dir(constants) if not n.startswith("_")}
+
+
+def test_all_constants_are_non_empty_strings():
+    for name, value in _public_constants().items():
+        assert isinstance(value, str) and value, (
+            f"{name} must be a non-empty string, got {value!r}"
+        )
+
+
+def test_no_duplicate_header_values():
+    # Two header constants mapping to the same wire name is almost certainly a bug.
+    headers = [v for n, v in _public_constants().items() if n.startswith("HEADER_")]
+    assert len(headers) == len(set(headers)), "duplicate header wire names detected"

--- a/packages/uipath-platform/tests/common/test_constants_reexport.py
+++ b/packages/uipath-platform/tests/common/test_constants_reexport.py
@@ -1,0 +1,67 @@
+"""Tests for the constants source of truth and its deprecated re-export.
+
+``uipath.platform.constants`` is the single source of truth.
+``uipath.platform.common.constants`` is a deprecated shim that re-exports it
+and emits a FutureWarning. These tests pin the parity invariant (so the two can
+never drift — same name, different value) and the deprecation behavior.
+"""
+
+import importlib
+import sys
+import warnings
+
+
+def _public_names(module) -> set[str]:
+    return {name for name in dir(module) if not name.startswith("_")}
+
+
+def _import_shim():
+    """Import the deprecated shim with its FutureWarning suppressed."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        return importlib.import_module("uipath.platform.common.constants")
+
+
+def test_shim_reexports_canonical_with_no_drift():
+    canonical = importlib.import_module("uipath.platform.constants")
+    shim = _import_shim()
+
+    canonical_names = _public_names(canonical)
+
+    # Every canonical constant is re-exported with an identical value.
+    missing = sorted(n for n in canonical_names if not hasattr(shim, n))
+    assert not missing, f"shim missing constants: {missing}"
+
+    drift = sorted(
+        n for n in canonical_names if getattr(shim, n) != getattr(canonical, n)
+    )
+    assert not drift, f"value drift between shim and canonical for: {drift}"
+
+
+def test_shim_adds_nothing_of_its_own():
+    """The shim must not define constants absent from the canonical module,
+    otherwise it would no longer be the single source of truth."""
+    canonical = importlib.import_module("uipath.platform.constants")
+    shim = _import_shim()
+
+    extra = sorted(_public_names(shim) - _public_names(canonical))
+    assert not extra, f"shim defines names not in canonical module: {extra}"
+
+
+def test_shim_emits_future_warning():
+    sys.modules.pop("uipath.platform.common.constants", None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.import_module("uipath.platform.common.constants")
+
+    shim_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, FutureWarning)
+        and "uipath.platform.common.constants" in str(w.message)
+        and "uipath.platform.constants" in str(w.message)
+    ]
+    assert len(shim_warnings) == 1, (
+        f"expected exactly one deprecation FutureWarning, got {len(shim_warnings)}: "
+        f"{[str(w.message) for w in caught]}"
+    )

--- a/packages/uipath-platform/tests/common/test_job_context.py
+++ b/packages/uipath-platform/tests/common/test_job_context.py
@@ -1,7 +1,7 @@
 import pytest
 
 from uipath.platform.common._job_context import header_job_key
-from uipath.platform.common.constants import ENV_JOB_KEY, HEADER_JOB_KEY
+from uipath.platform.constants import ENV_JOB_KEY, HEADER_JOB_KEY
 
 
 def test_returns_header_when_env_var_set(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/uipath-platform/tests/services/test_actions_service.py
+++ b/packages/uipath-platform/tests/services/test_actions_service.py
@@ -8,7 +8,7 @@ from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.action_center import Task
 from uipath.platform.action_center._tasks_service import TasksService
 from uipath.platform.action_center.tasks import TaskRecipient, TaskRecipientType
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 
 
 @pytest.fixture

--- a/packages/uipath-platform/tests/services/test_api_client.py
+++ b/packages/uipath-platform/tests/services/test_api_client.py
@@ -3,7 +3,7 @@ from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common._api_client import ApiClient
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 
 
 @pytest.fixture

--- a/packages/uipath-platform/tests/services/test_assets_service.py
+++ b/packages/uipath-platform/tests/services/test_assets_service.py
@@ -4,8 +4,8 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import HEADER_USER_AGENT
 from uipath.platform.common.paging import PagedResult
+from uipath.platform.constants import HEADER_USER_AGENT
 from uipath.platform.orchestrator import Asset, UserAsset
 from uipath.platform.orchestrator._assets_service import AssetsService
 

--- a/packages/uipath-platform/tests/services/test_attachments_service.py
+++ b/packages/uipath-platform/tests/services/test_attachments_service.py
@@ -10,7 +10,7 @@ from pytest_httpx import HTTPXMock
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.attachments import Attachment
 from uipath.platform.attachments.attachments import AttachmentMode
-from uipath.platform.common.constants import HEADER_USER_AGENT, TEMP_ATTACHMENTS_FOLDER
+from uipath.platform.constants import HEADER_USER_AGENT, TEMP_ATTACHMENTS_FOLDER
 from uipath.platform.orchestrator._attachments_service import AttachmentsService
 
 if TYPE_CHECKING:

--- a/packages/uipath-platform/tests/services/test_base_service.py
+++ b/packages/uipath-platform/tests/services/test_base_service.py
@@ -3,7 +3,7 @@ from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common._base_service import BaseService
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 from uipath.platform.errors import EnrichedException
 
 

--- a/packages/uipath-platform/tests/services/test_connections_service.py
+++ b/packages/uipath-platform/tests/services/test_connections_service.py
@@ -8,7 +8,6 @@ from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common import jsonschema_to_pydantic
-from uipath.platform.common.constants import HEADER_FOLDER_KEY, HEADER_USER_AGENT
 from uipath.platform.connections import (
     ActivityMetadata,
     ActivityParameterLocationInfo,
@@ -21,6 +20,7 @@ from uipath.platform.connections._connections_service import (
     HEADER_ACTIVITY_JOB_ID,
     ConnectionsService,
 )
+from uipath.platform.constants import HEADER_FOLDER_KEY, HEADER_USER_AGENT
 from uipath.platform.orchestrator._folder_service import FolderService
 
 

--- a/packages/uipath-platform/tests/services/test_context_grounding_service.py
+++ b/packages/uipath-platform/tests/services/test_context_grounding_service.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_JOB_KEY,
     HEADER_JOB_KEY,
     HEADER_USER_AGENT,

--- a/packages/uipath-platform/tests/services/test_folder_context.py
+++ b/packages/uipath-platform/tests/services/test_folder_context.py
@@ -15,7 +15,7 @@ from uipath.platform.common._folder_context import (
     folder_path_header,
     header_folder,
 )
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_FOLDER_KEY,
     HEADER_FOLDER_PATH,
     HEADER_FOLDER_PATH_ENCODED,

--- a/packages/uipath-platform/tests/services/test_folder_service.py
+++ b/packages/uipath-platform/tests/services/test_folder_service.py
@@ -2,7 +2,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 from uipath.platform.errors import FolderNotFoundException
 from uipath.platform.orchestrator._folder_service import FolderService
 

--- a/packages/uipath-platform/tests/services/test_jobs_service.py
+++ b/packages/uipath-platform/tests/services/test_jobs_service.py
@@ -9,7 +9,7 @@ from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import HEADER_USER_AGENT, TEMP_ATTACHMENTS_FOLDER
+from uipath.platform.constants import HEADER_USER_AGENT, TEMP_ATTACHMENTS_FOLDER
 from uipath.platform.orchestrator import Job
 from uipath.platform.orchestrator._jobs_service import JobsService
 

--- a/packages/uipath-platform/tests/services/test_llm_trace_context.py
+++ b/packages/uipath-platform/tests/services/test_llm_trace_context.py
@@ -8,7 +8,7 @@ from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from uipath.core.feature_flags import FeatureFlags
 
 from uipath.platform.chat.llm_trace_context import build_trace_context_headers
-from uipath.platform.common.constants import ENV_PROJECT_KEY
+from uipath.platform.constants import ENV_PROJECT_KEY
 
 FEATURE_FLAG = "EnableTraceContextHeaders"
 

--- a/packages/uipath-platform/tests/services/test_mcp_service.py
+++ b/packages/uipath-platform/tests/services/test_mcp_service.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import HEADER_FOLDER_KEY, HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_FOLDER_KEY, HEADER_USER_AGENT
 from uipath.platform.orchestrator import McpService
 from uipath.platform.orchestrator._folder_service import FolderService
 from uipath.platform.orchestrator.mcp import McpServer

--- a/packages/uipath-platform/tests/services/test_processes_service.py
+++ b/packages/uipath-platform/tests/services/test_processes_service.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 from uipath.platform.orchestrator import Job
 from uipath.platform.orchestrator._attachments_service import AttachmentsService
 from uipath.platform.orchestrator._processes_service import ProcessesService

--- a/packages/uipath-platform/tests/services/test_queues_service.py
+++ b/packages/uipath-platform/tests/services/test_queues_service.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_FOLDER_KEY,
     HEADER_FOLDER_PATH,
     HEADER_USER_AGENT,

--- a/packages/uipath-platform/tests/services/test_remote_a2a_service.py
+++ b/packages/uipath-platform/tests/services/test_remote_a2a_service.py
@@ -2,7 +2,7 @@ import pytest
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.agenthub._remote_a2a_service import RemoteA2aService
-from uipath.platform.common.constants import HEADER_FOLDER_KEY
+from uipath.platform.constants import HEADER_FOLDER_KEY
 from uipath.platform.orchestrator._folder_service import FolderService
 
 

--- a/packages/uipath-platform/tests/services/test_resource_catalog_service.py
+++ b/packages/uipath-platform/tests/services/test_resource_catalog_service.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 from uipath.platform.orchestrator._folder_service import FolderService
 from uipath.platform.resource_catalog import ResourceType
 from uipath.platform.resource_catalog._resource_catalog_service import (

--- a/packages/uipath-platform/tests/services/test_service_url_overrides.py
+++ b/packages/uipath-platform/tests/services/test_service_url_overrides.py
@@ -4,7 +4,7 @@ from uipath.platform.common._service_url_overrides import (
     inject_routing_headers,
     resolve_service_url,
 )
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_INTERNAL_ACCOUNT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )

--- a/packages/uipath-platform/tests/services/test_span_utils.py
+++ b/packages/uipath-platform/tests/services/test_span_utils.py
@@ -16,7 +16,7 @@ from uipath.platform.common._span_utils import (
     SpanStatus,
     VerbosityLevel,
 )
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_PROJECT_KEY,
     ENV_UIPATH_AGENT_ID,
     ENV_UIPATH_PROJECT_ID,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.88"
+version = "0.1.89"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.12.3"
+version = "2.12.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.26, <0.6.0",
   "uipath-runtime>=0.11.5, <0.12.0",
-  "uipath-platform>=0.1.87, <0.2.0",
+  "uipath-platform>=0.1.89, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/_cli/__init__.py
+++ b/packages/uipath/src/uipath/_cli/__init__.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 from uipath._cli._utils._context import CliContext
 from uipath._utils._logs import setup_logging
-from uipath.platform.common.constants import DOTENV_FILE
+from uipath.platform.constants import DOTENV_FILE
 
 # Windows console uses codepages (e.g. cp1252) that can't encode Unicode
 # characters used by Rich spinners (Braille) and emoji output.

--- a/packages/uipath/src/uipath/_cli/_auth/_auth_service.py
+++ b/packages/uipath/src/uipath/_cli/_auth/_auth_service.py
@@ -9,7 +9,7 @@ from uipath._cli._auth._utils import get_parsed_token_data
 from uipath._cli._utils._console import ConsoleLogger
 from uipath._utils._auth import update_env_file
 from uipath.platform.common import ExternalApplicationService, TokenData
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_ORGANIZATION_ID,
     ENV_TENANT_ID,

--- a/packages/uipath/src/uipath/_cli/_auth/_auth_session.py
+++ b/packages/uipath/src/uipath/_cli/_auth/_auth_session.py
@@ -3,7 +3,7 @@ import time
 import click
 
 from uipath.platform.common import TokenData
-from uipath.platform.common.constants import ENV_UIPATH_ACCESS_TOKEN
+from uipath.platform.constants import ENV_UIPATH_ACCESS_TOKEN
 from uipath.platform.identity import IdentityService
 from uipath.platform.portal import (
     PortalService as PlatformPortalService,

--- a/packages/uipath/src/uipath/_cli/_auth/_url_utils.py
+++ b/packages/uipath/src/uipath/_cli/_auth/_url_utils.py
@@ -2,7 +2,8 @@ import os
 from typing import Tuple
 from urllib.parse import urlparse
 
-from ...platform.common.constants import ENV_BASE_URL
+from uipath.platform.constants import ENV_BASE_URL
+
 from .._utils._console import ConsoleLogger
 
 console = ConsoleLogger()

--- a/packages/uipath/src/uipath/_cli/_chat/_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_chat/_bridge.py
@@ -21,7 +21,7 @@ from uipath.core.chat import (
     UiPathConversationToolCallEvent,
 )
 from uipath.core.triggers import UiPathResumeTrigger
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_ORGANIZATION_ID,
     ENV_TENANT_ID,

--- a/packages/uipath/src/uipath/_cli/_chat/_voice_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_chat/_voice_bridge.py
@@ -17,7 +17,7 @@ from uipath.core.chat import (
     UiPathVoiceToolCallRequest,
     UiPathVoiceToolCallResult,
 )
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_ORGANIZATION_ID,
     ENV_TENANT_ID,

--- a/packages/uipath/src/uipath/_cli/_debug/_bridge.py
+++ b/packages/uipath/src/uipath/_cli/_debug/_bridge.py
@@ -13,7 +13,7 @@ from rich.tree import Tree
 
 from uipath.core.serialization import serialize_object
 from uipath.core.triggers import UiPathResumeTriggerType
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_UIPATH_ACCESS_TOKEN,
     HEADER_FOLDER_KEY,

--- a/packages/uipath/src/uipath/_cli/_evals/_progress_reporter.py
+++ b/packages/uipath/src/uipath/_cli/_evals/_progress_reporter.py
@@ -33,7 +33,7 @@ from uipath.eval.runtime.events import (
 )
 from uipath.platform import UiPath
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_EVAL_BACKEND_URL,
     ENV_TENANT_ID,
     ENV_UIPATH_AGENT_ID,

--- a/packages/uipath/src/uipath/_cli/_evals/_telemetry.py
+++ b/packages/uipath/src/uipath/_cli/_evals/_telemetry.py
@@ -19,7 +19,7 @@ from uipath.eval.runtime.events import (
     EvaluationEvents,
 )
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import ENV_TENANT_ID
+from uipath.platform.constants import ENV_TENANT_ID
 from uipath.telemetry._track import is_telemetry_enabled, track_event
 
 logger = logging.getLogger(__name__)

--- a/packages/uipath/src/uipath/_cli/_push/sw_file_handler.py
+++ b/packages/uipath/src/uipath/_cli/_push/sw_file_handler.py
@@ -10,7 +10,7 @@ import click
 
 from uipath._cli.models.uipath_json_schema import PackOptions
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     EVALS_FOLDER,
     LEGACY_EVAL_FOLDER,
     PYTHON_CONFIGURATION_FILE,

--- a/packages/uipath/src/uipath/_cli/_telemetry.py
+++ b/packages/uipath/src/uipath/_cli/_telemetry.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Optional
 
 from uipath._cli._utils._common import get_claim_from_token
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import ENV_UIPATH_AGENT_ID
+from uipath.platform.constants import ENV_UIPATH_AGENT_ID
 from uipath.telemetry._track import (
     _get_project_key,
     is_telemetry_enabled,

--- a/packages/uipath/src/uipath/_cli/_utils/_common.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_common.py
@@ -13,7 +13,7 @@ from uipath.platform.common import (
     ResourceOverwriteParser,
     UiPathConfig,
 )
-from uipath.platform.common.constants import ENV_BASE_URL, ENV_UIPATH_ACCESS_TOKEN
+from uipath.platform.constants import ENV_BASE_URL, ENV_UIPATH_ACCESS_TOKEN
 
 from ..models.runtime_schema import EntryPoint
 from ..spinner import Spinner

--- a/packages/uipath/src/uipath/_cli/_utils/_project_files.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_project_files.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field, TypeAdapter
 
 from uipath._cli.models.uipath_json_schema import PackOptions, UiPathJsonConfig
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     LEGACY_EVAL_FOLDER,
     PYTHON_CONFIGURATION_FILE,
     UIPATH_CONFIG_FILE,

--- a/packages/uipath/src/uipath/_cli/_utils/_service_base.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_service_base.py
@@ -19,7 +19,8 @@ from typing import Any, Callable
 import click
 from httpx import HTTPError
 
-from ...platform.common.constants import ENV_BASE_URL, ENV_UIPATH_ACCESS_TOKEN
+from uipath.platform.constants import ENV_BASE_URL, ENV_UIPATH_ACCESS_TOKEN
+
 from ...platform.errors import (
     BaseUrlMissingError,
     EnrichedException,

--- a/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
@@ -14,7 +14,7 @@ from uipath.platform.common import (
     ResourceOverwriteParser,
     UiPathConfig,
 )
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_TENANT_ID,
     HEADER_SW_LOCK_KEY,
     HEADER_TENANT_ID,

--- a/packages/uipath/src/uipath/_cli/cli_eval.py
+++ b/packages/uipath/src/uipath/_cli/cli_eval.py
@@ -26,7 +26,7 @@ from uipath.platform.common import (
     ResourceOverwritesContext,
     UiPathConfig,
 )
-from uipath.platform.common.constants import ENV_FOLDER_KEY
+from uipath.platform.constants import ENV_FOLDER_KEY
 from uipath.runtime import (
     UiPathRuntimeContext,
     UiPathRuntimeFactoryRegistry,

--- a/packages/uipath/src/uipath/_cli/cli_init.py
+++ b/packages/uipath/src/uipath/_cli/cli_init.py
@@ -23,7 +23,7 @@ from mermaid_builder.flowchart import (  # type: ignore[import-untyped]
 )
 
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     DOTENV_FILE,
     ENTRY_POINTS_FILE,
     PYTHON_CONFIGURATION_FILE,

--- a/packages/uipath/src/uipath/_cli/cli_invoke.py
+++ b/packages/uipath/src/uipath/_cli/cli_invoke.py
@@ -6,8 +6,9 @@ import tomllib
 import click
 import httpx
 
+from uipath.platform.constants import PYTHON_CONFIGURATION_FILE
+
 from .._utils._ssl_context import get_httpx_client_kwargs
-from ..platform.common.constants import PYTHON_CONFIGURATION_FILE
 from ._telemetry import track_command
 from ._utils._common import get_env_vars
 from ._utils._console import ConsoleLogger

--- a/packages/uipath/src/uipath/_cli/cli_new.py
+++ b/packages/uipath/src/uipath/_cli/cli_new.py
@@ -4,7 +4,8 @@ import shutil
 
 import click
 
-from ..platform.common.constants import PYTHON_CONFIGURATION_FILE, UIPATH_CONFIG_FILE
+from uipath.platform.constants import PYTHON_CONFIGURATION_FILE, UIPATH_CONFIG_FILE
+
 from ._telemetry import track_command
 from ._utils._console import ConsoleLogger
 from .middlewares import Middlewares

--- a/packages/uipath/src/uipath/_cli/cli_pack.py
+++ b/packages/uipath/src/uipath/_cli/cli_pack.py
@@ -11,7 +11,7 @@ from uipath._cli.models.runtime_schema import Bindings, EntryPoint, EntryPoints
 from uipath._cli.models.uipath_json_schema import UiPathJsonConfig
 from uipath.eval.constants import EVALS_FOLDER, LEGACY_EVAL_FOLDER
 from uipath.platform.common import UiPathConfig
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENTRY_POINTS_FILE,
     PYTHON_CONFIGURATION_FILE,
     UIPATH_BINDINGS_FILE,

--- a/packages/uipath/src/uipath/_cli/models/runtime_schema.py
+++ b/packages/uipath/src/uipath/_cli/models/runtime_schema.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ...platform.common.constants import ENTRY_POINTS_FILE
+from uipath.platform.constants import ENTRY_POINTS_FILE
 
 
 class BaseModelWithDefaultConfig(BaseModel):

--- a/packages/uipath/src/uipath/_cli/models/uipath_json_schema.py
+++ b/packages/uipath/src/uipath/_cli/models/uipath_json_schema.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ...platform.common.constants import UIPATH_CONFIG_FILE
+from uipath.platform.constants import UIPATH_CONFIG_FILE
 
 
 class BaseModelWithDefaultConfig(BaseModel):

--- a/packages/uipath/src/uipath/_utils/_auth.py
+++ b/packages/uipath/src/uipath/_utils/_auth.py
@@ -4,7 +4,7 @@ from os import environ as env
 from pathlib import Path
 from typing import Optional
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     DOTENV_FILE,
     ENV_BASE_URL,
     ENV_UIPATH_ACCESS_TOKEN,

--- a/packages/uipath/src/uipath/_utils/_request_override.py
+++ b/packages/uipath/src/uipath/_utils/_request_override.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 from typing import Optional
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_FOLDER_KEY,
     HEADER_FOLDER_PATH,
     HEADER_FOLDER_PATH_ENCODED,

--- a/packages/uipath/src/uipath/_utils/_user_agent.py
+++ b/packages/uipath/src/uipath/_utils/_user_agent.py
@@ -1,6 +1,6 @@
 import importlib
 
-from uipath.platform.common.constants import HEADER_USER_AGENT
+from uipath.platform.constants import HEADER_USER_AGENT
 
 
 def user_agent_value(specific_component: str) -> str:

--- a/packages/uipath/src/uipath/_utils/constants.py
+++ b/packages/uipath/src/uipath/_utils/constants.py
@@ -1,16 +1,16 @@
-"""Deprecated alias for ``uipath.platform.common.constants``.
+"""Deprecated alias for the canonical constants module.
 
 This module is kept as a backward-compatibility shim so existing imports keep
-working. New code should import from ``uipath.platform.common.constants``.
+working. New code should import from ``uipath.platform.constants``.
 """
 
 import warnings as _warnings
 
-from uipath.platform.common.constants import *  # noqa: F401,F403
+from uipath.platform.constants import *  # noqa: F401,F403
 
 _warnings.warn(
-    "uipath._utils.constants is deprecated and will be removed in a future "
-    "release; import from uipath.platform.common.constants instead.",
+    "uipath._utils.constants is deprecated and will be removed in a future release; "
+    "import from uipath.platform.constants instead.",
     FutureWarning,
     stacklevel=2,
 )

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_evaluator_utils.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_evaluator_utils.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, Optional
 
-from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
+from uipath.platform.constants import COMMUNITY_agents_SUFFIX
 
 
 def clean_model_name(model: str) -> str:

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_llm_as_judge_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_llm_as_judge_evaluator.py
@@ -8,7 +8,7 @@ from pydantic import Field, field_validator
 from uipath.platform import UiPath
 from uipath.platform.chat import UiPathLlmChatService
 from uipath.platform.chat.llm_gateway import RequiredToolChoice
-from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
+from uipath.platform.constants import COMMUNITY_agents_SUFFIX
 
 from .._execution_context import eval_set_run_id_context
 from .._helpers.helpers import is_empty_value

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_trajectory_evaluator.py
@@ -9,7 +9,7 @@ from pydantic import Field, field_validator
 from uipath.platform import UiPath
 from uipath.platform.chat import UiPathLlmChatService
 from uipath.platform.chat.llm_gateway import RequiredToolChoice
-from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
+from uipath.platform.constants import COMMUNITY_agents_SUFFIX
 
 from .._execution_context import eval_set_run_id_context
 from .._helpers.evaluators_helpers import trace_to_str

--- a/packages/uipath/src/uipath/eval/evaluators/llm_as_judge_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/llm_as_judge_evaluator.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from uipath.platform import UiPath
 from uipath.platform.chat import UiPathLlmChatService
-from uipath.platform.common.constants import COMMUNITY_agents_SUFFIX
+from uipath.platform.constants import COMMUNITY_agents_SUFFIX
 
 from .._execution_context import eval_set_run_id_context
 from ..models import (

--- a/packages/uipath/src/uipath/eval/mocks/_simulate_component_service.py
+++ b/packages/uipath/src/uipath/eval/mocks/_simulate_component_service.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from uipath._utils import Endpoint
 from uipath.platform.common import BaseService
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_INTERNAL_ACCOUNT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )

--- a/packages/uipath/src/uipath/functions/__init__.py
+++ b/packages/uipath/src/uipath/functions/__init__.py
@@ -1,6 +1,6 @@
 """UiPath Functions Runtime - factory and runtime for function-based execution."""
 
-from uipath.platform.common.constants import UIPATH_CONFIG_FILE
+from uipath.platform.constants import UIPATH_CONFIG_FILE
 from uipath.runtime import UiPathRuntimeFactoryRegistry
 
 from .debug import UiPathDebugFunctionsRuntime

--- a/packages/uipath/src/uipath/functions/factory.py
+++ b/packages/uipath/src/uipath/functions/factory.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from uipath.platform.common.constants import UIPATH_CONFIG_FILE
+from uipath.platform.constants import UIPATH_CONFIG_FILE
 from uipath.runtime import (
     UiPathRuntimeFactorySettings,
     UiPathRuntimeProtocol,

--- a/packages/uipath/src/uipath/telemetry/_track.py
+++ b/packages/uipath/src/uipath/telemetry/_track.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, ClassVar, Dict, Mapping, Optional, Union
 from opentelemetry.sdk._logs import LoggingHandler
 from opentelemetry.util.types import AnyValue
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_ORGANIZATION_ID,
     ENV_TELEMETRY_ENABLED,

--- a/packages/uipath/src/uipath/tracing/_otel_exporters.py
+++ b/packages/uipath/src/uipath/tracing/_otel_exporters.py
@@ -14,7 +14,8 @@ from opentelemetry.sdk.trace.export import (
 from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.platform.common import _SpanUtils
 from uipath.platform.common._span_utils import SpanStatus
-from uipath.platform.common.constants import (
+from uipath.platform.common.retry import NON_RETRYABLE_STATUS_CODES
+from uipath.platform.constants import (
     ENV_BASE_URL,
     ENV_ORGANIZATION_ID,
     ENV_TENANT_ID,
@@ -22,7 +23,6 @@ from uipath.platform.common.constants import (
     HEADER_INTERNAL_ACCOUNT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )
-from uipath.platform.common.retry import NON_RETRYABLE_STATUS_CODES
 
 logger = logging.getLogger(__name__)
 

--- a/packages/uipath/tests/cli/chat/test_bridge.py
+++ b/packages/uipath/tests/cli/chat/test_bridge.py
@@ -11,7 +11,7 @@ import pytest
 from uipath._cli._chat._bridge import SocketIOChatBridge, get_chat_bridge
 from uipath._cli._debug._bridge import SignalRDebugBridge
 from uipath.core.triggers import UiPathApiTrigger, UiPathResumeTrigger
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_INTERNAL_ACCOUNT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )

--- a/packages/uipath/tests/cli/chat/test_voice_bridge.py
+++ b/packages/uipath/tests/cli/chat/test_voice_bridge.py
@@ -14,7 +14,7 @@ from uipath.core.chat import (
     UiPathVoiceToolCallRequest,
     UiPathVoiceToolCallResult,
 )
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_INTERNAL_ACCOUNT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )

--- a/packages/uipath/tests/cli/eval/test_eval_telemetry.py
+++ b/packages/uipath/tests/cli/eval/test_eval_telemetry.py
@@ -25,7 +25,7 @@ from uipath.eval.runtime.events import (
     EvalSetRunCreatedEvent,
     EvalSetRunUpdatedEvent,
 )
-from uipath.platform.common.constants import ENV_UIPATH_AGENT_ID
+from uipath.platform.constants import ENV_UIPATH_AGENT_ID
 
 
 class TestEventNameConstants:

--- a/packages/uipath/tests/sdk/test_utils_constants_shim.py
+++ b/packages/uipath/tests/sdk/test_utils_constants_shim.py
@@ -1,9 +1,9 @@
 """Regression tests for the uipath._utils.constants deprecation shim.
 
-The shim re-exports from uipath.platform.common.constants and emits a
-FutureWarning so external consumers can migrate. Internal callsites are
-already on the canonical path; these tests pin the shim's behavior so it
-keeps working for downstream code.
+The shim re-exports from uipath.platform.constants (the source of truth) and emits
+a FutureWarning so external consumers can migrate. Internal callsites are
+already on the canonical path; these tests pin the shim's behavior so it keeps
+working for downstream code.
 """
 
 import importlib
@@ -13,11 +13,7 @@ import warnings
 
 def _reload_shim():
     """Force a fresh import of the shim so FutureWarning re-fires."""
-    for name in [
-        "uipath._utils.constants",
-        "uipath.platform.common.constants",
-    ]:
-        sys.modules.pop(name, None)
+    sys.modules.pop("uipath._utils.constants", None)
     return importlib.import_module("uipath._utils.constants")
 
 
@@ -31,7 +27,7 @@ def test_shim_emits_future_warning():
         for w in caught
         if issubclass(w.category, FutureWarning)
         and "uipath._utils.constants" in str(w.message)
-        and "uipath.platform.common.constants" in str(w.message)
+        and "uipath.platform.constants" in str(w.message)
     ]
     assert len(shim_warnings) == 1, (
         f"expected exactly one shim FutureWarning, got {len(shim_warnings)}: "
@@ -41,7 +37,7 @@ def test_shim_emits_future_warning():
 
 def test_shim_re_exports_canonical_symbols():
     shim = _reload_shim()
-    canonical = importlib.import_module("uipath.platform.common.constants")
+    canonical = importlib.import_module("uipath.platform.constants")
 
     # Sample a representative set: env vars, headers, mixed-case symbols,
     # file constants, data-source magic strings.

--- a/packages/uipath/tests/telemetry/test_track.py
+++ b/packages/uipath/tests/telemetry/test_track.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     ENV_PROJECT_KEY,
     ENV_UIPATH_AGENT_ID,
     ENV_UIPATH_PROJECT_ID,

--- a/packages/uipath/tests/tracing/test_otel_exporters.py
+++ b/packages/uipath/tests/tracing/test_otel_exporters.py
@@ -8,7 +8,7 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
 
 from uipath.platform.common._span_utils import SpanStatus
-from uipath.platform.common.constants import (
+from uipath.platform.constants import (
     HEADER_INTERNAL_ACCOUNT_ID,
     HEADER_INTERNAL_TENANT_ID,
 )

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.12.3"
+version = "2.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2691,7 +2691,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.88"
+version = "0.1.89"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Gives shared constants a **cheap-to-import** home and makes the platform package import lazily, so CLI / agent-runtime hot paths don't pay for the full service layer just to read a constant.

- **New `uipath.platform.constants`** — a `constants/` package sibling to `common/`, the single source of truth for the shared string constants.
- **Lazy `uipath/platform/__init__.py` (PEP 562)** — `UiPath` and the config types resolve on attribute access, so importing `uipath.platform.constants` no longer drags in the service layer. Cold `import uipath.platform.constants` drops **~273ms → ~6ms** and pulls in **neither httpx nor pydantic**.
- **Both re-export paths deprecated** — `uipath.platform.common.constants` and `uipath._utils.constants` forward to `uipath.platform.constants` and emit a `FutureWarning`.
- **All internal importers migrated** (source + tests, both packages) to `uipath.platform.constants`, so the SDK/CLI never trips its own deprecation warning — `import uipath._cli` is warning-free.
- **Tests** — parity + deprecation tests, structural invariants for the constants module, and coverage of `ConfigurationManager` env-var/path properties.

## Compatibility

- External consumers importing `uipath.platform.common.constants` keep working (with a deprecation warning).
- `uipath.eval.constants` is a separate, unrelated module — untouched.
- **`uipath-core` is unchanged** by this PR.

## Version bumps

- `uipath-platform` 0.1.88 → 0.1.89
- `uipath` 2.12.3 → 2.12.4 (platform pin → `>=0.1.89`)
- `uipath-core` unchanged (0.5.28)

## Testing

- ruff clean on `src` + `tests` for all three packages.
- All three full test suites pass (0 failures).
- Verified: `import uipath.platform.constants` = ~6ms with no httpx/pydantic; `from uipath.platform import UiPath` still works (lazy); `import uipath._cli` emits no deprecation warning; both deprecated paths warn when imported directly; shim ↔ canonical parity holds.

> Note: the branch name (`feat/core-constants-source-of-truth`) is a leftover from an earlier iteration that placed the module in `uipath-core`; the constants now live in `uipath.platform.constants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)