### PR TITLE
fix: remove timeout kind metadata

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.29"
+version = "0.5.30"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/triggers/trigger.py
+++ b/packages/uipath-core/src/uipath/core/triggers/trigger.py
@@ -51,7 +51,6 @@ class UiPathResumeTriggerName(str, Enum):
 class UiPathResumeMetadata(BaseModel):
     """UiPath metadata attached to resume values from multi-trigger interrupts."""
 
-    kind: str | None = None
     trigger_type: UiPathResumeTriggerType | None = Field(
         default=None, alias="triggerType"
     )

--- a/packages/uipath-core/tests/triggers/test_resume_metadata.py
+++ b/packages/uipath-core/tests/triggers/test_resume_metadata.py
@@ -8,13 +8,11 @@ from uipath.core.triggers import (
 def test_resume_metadata_accepts_trigger_aliases() -> None:
     metadata = UiPathResumeMetadata.model_validate(
         {
-            "kind": "timeout",
             "triggerType": "Timer",
             "triggerName": "Timer",
         }
     )
 
-    assert metadata.kind == "timeout"
     assert metadata.trigger_type == UiPathResumeTriggerType.TIMER
     assert metadata.trigger_name == UiPathResumeTriggerName.TIMER
 

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.29"
+version = "0.5.30"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.2"
+version = "0.2.3"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ dependencies = [
   "httpx>=0.28.1",
   "tenacity>=9.0.0",
   "truststore>=0.10.1",
-  "uipath-core>=0.5.29, <0.6.0",
+  "uipath-core>=0.5.30, <0.6.0",
   "pydantic-function-models>=0.1.11",
   "sqlparse>=0.5.5",
 ]

--- a/packages/uipath-platform/src/uipath/platform/common/timeout.py
+++ b/packages/uipath-platform/src/uipath/platform/common/timeout.py
@@ -7,11 +7,10 @@ from pydantic import ValidationError
 from uipath.core.triggers import (
     UIPATH_METADATA_KEY,
     UiPathResumeMetadata,
+    UiPathResumeTriggerType,
 )
 
 T = TypeVar("T")
-
-_TIMEOUT_KIND = "timeout"
 
 
 class UiPathTimeoutError(TimeoutError):
@@ -26,7 +25,9 @@ class UiPathTimeoutError(TimeoutError):
 def is_timeout(value: Any) -> bool:
     """Return True when a resume value came from a UiPath timeout trigger."""
     metadata = get_resume_metadata(value)
-    return metadata is not None and metadata.kind == _TIMEOUT_KIND
+    return (
+        metadata is not None and metadata.trigger_type == UiPathResumeTriggerType.TIMER
+    )
 
 
 def assert_no_timeout(value: T) -> T:

--- a/packages/uipath-platform/tests/common/test_timeout_helpers.py
+++ b/packages/uipath-platform/tests/common/test_timeout_helpers.py
@@ -17,7 +17,6 @@ from uipath.platform.common import (
 def test_is_timeout_detects_timeout_metadata() -> None:
     value = {
         UIPATH_METADATA_KEY: {
-            "kind": "timeout",
             "triggerType": "Timer",
             "triggerName": "Timer",
         },
@@ -30,7 +29,6 @@ def test_is_timeout_detects_timeout_metadata() -> None:
 def test_get_resume_metadata_returns_typed_metadata() -> None:
     value = {
         UIPATH_METADATA_KEY: {
-            "kind": "timeout",
             "triggerType": "Timer",
             "triggerName": "Timer",
         },
@@ -40,7 +38,6 @@ def test_get_resume_metadata_returns_typed_metadata() -> None:
     metadata = get_resume_metadata(value)
 
     assert isinstance(metadata, UiPathResumeMetadata)
-    assert metadata.kind == "timeout"
     assert metadata.trigger_type == UiPathResumeTriggerType.TIMER
     assert metadata.trigger_name == UiPathResumeTriggerName.TIMER
 
@@ -61,13 +58,13 @@ def test_get_resume_metadata_returns_none_for_invalid_metadata() -> None:
     assert get_resume_metadata(value) is None
 
 
-def test_is_timeout_ignores_plain_timer_metadata() -> None:
+def test_is_timeout_ignores_non_timer_metadata() -> None:
     value = {
         UIPATH_METADATA_KEY: {
-            "triggerType": "Timer",
-            "triggerName": "Timer",
+            "triggerType": "Job",
+            "triggerName": "Job",
         },
-        "resumeTime": "2026-07-07T12:00:00Z",
+        "value": {"jobKey": "job-1"},
     }
 
     assert is_timeout(value) is False
@@ -86,7 +83,10 @@ def test_assert_no_timeout_returns_original_value() -> None:
 
 def test_assert_no_timeout_raises_with_resume_value() -> None:
     value = {
-        UIPATH_METADATA_KEY: {"kind": "timeout"},
+        UIPATH_METADATA_KEY: {
+            "triggerType": "Timer",
+            "triggerName": "Timer",
+        },
         "value": {"jobKey": "job-1"},
     }
 

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.29"
+version = "0.5.30"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python SDK and CLI for UiPath Platform, enabling programmatic int
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
-  "uipath-core>=0.5.29, <0.6.0",
+  "uipath-core>=0.5.30, <0.6.0",
   "uipath-runtime>=0.11.7, <0.13.0",
   "uipath-platform>=0.2.2, <0.3.0",
   "click>=8.3.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2709,7 +2709,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.29"
+version = "0.5.30"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
@@ -2741,7 +2741,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- remove the timeout-specific `kind` field from resume metadata
- detect timeout resumes from timer trigger metadata
- keep dependent package locks aligned with the package bumps