### PR TITLE
fix(cli): guard find_spec in module preload against missing parents

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.0"
+version = "2.13.1"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -83,9 +83,10 @@ def preload_modules() -> None:
     for module_name in modules_to_load:
         if module_name in sys.modules:
             continue
-        if find_spec(module_name) is None:
-            continue
         try:
+            # find_spec raises ModuleNotFoundError when a parent package is missing
+            if find_spec(module_name) is None:
+                continue
             importlib.import_module(module_name)
             console.success(f"Pre-loaded module: {module_name}")
         except ImportError as e:

--- a/packages/uipath/tests/cli/test_server.py
+++ b/packages/uipath/tests/cli/test_server.py
@@ -369,3 +369,59 @@ class TestServerEnvIsolation:
         assert "SHOULD_NOT_PERSIST" not in os.environ
         for key in baseline:
             assert os.environ.get(key) == baseline[key]
+
+
+class TestPreloadModules:
+    """Tests for preload_modules and its find_spec guard."""
+
+    def _run_with_modules(self, monkeypatch, modules):
+        from uipath._cli import cli_server
+
+        class _FakeEntryPoint:
+            name = "fake"
+
+            def load(self):
+                return lambda: modules
+
+        monkeypatch.setattr(
+            cli_server, "entry_points", lambda group: [_FakeEntryPoint()]
+        )
+        monkeypatch.setattr(cli_server, "DEFAULT_PRELOAD_MODULES", [])
+        cli_server.preload_modules()
+
+    def test_missing_parent_package_does_not_crash(self, monkeypatch):
+        # find_spec raises ModuleNotFoundError when a parent package is absent;
+        # a stale entry like this must be skipped, not take down the server.
+        self._run_with_modules(monkeypatch, ["definitely_missing_pkg._private.types"])
+
+    def test_missing_leaf_module_is_skipped(self, monkeypatch):
+        # parent imports fine, leaf is absent -> find_spec returns None
+        self._run_with_modules(monkeypatch, ["json.does_not_exist"])
+
+    def test_existing_module_is_imported(self, monkeypatch):
+        import sys
+
+        sys.modules.pop("difflib", None)
+        self._run_with_modules(monkeypatch, ["difflib"])
+        assert "difflib" in sys.modules
+
+    def test_already_loaded_module_is_skipped(self, monkeypatch):
+        import sys
+
+        assert "json" in sys.modules
+        self._run_with_modules(monkeypatch, ["json"])
+
+    def test_failing_entry_point_does_not_crash(self, monkeypatch):
+        from uipath._cli import cli_server
+
+        class _BrokenEntryPoint:
+            name = "broken"
+
+            def load(self):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            cli_server, "entry_points", lambda group: [_BrokenEntryPoint()]
+        )
+        monkeypatch.setattr(cli_server, "DEFAULT_PRELOAD_MODULES", [])
+        cli_server.preload_modules()

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- preloading a module whose parent package is absent no longer crashes the python server on startup, it is skipped like any other unresolvable entry

## Why

module preloading is a best-effort startup optimization, but `find_spec("a.b.c")` imports the parent packages to resolve a dotted name and raises `ModuleNotFoundError` when a parent is missing 