### PR TITLE
fix: prevent .whl files from being corrupted during pack

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.12.2"
+version = "2.12.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_utils/_constants.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_constants.py
@@ -20,7 +20,7 @@ IMAGE_EXTENSIONS = {
 
 DOCUMENT_EXTENSIONS = {".pdf", ".docx", ".pptx", ".xlsx", ".xls"}
 
-ARCHIVE_EXTENSIONS = {".zip", ".tar", ".gz", ".rar", ".7z", ".bz2", ".xz"}
+ARCHIVE_EXTENSIONS = {".zip", ".tar", ".gz", ".rar", ".7z", ".bz2", ".xz", ".whl"}
 
 MEDIA_EXTENSIONS = {
     ".mp3",

--- a/packages/uipath/tests/cli/test_pack.py
+++ b/packages/uipath/tests/cli/test_pack.py
@@ -1,4 +1,5 @@
 # type: ignore
+import io
 import json
 import os
 import zipfile
@@ -326,6 +327,57 @@ class TestPack:
                 extracted_binary_content = z.read(f"content/{binary_file_name}")
                 assert extracted_binary_content == binary_content, (
                     "Binary file content was corrupted during packing"
+                )
+
+    def test_include_wheel_file_not_corrupted(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+    ) -> None:
+        """Test that .whl files included via packOptions are packed byte-for-byte.
+
+        A .whl file is itself a zip archive full of arbitrary binary bytes. If it
+        is not recognized as binary by the packager, it gets round-tripped through
+        a text decode/encode (latin-1 -> UTF-8), which corrupts any byte >= 0x80
+        and produces an invalid zip file at runtime.
+        """
+        wheel_file_name = "example_pkg-1.0.0-py3-none-any.whl"
+
+        # Minimal valid zip (wheel) content, deliberately containing high bytes
+        # (0x80-0xff) that would be mangled by a latin-1 -> UTF-8 round trip.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as wheel_zip:
+            wheel_zip.writestr("example_pkg/__init__.py", bytes(range(256)) * 4)
+        wheel_bytes = buf.getvalue()
+
+        pack_options = {"fileExtensionsIncluded": [".whl"]}
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("uipath.json", "w") as f:
+                json.dump(create_uipath_json(pack_options=pack_options), f)
+            with open("pyproject.toml", "w") as f:
+                f.write(project_details.to_toml())
+            with open("main.py", "w") as f:
+                f.write("def main(input): return input")
+            with open(wheel_file_name, "wb") as f:
+                f.write(wheel_bytes)
+
+            with patch("uipath._cli.cli_init.Middlewares.next") as mock_middleware:
+                mock_middleware.return_value = MiddlewareResult(should_continue=True)
+                init_result = runner.invoke(cli, ["init"], env={})
+                assert init_result.exit_code == 0
+
+            result = runner.invoke(cli, ["pack", "./"], env={})
+
+            assert result.exit_code == 0
+            with zipfile.ZipFile(
+                f".uipath/{project_details.name}.{project_details.version}.nupkg", "r"
+            ) as z:
+                assert f"content/{wheel_file_name}" in z.namelist()
+                extracted_wheel_bytes = z.read(f"content/{wheel_file_name}")
+                assert extracted_wheel_bytes == wheel_bytes, (
+                    ".whl file content was corrupted during packing"
                 )
 
     def test_include_files(

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.12.2"
+version = "2.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- add `.whl` to the packager's binary-file extensions so wheel files added via `packOptions.fileExtensionsIncluded` are copied byte-for-byte into the `.nupkg`
- add a regression test that packs a `.whl` with high-byte content and asserts it round-trips unmodified

## Why

Files not in `BINARY_EXTENSIONS` are read as text (with a latin-1 fallback that "succeeds" on any byte sequence) and rewritten via `zipfile.writestr(str)`, which re-encodes as UTF-8. For a `.whl` file (itself a zip full of arbitrary binary bytes), this silently corrupts the archive, so a wheel bundled into a package this way becomes an unreadable zip at runtime ("Invalid zip file structure"). This surfaced while validating an offline dependency bundling workflow for #1603.

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.12.3.dev1017827077",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.12.3.dev1017820000,<2.12.3.dev1017830000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
```