### PR TITLE
feat(cli): init enhancements

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -6,7 +6,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
-  "uipath-runtime>=0.11.7, <0.13.0",
+  "uipath-runtime>=0.12.2, <0.13.0",
   "uipath-platform>=0.2.2, <0.3.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.3"
+version = "2.13.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_init.py
+++ b/packages/uipath/src/uipath/_cli/cli_init.py
@@ -158,6 +158,27 @@ def write_bindings_file(bindings: Bindings) -> Path:
     return bindings_file_path
 
 
+def mark_transaction_root_entrypoints(
+    entry_point_schemas: list[UiPathRuntimeSchema],
+) -> None:
+    """Stamp entrypoints with 'isTransactionRoot: true' for vertical-solution projects.
+
+    Reads 'runtimeOptions._uipathVerticalSolution' from uipath.json; when true,
+    marks every entrypoint schema in-place so the flag serializes into
+    entry-points.json. Otherwise leaves the schemas untouched, so the flag is
+    dropped on regeneration.
+
+    Args:
+        entry_point_schemas: The discovered entrypoint schemas.
+    """
+    config = UiPathJsonConfig.load_from_file(str(UiPathConfig.config_file_path))
+    if config.runtime_options.uipath_vertical_solution is not True:
+        return
+
+    for schema in entry_point_schemas:
+        schema.is_transaction_root = True
+
+
 def write_entry_points_file(entry_points: list[UiPathRuntimeSchema]) -> Path:
     """Write entrypoints to a JSON file.
 
@@ -472,6 +493,8 @@ def init(no_agents_md_override: bool) -> None:
                                 await runtime.dispose()
                 finally:
                     await factory.dispose()
+
+                mark_transaction_root_entrypoints(entry_point_schemas)
 
                 # Write entry-points.json with all schemas
                 entry_points_path = write_entry_points_file(entry_point_schemas)

--- a/packages/uipath/src/uipath/_cli/models/uipath_json_schema.py
+++ b/packages/uipath/src/uipath/_cli/models/uipath_json_schema.py
@@ -26,6 +26,13 @@ class RuntimeOptions(BaseModelWithDefaultConfig):
         alias="isConversational",
         description="Enable conversational mode for the runtime",
     )
+    uipath_vertical_solution: bool | None = Field(
+        default=None,
+        alias="_uipathVerticalSolution",
+        description="Marks the project as part of a UiPath vertical solution. "
+        "When true, 'uipath init' stamps 'isTransactionRoot: true' on every "
+        "entrypoint in entry-points.json.",
+    )
 
 
 class DesignOptions(BaseModelWithDefaultConfig):

--- a/packages/uipath/tests/cli/test_init.py
+++ b/packages/uipath/tests/cli/test_init.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -713,6 +714,94 @@ def main(input: InputModel) -> InputModel: return input""")
             assert (
                 "We recommend using a single type for all entrypoints" in result.output
             )
+
+    @pytest.mark.parametrize("entrypoint_kind", ["functions", "agents"])
+    def test_init_vertical_solution_stamps_transaction_root(
+        self, runner: CliRunner, temp_dir: str, entrypoint_kind: str
+    ) -> None:
+        """'_uipathVerticalSolution: true' stamps isTransactionRoot on entrypoints."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("main.py", "w") as f:
+                f.write("def main(input: str) -> str: return input")
+            with open("uipath.json", "w") as f:
+                json.dump(
+                    {
+                        "runtimeOptions": {"_uipathVerticalSolution": True},
+                        entrypoint_kind: {"main": "main.py:main"},
+                    },
+                    f,
+                )
+            self._generate_pyproject()
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+
+            with open("entry-points.json", "r") as f:
+                entry_points = json.load(f)["entryPoints"]
+            assert len(entry_points) == 1
+            assert entry_points[0]["isTransactionRoot"] is True
+
+    @pytest.mark.parametrize(
+        "runtime_options",
+        [None, {}, {"_uipathVerticalSolution": False}],
+    )
+    def test_init_without_vertical_solution_omits_transaction_root(
+        self, runner: CliRunner, temp_dir: str, runtime_options: dict[str, Any] | None
+    ) -> None:
+        """Entrypoints are not stamped when the flag is absent or false."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("main.py", "w") as f:
+                f.write("def main(input: str) -> str: return input")
+            uipath_config: dict[str, Any] = {"functions": {"main": "main.py:main"}}
+            if runtime_options is not None:
+                uipath_config["runtimeOptions"] = runtime_options
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+            self._generate_pyproject()
+
+            result = runner.invoke(cli, ["init"], env={})
+            assert result.exit_code == 0
+
+            with open("entry-points.json", "r") as f:
+                entry_points = json.load(f)["entryPoints"]
+            assert "isTransactionRoot" not in entry_points[0]
+
+    def test_init_rerun_syncs_transaction_root_with_vertical_solution_flag(
+        self, runner: CliRunner, temp_dir: str
+    ) -> None:
+        """Rerunning init keeps or removes isTransactionRoot to match the flag."""
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            with open("main.py", "w") as f:
+                f.write("def main(input: str) -> str: return input")
+            with open("uipath.json", "w") as f:
+                json.dump(
+                    {
+                        "runtimeOptions": {"_uipathVerticalSolution": True},
+                        "functions": {"main": "main.py:main"},
+                    },
+                    f,
+                )
+            self._generate_pyproject()
+
+            assert runner.invoke(cli, ["init"], env={}).exit_code == 0
+            with open("entry-points.json", "r") as f:
+                assert json.load(f)["entryPoints"][0]["isTransactionRoot"] is True
+
+            # Rerun with the flag still present: the stamp is kept.
+            assert runner.invoke(cli, ["init"], env={}).exit_code == 0
+            with open("entry-points.json", "r") as f:
+                assert json.load(f)["entryPoints"][0]["isTransactionRoot"] is True
+
+            # Remove the flag (keep the backfilled id and functions untouched).
+            with open("uipath.json", "r") as f:
+                uipath_config = json.load(f)
+            del uipath_config["runtimeOptions"]["_uipathVerticalSolution"]
+            with open("uipath.json", "w") as f:
+                json.dump(uipath_config, f)
+
+            assert runner.invoke(cli, ["init"], env={}).exit_code == 0
+            with open("entry-points.json", "r") as f:
+                assert "isTransactionRoot" not in json.load(f)["entryPoints"][0]
 
     def test_init_creates_studio_metadata_file(
         self, runner: CliRunner, temp_dir: str

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2674,7 +2674,7 @@ requires-dist = [
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
     { name = "uipath-platform", editable = "../uipath-platform" },
-    { name = "uipath-runtime", specifier = ">=0.11.7,<0.13.0" },
+    { name = "uipath-runtime", specifier = ">=0.12.2,<0.13.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2779,16 +2779,16 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.12.1"
+version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/0b/6d6bfd912c2ad6978f58646becf3647430ccb087008a8c78dbc33b0b101e/uipath_runtime-0.12.1.tar.gz", hash = "sha256:a63ce739ea53da8479bb0314477f89d42724045ecbd7db3f2a3f0a09ab17a755", size = 235372, upload-time = "2026-07-06T11:14:51.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/eb/1638b8307c9305527a449664c95a03a2af1bfaf1bd150819fb882ef71415/uipath_runtime-0.12.2.tar.gz", hash = "sha256:0d1f56f41add0d932bbe0c975d473ec27a86c58e14e9aa745d6501356c51284a", size = 235789, upload-time = "2026-07-07T11:02:12.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/4c/433de72c4c5869ee26a63f68361b5c62d04bb03e9c7db9a69c0d3db7b458/uipath_runtime-0.12.1-py3-none-any.whl", hash = "sha256:88b014e0c5a50a5b41b2e532bd628eebc91d70ad42b6d3389fdc61b7ae78e0a6", size = 92004, upload-time = "2026-07-06T11:14:50.363Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7a/9042e41a71726386d6f7673f843decd5405daff0787bfe127a8ac15abaa4/uipath_runtime-0.12.2-py3-none-any.whl", hash = "sha256:8faa88ac0af208b48f08abfff11530ae0279f1e88a12e9d2935f7f74111ebde1", size = 92087, upload-time = "2026-07-07T11:02:11.221Z" },
 ]
 
 [[package]]

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.3"
+version = "2.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

- init enhancements
- Bump `uipath-runtime` to `>=0.12.2, <0.13.0`.
- Bump `uipath` to `2.13.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Development Packages

### uipath-platform

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-platform==0.2.2.dev1017967183",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-platform>=0.2.2.dev1017960000,<0.2.2.dev1017970000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-platform = { index = "testpypi" }
```

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.13.4.dev1017967183",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.13.4.dev1017960000,<2.13.4.dev1017970000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
uipath-platform = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-platform==0.2.2.dev1017967183"]
```