### PR TITLE
feat: add set_conversational_output tool + generate-output prompt for conversational agents

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.4"
+version = "2.13.5"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.5"
+version = "2.13.6"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/react/__init__.py
+++ b/packages/uipath/src/uipath/agent/react/__init__.py
@@ -6,15 +6,18 @@ This module includes UiPath ReAct Agent Loop constructs such as prompts, tools
 from .conversational_prompts import (
     PromptUserSettings,
     get_chat_system_prompt,
+    get_generate_output_prompt,
 )
 from .conversational_voice_prompts import get_voice_system_prompt
 from .prompts import AGENT_SYSTEM_PROMPT_TEMPLATE
 from .tools import (
     END_EXECUTION_TOOL,
     RAISE_ERROR_TOOL,
+    SET_CONVERSATIONAL_OUTPUT_TOOL,
     EndExecutionToolSchemaModel,
     FlowControlToolConfig,
     RaiseErrorToolSchemaModel,
+    SetConversationalOutputToolSchemaModel,
 )
 
 __all__ = [
@@ -22,9 +25,12 @@ __all__ = [
     "FlowControlToolConfig",
     "END_EXECUTION_TOOL",
     "RAISE_ERROR_TOOL",
+    "SET_CONVERSATIONAL_OUTPUT_TOOL",
     "EndExecutionToolSchemaModel",
     "RaiseErrorToolSchemaModel",
+    "SetConversationalOutputToolSchemaModel",
     "PromptUserSettings",
     "get_chat_system_prompt",
+    "get_generate_output_prompt",
     "get_voice_system_prompt",
 ]

--- a/packages/uipath/src/uipath/agent/react/conversational_prompts.py
+++ b/packages/uipath/src/uipath/agent/react/conversational_prompts.py
@@ -245,6 +245,9 @@ Rules:
 
 
 def get_generate_output_prompt() -> str:
-    """Framework-internal instruction appended as a final user-message to the
-    conversational structured-output node's LLM call."""
+    """Return the framework-internal generate-output instruction.
+
+    Appended as a final user-message to the conversational structured-output
+    node's LLM call.
+    """
     return _GENERATE_OUTPUT_INSTRUCTION

--- a/packages/uipath/src/uipath/agent/react/conversational_prompts.py
+++ b/packages/uipath/src/uipath/agent/react/conversational_prompts.py
@@ -233,3 +233,18 @@ def get_conversation_id_template(conversation_id: str | None) -> str:
     if not conversation_id:
         return ""
     return _CONVERSATION_ID_TEMPLATE.format(conversation_id=conversation_id)
+
+
+_GENERATE_OUTPUT_INSTRUCTION = """The conversational response for this turn has already been delivered to the user. Call the `set_conversational_output` tool to record the structured output fields for this turn.
+
+Rules:
+- For each field, use values inferred from the conversation's recent turn.
+- For optional fields that are not yet relevant or determinable from the conversation so far, omit them entirely.
+- For required fields that cannot yet be determined (e.g., the conversation is still gathering context, or the topic hasn't surfaced yet), use a clear placeholder value (e.g. "N/A" or "unknown" for string fields). DO NOT fabricate, guess, or hallucinate values.
+- Do not produce any text content — only call the tool."""
+
+
+def get_generate_output_prompt() -> str:
+    """Framework-internal instruction appended as a final user-message to the
+    conversational structured-output node's LLM call."""
+    return _GENERATE_OUTPUT_INSTRUCTION

--- a/packages/uipath/src/uipath/agent/react/conversational_prompts.py
+++ b/packages/uipath/src/uipath/agent/react/conversational_prompts.py
@@ -239,9 +239,9 @@ _GENERATE_OUTPUT_INSTRUCTION = """The conversational response for this turn has 
 
 Rules:
 - For each field, use values inferred from the conversation's recent turn.
-- For optional fields that are not yet relevant or determinable from the conversation so far, omit them entirely.
-- For required fields that cannot yet be determined (e.g., the conversation is still gathering context, or the topic hasn't surfaced yet), use a clear placeholder value (e.g. "N/A" or "unknown" for string fields). DO NOT fabricate, guess, or hallucinate values.
-- Do not produce any text content — only call the tool."""
+- For optional fields that are not yet relevant or determinable (e.g. the conversation is still gathering context, or the topic hasn't surfaced yet), omit them entirely.
+- For required fields that cannot yet be determined, provide a default placeholder. DO NOT fabricate, guess, or hallucinate meaningful values.
+- Do not produce any text response, as this will not be seen by the user. Only call the tool."""
 
 
 def get_generate_output_prompt() -> str:

--- a/packages/uipath/src/uipath/agent/react/tools.py
+++ b/packages/uipath/src/uipath/agent/react/tools.py
@@ -11,6 +11,7 @@ class FlowControlToolName(str, Enum):
 
     END_EXECUTION = "end_execution"
     RAISE_ERROR = "raise_error"
+    SET_CONVERSATIONAL_OUTPUT = "set_conversational_output"
 
 
 @dataclass(frozen=True)
@@ -71,4 +72,26 @@ RAISE_ERROR_TOOL = FlowControlToolConfig(
     name=FlowControlToolName.RAISE_ERROR,
     description="Raises an error and ends the execution of the agent",
     args_schema=RaiseErrorToolSchemaModel,
+)
+
+
+class SetConversationalOutputToolSchemaModel(BaseModel):
+    """Placeholder args_schema for the `set_conversational_output` tool.
+
+    Always overridden at construction time with the agent's stripped output
+    schema (i.e. the user's `outputSchema` with `uipath__agent_response_messages`
+    removed). Declared here so the tool entry has a well-typed default.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+SET_CONVERSATIONAL_OUTPUT_TOOL = FlowControlToolConfig(
+    name=FlowControlToolName.SET_CONVERSATIONAL_OUTPUT,
+    description=(
+        "Sets the structured output fields for the current conversational "
+        "turn. Called once per turn after the conversational response has been "
+        "delivered, to populate fields as the agent's output."
+    ),
+    args_schema=SetConversationalOutputToolSchemaModel,
 )

--- a/packages/uipath/tests/agent/react/test_conversational_prompts.py
+++ b/packages/uipath/tests/agent/react/test_conversational_prompts.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from uipath.agent.react.conversational_prompts import (
     PromptUserSettings,
     get_chat_system_prompt,
+    get_generate_output_prompt,
     get_user_settings_template,
 )
 
@@ -348,3 +349,33 @@ class TestGetUserSettingsTemplate:
         assert json_data["company"] == "Big Corp"
         assert json_data["country"] == "UK"
         assert json_data["timezone"] == "Europe/London"
+
+
+class TestGetGenerateOutputInstruction:
+    """Tests for get_generate_output_prompt function."""
+
+    def test_returns_non_empty_string(self):
+        instruction = get_generate_output_prompt()
+        assert isinstance(instruction, str)
+        assert instruction.strip()
+
+    def test_references_set_conversational_output_tool(self):
+        """The instruction must name the tool the new node binds."""
+        assert "set_conversational_output" in get_generate_output_prompt()
+
+    def test_mentions_placeholder_rule_for_required_fields(self):
+        """The instruction must steer the model toward 'N/A'-style placeholders
+        rather than fabricated values for required fields with no context yet."""
+        instruction = get_generate_output_prompt()
+        assert "N/A" in instruction or "unknown" in instruction.lower()
+
+    def test_mentions_omit_rule_for_optional_fields(self):
+        """The instruction must steer the model toward omitting optional fields
+        when they're not yet relevant."""
+        instruction = get_generate_output_prompt().lower()
+        assert "omit" in instruction or "optional" in instruction
+
+    def test_no_text_content_directive(self):
+        """The instruction must explicitly forbid producing conversational text."""
+        instruction = get_generate_output_prompt().lower()
+        assert "do not produce" in instruction or "only call the tool" in instruction

--- a/packages/uipath/tests/agent/react/test_conversational_prompts.py
+++ b/packages/uipath/tests/agent/react/test_conversational_prompts.py
@@ -351,7 +351,7 @@ class TestGetUserSettingsTemplate:
         assert json_data["timezone"] == "Europe/London"
 
 
-class TestGetGenerateOutputInstruction:
+class TestGetGenerateOutputPrompt:
     """Tests for get_generate_output_prompt function."""
 
     def test_returns_non_empty_string(self):

--- a/packages/uipath/tests/agent/react/test_conversational_prompts.py
+++ b/packages/uipath/tests/agent/react/test_conversational_prompts.py
@@ -362,20 +362,3 @@ class TestGetGenerateOutputInstruction:
     def test_references_set_conversational_output_tool(self):
         """The instruction must name the tool the new node binds."""
         assert "set_conversational_output" in get_generate_output_prompt()
-
-    def test_mentions_placeholder_rule_for_required_fields(self):
-        """The instruction must steer the model toward 'N/A'-style placeholders
-        rather than fabricated values for required fields with no context yet."""
-        instruction = get_generate_output_prompt()
-        assert "N/A" in instruction or "unknown" in instruction.lower()
-
-    def test_mentions_omit_rule_for_optional_fields(self):
-        """The instruction must steer the model toward omitting optional fields
-        when they're not yet relevant."""
-        instruction = get_generate_output_prompt().lower()
-        assert "omit" in instruction or "optional" in instruction
-
-    def test_no_text_content_directive(self):
-        """The instruction must explicitly forbid producing conversational text."""
-        instruction = get_generate_output_prompt().lower()
-        assert "do not produce" in instruction or "only call the tool" in instruction

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.5"
+version = "2.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.4"
+version = "2.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

Two additive changes in `uipath/agent/react/`:

1. **New flow-control tool definition** `set_conversational_output` — a framework-internal tool bound by the langchain runtime's `GENERATE_CONVERSATIONAL_OUTPUT` node to reliably extract structured output fields from a conversational agent's turn. Mirrors the existing `end_execution`/`raise_error` shape.
2. **New generate-output instruction prompt** — the framework-internal HumanMessage appended to the extraction LLM call, telling the model to fill the tool's args from the conversation with per-turn priority and `"N/A"`-placeholder rules for un-yet-determinable required fields.

## Context

Part of a four-PR series enabling reliable structured-output extraction for conversational agents. This PR only adds primitives to \`uipath\`; the graph wiring lives in uipath-langchain, the runtime gating in uipath-agents, and the FPS field in uipath-runtime.

## Related PRs

Part of a coordinated four-repo change. Each PR is independently reviewable, but they land together:

- **uipath-runtime-python** https://github.com/UiPath/uipath-runtime-python/pull/142 — surfaces the `conversationalService.enableOutputs` FPS flag on `UiPathRuntimeContext`.
- **uipath-python** https://github.com/UiPath/uipath-python/pull/1785 — adds the `set_conversational_output` flow-control tool + generate-output prompt primitives.
- **uipath-langchain-python** https://github.com/UiPath/uipath-langchain-python/pull/965 — implements the `GENERATE_CONVERSATIONAL_OUTPUT` graph node, router path, and terminate extraction (the main change).
- **uipath-agents-python** https://github.com/UiPath/uipath-agents-python/pull/588 — Gates custom outputs on the FPS flag + agent-version.

## Test plan

- [x] \`uv run pytest packages/uipath/tests/agent/react/test_conversational_prompts.py\` (26 tests pass)
- [x] \`ruff check\` + \`ruff format --check\` clean
