### PR TITLE
chore: loosen runtime bound for uipath 2.12.9

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.12.8"
+version = "2.12.9"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.26, <0.6.0",
-  "uipath-runtime>=0.12.1, <0.13.0",
+  "uipath-runtime>=0.11.7, <0.13.0",
   "uipath-platform>=0.1.91, <0.2.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.12.8"
+version = "2.12.9"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2674,7 +2674,7 @@ requires-dist = [
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
     { name = "uipath-platform", editable = "../uipath-platform" },
-    { name = "uipath-runtime", specifier = ">=0.12.1,<0.13.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.7,<0.13.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- bump `uipath` to `2.12.9`
- relax `uipath-runtime` from `>=0.12.1,<0.13.0` to `>=0.11.7,<0.13.0`
- regenerate `packages/uipath/uv.lock`

## Why
The voice `end_detail` support added in `2.12.8` does not require runtime `0.12.x` on the happy path. This allows downstream packages that still depend on `uipath-langchain==0.13.23` to resolve with `uipath-runtime 0.11.x` while still consuming the new `uipath` voice behavior.

## Tests
- `uv run pytest tests/cli/chat/test_voice_bridge.py -q`
- `uv run ruff check src/uipath/_cli/_chat/_voice_bridge.py tests/cli/chat/test_voice_bridge.py`
- `uv run --with 'uipath-runtime==0.11.8' --refresh-package uipath-runtime pytest tests/cli/chat/test_voice_bridge.py -q`