### PR TITLE
feat: add timeout resume helpers

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.28"
+version = "0.5.29"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/triggers/__init__.py
+++ b/packages/uipath-core/src/uipath/core/triggers/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "UiPathResumeTriggerType",
     "UiPathApiTrigger",
     "UiPathIntegrationTrigger",
+    "UiPathResumeMetadata",
     "UiPathResumeTriggerName",
     "UIPATH_METADATA_KEY",
 ]
@@ -13,6 +14,7 @@ from uipath.core.triggers.trigger import (
     UIPATH_METADATA_KEY,
     UiPathApiTrigger,
     UiPathIntegrationTrigger,
+    UiPathResumeMetadata,
     UiPathResumeTrigger,
     UiPathResumeTriggerName,
     UiPathResumeTriggerType,

--- a/packages/uipath-core/src/uipath/core/triggers/trigger.py
+++ b/packages/uipath-core/src/uipath/core/triggers/trigger.py
@@ -48,6 +48,20 @@ class UiPathResumeTriggerName(str, Enum):
     DEEP_RAG_RAW = "DeepRagRaw"
 
 
+class UiPathResumeMetadata(BaseModel):
+    """UiPath metadata attached to resume values from multi-trigger interrupts."""
+
+    kind: str | None = None
+    trigger_type: UiPathResumeTriggerType | None = Field(
+        default=None, alias="triggerType"
+    )
+    trigger_name: UiPathResumeTriggerName | None = Field(
+        default=None, alias="triggerName"
+    )
+
+    model_config = ConfigDict(validate_by_name=True)
+
+
 class UiPathApiTrigger(BaseModel):
     """API resume trigger request."""
 

--- a/packages/uipath-core/tests/triggers/test_resume_metadata.py
+++ b/packages/uipath-core/tests/triggers/test_resume_metadata.py
@@ -1,0 +1,29 @@
+from uipath.core.triggers import (
+    UiPathResumeMetadata,
+    UiPathResumeTriggerName,
+    UiPathResumeTriggerType,
+)
+
+
+def test_resume_metadata_accepts_trigger_aliases() -> None:
+    metadata = UiPathResumeMetadata.model_validate(
+        {
+            "kind": "timeout",
+            "triggerType": "Timer",
+            "triggerName": "Timer",
+        }
+    )
+
+    assert metadata.kind == "timeout"
+    assert metadata.trigger_type == UiPathResumeTriggerType.TIMER
+    assert metadata.trigger_name == UiPathResumeTriggerName.TIMER
+
+
+def test_resume_metadata_accepts_field_names() -> None:
+    metadata = UiPathResumeMetadata(
+        trigger_type=UiPathResumeTriggerType.API,
+        trigger_name=UiPathResumeTriggerName.API,
+    )
+
+    assert metadata.trigger_type == UiPathResumeTriggerType.API
+    assert metadata.trigger_name == UiPathResumeTriggerName.API

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.28"
+version = "0.5.29"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.1"
+version = "0.2.2"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ dependencies = [
   "httpx>=0.28.1",
   "tenacity>=9.0.0",
   "truststore>=0.10.1",
-  "uipath-core>=0.5.28, <0.6.0",
+  "uipath-core>=0.5.29, <0.6.0",
   "pydantic-function-models>=0.1.11",
   "sqlparse>=0.5.5",
 ]

--- a/packages/uipath-platform/src/uipath/platform/common/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/common/__init__.py
@@ -3,6 +3,8 @@
 This module contains common models used across multiple services.
 """
 
+from uipath.core.triggers import UiPathResumeMetadata
+
 from ._api_client import ApiClient
 from ._base_service import BaseService, resolve_trace_id
 from ._bindings import (
@@ -62,6 +64,12 @@ from .interrupt_models import (
     WaitUntil,
 )
 from .paging import PagedResult
+from .timeout import (
+    UiPathTimeoutError,
+    assert_no_timeout,
+    get_resume_metadata,
+    is_timeout,
+)
 
 __all__ = [
     "ApiClient",
@@ -125,6 +133,11 @@ __all__ = [
     "resolve_service_url",
     "inject_routing_headers",
     "resolve_trace_id",
+    "UiPathTimeoutError",
+    "UiPathResumeMetadata",
+    "assert_no_timeout",
+    "get_resume_metadata",
+    "is_timeout",
 ]
 
 from .validation import validate_pagination_params

--- a/packages/uipath-platform/src/uipath/platform/common/timeout.py
+++ b/packages/uipath-platform/src/uipath/platform/common/timeout.py
@@ -1,0 +1,56 @@
+"""Helpers for resume values produced by timeout triggers."""
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from pydantic import ValidationError
+from uipath.core.triggers import (
+    UIPATH_METADATA_KEY,
+    UiPathResumeMetadata,
+)
+
+T = TypeVar("T")
+
+_TIMEOUT_KIND = "timeout"
+
+
+class UiPathTimeoutError(TimeoutError):
+    """Raised when a resume value came from a UiPath timeout trigger."""
+
+    def __init__(self, value: Any):
+        """Create a timeout error that keeps the original resume value."""
+        super().__init__("UiPath interrupt timed out.")
+        self.value = value
+
+
+def is_timeout(value: Any) -> bool:
+    """Return True when a resume value came from a UiPath timeout trigger."""
+    metadata = get_resume_metadata(value)
+    return metadata is not None and metadata.kind == _TIMEOUT_KIND
+
+
+def assert_no_timeout(value: T) -> T:
+    """Raise UiPathTimeoutError if a resume value came from a timeout trigger."""
+    if is_timeout(value):
+        raise UiPathTimeoutError(value)
+    return value
+
+
+def get_resume_metadata(value: Any) -> UiPathResumeMetadata | None:
+    """Return UiPath resume metadata when present on a resume value."""
+    metadata = _metadata(value)
+    if metadata is None:
+        return None
+
+    try:
+        return UiPathResumeMetadata.model_validate(metadata)
+    except ValidationError:
+        return None
+
+
+def _metadata(value: Any) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+
+    metadata = value.get(UIPATH_METADATA_KEY)
+    return metadata if isinstance(metadata, Mapping) else None

--- a/packages/uipath-platform/tests/common/test_timeout_helpers.py
+++ b/packages/uipath-platform/tests/common/test_timeout_helpers.py
@@ -1,0 +1,96 @@
+import pytest
+from uipath.core.triggers import (
+    UIPATH_METADATA_KEY,
+    UiPathResumeTriggerName,
+    UiPathResumeTriggerType,
+)
+
+from uipath.platform.common import (
+    UiPathResumeMetadata,
+    UiPathTimeoutError,
+    assert_no_timeout,
+    get_resume_metadata,
+    is_timeout,
+)
+
+
+def test_is_timeout_detects_timeout_metadata() -> None:
+    value = {
+        UIPATH_METADATA_KEY: {
+            "kind": "timeout",
+            "triggerType": "Timer",
+            "triggerName": "Timer",
+        },
+        "value": None,
+    }
+
+    assert is_timeout(value) is True
+
+
+def test_get_resume_metadata_returns_typed_metadata() -> None:
+    value = {
+        UIPATH_METADATA_KEY: {
+            "kind": "timeout",
+            "triggerType": "Timer",
+            "triggerName": "Timer",
+        },
+        "resumeTime": "2026-07-07T12:00:00Z",
+    }
+
+    metadata = get_resume_metadata(value)
+
+    assert isinstance(metadata, UiPathResumeMetadata)
+    assert metadata.kind == "timeout"
+    assert metadata.trigger_type == UiPathResumeTriggerType.TIMER
+    assert metadata.trigger_name == UiPathResumeTriggerName.TIMER
+
+
+def test_get_resume_metadata_returns_none_without_metadata() -> None:
+    assert get_resume_metadata({"result": "done"}) is None
+    assert get_resume_metadata("done") is None
+
+
+def test_get_resume_metadata_returns_none_for_invalid_metadata() -> None:
+    value = {
+        UIPATH_METADATA_KEY: {
+            "triggerType": "NotARealTrigger",
+            "triggerName": "Timer",
+        },
+    }
+
+    assert get_resume_metadata(value) is None
+
+
+def test_is_timeout_ignores_plain_timer_metadata() -> None:
+    value = {
+        UIPATH_METADATA_KEY: {
+            "triggerType": "Timer",
+            "triggerName": "Timer",
+        },
+        "resumeTime": "2026-07-07T12:00:00Z",
+    }
+
+    assert is_timeout(value) is False
+
+
+def test_is_timeout_ignores_user_timed_out_fields() -> None:
+    assert is_timeout({"timedOut": True}) is False
+    assert is_timeout("timeout") is False
+
+
+def test_assert_no_timeout_returns_original_value() -> None:
+    value = {"result": "done"}
+
+    assert assert_no_timeout(value) is value
+
+
+def test_assert_no_timeout_raises_with_resume_value() -> None:
+    value = {
+        UIPATH_METADATA_KEY: {"kind": "timeout"},
+        "value": {"jobKey": "job-1"},
+    }
+
+    with pytest.raises(UiPathTimeoutError) as exc_info:
+        assert_no_timeout(value)
+
+    assert exc_info.value.value is value

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.28"
+version = "0.5.29"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.13.2"
+version = "2.13.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-  "uipath-core>=0.5.26, <0.6.0",
+  "uipath-core>=0.5.29, <0.6.0",
   "uipath-runtime>=0.11.7, <0.13.0",
-  "uipath-platform>=0.2.1, <0.3.0",
+  "uipath-platform>=0.2.2, <0.3.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/testcases/langchain-cross/pyproject.toml
+++ b/packages/uipath/testcases/langchain-cross/pyproject.toml
@@ -4,17 +4,18 @@ version = "0.0.1"
 description = "agent"
 authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 dependencies = [
-    "uipath-langchain>=0.0.149",
+    "uipath-langchain>=0.14.0,<0.15.0",
     "uipath"
 ]
 requires-python = ">=3.11"
 
 [tool.uv.sources]
 uipath = { path = "../../", editable = true }
+uipath-core = { path = "../../../uipath-core", editable = true }
+uipath-platform = { path = "../../../uipath-platform", editable = true }
 
-# Force the local uipath (the version under test) regardless of the upper bound
-# the published uipath-langchain declares, so a backward-compatible minor bump
-# does not break resolution purely on that cap. Mirrors the uv override used in
-# the cross-repo test workflows.
+# Force local UiPath packages under test regardless of upper bounds declared by
+# the published uipath-langchain package. Mirrors the uv override used in the
+# cross-repo test workflows.
 [tool.uv]
-override-dependencies = ["uipath"]
+override-dependencies = ["uipath", "uipath-core", "uipath-platform"]

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.2"
+version = "2.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2709,7 +2709,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.28"
+version = "0.5.29"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
@@ -2741,7 +2741,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add helpers for detecting and asserting UiPath timeout resume values
- add typed `UiPathResumeMetadata` and `get_resume_metadata` for enum-based branching on multi-trigger resumes
- expose the helper API from `uipath.platform.common`