### PR TITLE
fix: classify invalid function inputs as user errors instead of runtime crashes

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.7"
+version = "2.13.9"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_evals/_telemetry.py
+++ b/packages/uipath/src/uipath/_cli/_evals/_telemetry.py
@@ -20,6 +20,7 @@ from uipath.eval.runtime.events import (
 )
 from uipath.platform.common import UiPathConfig
 from uipath.platform.constants import ENV_TENANT_ID
+from uipath.runtime.errors import UiPathBaseRuntimeError
 from uipath.telemetry._track import is_telemetry_enabled, track_event
 
 logger = logging.getLogger(__name__)
@@ -238,15 +239,15 @@ class EvalTelemetrySubscriber:
                 )
 
             if event.exception_details:
-                properties["ErrorType"] = type(
-                    event.exception_details.exception
-                ).__name__
-                properties["ErrorMessage"] = str(event.exception_details.exception)[
-                    :500
-                ]
+                exception = event.exception_details.exception
+                properties["ErrorType"] = type(exception).__name__
+                properties["ErrorMessage"] = str(exception)[:500]
                 properties["IsRuntimeException"] = (
                     event.exception_details.runtime_exception
                 )
+                if isinstance(exception, UiPathBaseRuntimeError):
+                    properties["ErrorCode"] = exception.error_info.code
+                    properties["ErrorCategory"] = exception.error_info.category.value
 
             self._enrich_properties(properties)
 

--- a/packages/uipath/src/uipath/eval/runtime/runtime.py
+++ b/packages/uipath/src/uipath/eval/runtime/runtime.py
@@ -782,7 +782,13 @@ class UiPathEvalRuntime:
                 )
 
             except Exception as e:
-                exception_details = EvalItemExceptionDetails(exception=e)
+                root_exception: Exception = (
+                    e.root_exception if isinstance(e, EvaluationRuntimeException) else e
+                )
+                exception_details = EvalItemExceptionDetails(
+                    exception=root_exception,
+                    runtime_exception=not _is_user_facing_error(root_exception),
+                )
 
                 for evaluator in evaluators:
                     evaluation_run_results.evaluation_run_results.append(
@@ -807,13 +813,6 @@ class UiPathEvalRuntime:
                 if isinstance(e, EvaluationRuntimeException):
                     eval_run_updated_event.spans = e.spans
                     eval_run_updated_event.logs = e.logs
-                    if eval_run_updated_event.exception_details:
-                        eval_run_updated_event.exception_details.exception = (
-                            e.root_exception
-                        )
-                        eval_run_updated_event.exception_details.runtime_exception = (
-                            not _is_user_facing_error(e.root_exception)
-                        )
 
                 await self.event_bus.publish(
                     EvaluationEvents.UPDATE_EVAL_RUN,

--- a/packages/uipath/src/uipath/eval/runtime/runtime.py
+++ b/packages/uipath/src/uipath/eval/runtime/runtime.py
@@ -38,6 +38,7 @@ from uipath.runtime import (
     UiPathRuntimeStorageProtocol,
 )
 from uipath.runtime.errors import (
+    UiPathBaseRuntimeError,
     UiPathErrorCategory,
     UiPathErrorContract,
 )
@@ -94,6 +95,19 @@ from .events import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_user_facing_error(exception: BaseException) -> bool:
+    """Whether an exception is a correctly-reported workload failure.
+
+    User-category errors (e.g. invalid input, business logic failures) are
+    failures of the agent under evaluation, not eval infrastructure crashes,
+    so they must not be flagged as runtime exceptions.
+    """
+    return (
+        isinstance(exception, UiPathBaseRuntimeError)
+        and exception.error_info.category == UiPathErrorCategory.USER
+    )
 
 
 def compute_evaluator_scores(
@@ -798,7 +812,7 @@ class UiPathEvalRuntime:
                             e.root_exception
                         )
                         eval_run_updated_event.exception_details.runtime_exception = (
-                            True
+                            not _is_user_facing_error(e.root_exception)
                         )
 
                 await self.event_bus.publish(

--- a/packages/uipath/src/uipath/functions/runtime.py
+++ b/packages/uipath/src/uipath/functions/runtime.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, AsyncGenerator, Callable, Type, cast, get_type_hints
 
+from pydantic import ValidationError
+
 from uipath.runtime import (
     UiPathExecuteOptions,
     UiPathRuntimeEvent,
@@ -33,6 +35,24 @@ from .type_conversion import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _format_input_validation_error(
+    function_name: str, input_type: Type[Any], error: Exception
+) -> str:
+    """Build a concise, human-readable message for an input conversion failure."""
+    type_name = getattr(input_type, "__name__", str(input_type))
+    if isinstance(error, ValidationError):
+        issues = "; ".join(
+            f"{'.'.join(str(loc) for loc in err['loc']) or type_name}: {err['msg']}"
+            for err in error.errors()
+        )
+    else:
+        issues = str(error)
+    return (
+        f"Input does not match the expected schema for "
+        f"'{function_name}' ({type_name}): {issues}"
+    )
 
 
 class UiPathFunctionsRuntime:
@@ -141,7 +161,18 @@ class UiPathFunctionsRuntime:
             or is_pydantic_model(input_type)
             or (inspect.isclass(input_type) and hasattr(input_type, "__annotations__"))
         ):
-            typed_input = convert_to_class(input_data, cast(Type[Any], input_type))
+            try:
+                typed_input = convert_to_class(input_data, cast(Type[Any], input_type))
+            except (ValidationError, TypeError, ValueError) as e:
+                raise UiPathRuntimeError(
+                    # Closest available code; uipath-runtime 0.12.x has no
+                    # dedicated input-validation error code yet.
+                    UiPathErrorCode.INPUT_INVALID_JSON,
+                    "Invalid input",
+                    _format_input_validation_error(self.function_name, input_type, e),
+                    UiPathErrorCategory.USER,
+                    include_traceback=False,
+                ) from e
             result = await func(typed_input) if is_async else func(typed_input)
         else:
             # Dict/untyped parameter

--- a/packages/uipath/tests/cli/eval/test_eval_telemetry.py
+++ b/packages/uipath/tests/cli/eval/test_eval_telemetry.py
@@ -339,6 +339,45 @@ class TestEvalRunUpdated:
 
     @pytest.mark.asyncio
     @patch("uipath._cli._evals._telemetry.track_event")
+    async def test_on_eval_run_updated_user_error_includes_classification(
+        self, mock_track_event
+    ):
+        """User-category runtime errors emit ErrorCode/ErrorCategory and are not runtime exceptions."""
+        from uipath.runtime.errors import (
+            UiPathErrorCategory,
+            UiPathErrorCode,
+            UiPathRuntimeError,
+        )
+
+        subscriber = EvalTelemetrySubscriber()
+        error = UiPathRuntimeError(
+            UiPathErrorCode.INPUT_INVALID_JSON,
+            "Invalid input",
+            "Input does not match the expected schema",
+            UiPathErrorCategory.USER,
+            include_traceback=False,
+        )
+        exception_details = EvalItemExceptionDetails(
+            exception=error,
+            runtime_exception=False,
+        )
+        event = self._create_eval_run_updated_event(
+            success=False,
+            exception_details=exception_details,
+        )
+
+        await subscriber._on_eval_run_updated(event)
+
+        call_args = mock_track_event.call_args
+        assert call_args[0][0] == EVAL_RUN_FAILED
+        properties = call_args[0][1]
+        assert properties["ErrorType"] == "UiPathRuntimeError"
+        assert properties["ErrorCode"] == "Python.INPUT_INVALID_JSON"
+        assert properties["ErrorCategory"] == "User"
+        assert properties["IsRuntimeException"] is False
+
+    @pytest.mark.asyncio
+    @patch("uipath._cli._evals._telemetry.track_event")
     async def test_on_eval_run_updated_with_scores(self, mock_track_event):
         """Test that average score is calculated and tracked."""
         subscriber = EvalTelemetrySubscriber()

--- a/packages/uipath/tests/cli/eval/test_runtime_error_classification.py
+++ b/packages/uipath/tests/cli/eval/test_runtime_error_classification.py
@@ -1,0 +1,34 @@
+"""Tests for classifying eval execution errors as user vs runtime failures."""
+
+from uipath.eval.runtime.runtime import _is_user_facing_error
+from uipath.runtime.errors import (
+    UiPathErrorCategory,
+    UiPathErrorCode,
+    UiPathRuntimeError,
+)
+
+
+def _make_error(category: UiPathErrorCategory) -> UiPathRuntimeError:
+    return UiPathRuntimeError(
+        UiPathErrorCode.FUNCTION_EXECUTION_ERROR,
+        "Some failure",
+        "details",
+        category,
+        include_traceback=False,
+    )
+
+
+def test_user_category_error_is_user_facing():
+    assert _is_user_facing_error(_make_error(UiPathErrorCategory.USER)) is True
+
+
+def test_system_category_error_is_not_user_facing():
+    assert _is_user_facing_error(_make_error(UiPathErrorCategory.SYSTEM)) is False
+
+
+def test_unknown_category_error_is_not_user_facing():
+    assert _is_user_facing_error(_make_error(UiPathErrorCategory.UNKNOWN)) is False
+
+
+def test_plain_exception_is_not_user_facing():
+    assert _is_user_facing_error(ValueError("boom")) is False

--- a/packages/uipath/tests/cli/eval/test_runtime_error_classification.py
+++ b/packages/uipath/tests/cli/eval/test_runtime_error_classification.py
@@ -1,11 +1,30 @@
 """Tests for classifying eval execution errors as user vs runtime failures."""
 
+import uuid
+from pathlib import Path
+from typing import Any, AsyncGenerator
+
+from uipath.core.events import EventBus
+from uipath.core.tracing import UiPathTraceManager
+from uipath.eval.helpers import EvalHelpers
+from uipath.eval.runtime import UiPathEvalContext, evaluate
+from uipath.eval.runtime.events import EvalRunUpdatedEvent, EvaluationEvents
 from uipath.eval.runtime.runtime import _is_user_facing_error
+from uipath.runtime import (
+    UiPathExecuteOptions,
+    UiPathRuntimeEvent,
+    UiPathRuntimeFactorySettings,
+    UiPathRuntimeProtocol,
+    UiPathRuntimeResult,
+    UiPathRuntimeStorageProtocol,
+    UiPathStreamOptions,
+)
 from uipath.runtime.errors import (
     UiPathErrorCategory,
     UiPathErrorCode,
     UiPathRuntimeError,
 )
+from uipath.runtime.schema import UiPathRuntimeSchema
 
 
 def _make_error(category: UiPathErrorCategory) -> UiPathRuntimeError:
@@ -32,3 +51,121 @@ def test_unknown_category_error_is_not_user_facing():
 
 def test_plain_exception_is_not_user_facing():
     assert _is_user_facing_error(ValueError("boom")) is False
+
+
+class _FailingRuntime:
+    """Runtime whose execution always raises the configured error."""
+
+    def __init__(self, error: Exception):
+        self._error = error
+
+    async def execute(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathExecuteOptions | None = None,
+    ) -> UiPathRuntimeResult:
+        raise self._error
+
+    async def stream(
+        self,
+        input: dict[str, Any] | None = None,
+        options: UiPathStreamOptions | None = None,
+    ) -> AsyncGenerator[UiPathRuntimeEvent, None]:
+        raise self._error
+        yield  # unreachable; makes this an async generator
+
+    async def get_schema(self) -> UiPathRuntimeSchema:
+        return UiPathRuntimeSchema(
+            filePath="test.py",
+            uniqueId="test",
+            type="workflow",
+            input={"type": "object", "properties": {}},
+            output={"type": "object", "properties": {}},
+        )
+
+    async def dispose(self) -> None:
+        pass
+
+
+class _FailingFactory:
+    def __init__(self, error: Exception):
+        self._error = error
+
+    def discover_entrypoints(self) -> list[str]:
+        return ["test"]
+
+    async def get_storage(self) -> UiPathRuntimeStorageProtocol | None:
+        return None
+
+    async def get_settings(self) -> UiPathRuntimeFactorySettings | None:
+        return None
+
+    async def new_runtime(
+        self, entrypoint: str, runtime_id: str, **kwargs
+    ) -> UiPathRuntimeProtocol:
+        return _FailingRuntime(self._error)
+
+    async def dispose(self) -> None:
+        pass
+
+
+async def _run_failing_eval(error: Exception) -> list[EvalRunUpdatedEvent]:
+    """Run an eval whose execution raises, returning captured run-updated events."""
+    event_bus = EventBus()
+    trace_manager = UiPathTraceManager()
+    captured: list[EvalRunUpdatedEvent] = []
+
+    async def capture(event: EvalRunUpdatedEvent) -> None:
+        captured.append(event)
+
+    event_bus.subscribe(EvaluationEvents.UPDATE_EVAL_RUN, capture)
+
+    factory = _FailingFactory(error)
+    eval_set_path = str(Path(__file__).parent / "evals" / "eval-sets" / "default.json")
+    evaluation_set, _ = EvalHelpers.load_eval_set(eval_set_path)
+    runtime = await factory.new_runtime("test", "test-runtime-id")
+    runtime_schema = await runtime.get_schema()
+    evaluators = await EvalHelpers.load_evaluators(
+        eval_set_path, evaluation_set, agent_model=None
+    )
+
+    context = UiPathEvalContext()
+    context.execution_id = str(uuid.uuid4())
+    context.evaluation_set = evaluation_set
+    context.runtime_schema = runtime_schema
+    context.evaluators = evaluators
+
+    await evaluate(factory, trace_manager, context, event_bus)
+    await event_bus.wait_for_all()
+    return captured
+
+
+async def test_user_error_execution_is_not_a_runtime_exception():
+    """A USER-category failure is reported unwrapped with runtime_exception=False."""
+    error = UiPathRuntimeError(
+        UiPathErrorCode.INPUT_INVALID_JSON,
+        "Invalid input",
+        "Input does not match the expected schema",
+        UiPathErrorCategory.USER,
+        include_traceback=False,
+    )
+    events = await _run_failing_eval(error)
+
+    failed = [e for e in events if not e.success]
+    assert failed
+    details = failed[0].exception_details
+    assert details is not None
+    assert details.exception is error
+    assert details.runtime_exception is False
+
+
+async def test_unexpected_error_execution_is_a_runtime_exception():
+    """A non-user failure in the execution path is flagged as a runtime exception."""
+    events = await _run_failing_eval(RuntimeError("infrastructure broke"))
+
+    failed = [e for e in events if not e.success]
+    assert failed
+    details = failed[0].exception_details
+    assert details is not None
+    assert isinstance(details.exception, RuntimeError)
+    assert details.runtime_exception is True

--- a/packages/uipath/tests/functions/test_input_validation.py
+++ b/packages/uipath/tests/functions/test_input_validation.py
@@ -66,6 +66,35 @@ async def test_invalid_input_raises_user_error(calculator_module, bad_input):
 
 
 @pytest.mark.asyncio
+async def test_missing_dataclass_field_raises_user_error(tmp_path):
+    """Non-Pydantic conversion failures (TypeError) are classified the same way."""
+    (tmp_path / "shipping.py").write_text(
+        textwrap.dedent("""\
+        from dataclasses import dataclass
+
+
+        @dataclass
+        class ShippingInput:
+            address: str
+            zip_code: str
+
+
+        async def main(input: ShippingInput) -> dict:
+            return {"ok": True}
+        """)
+    )
+    runtime = UiPathFunctionsRuntime(str(tmp_path / "shipping.py"), "main", "shipping")
+    with pytest.raises(UiPathRuntimeError) as exc_info:
+        await runtime.execute({"address": "1 Main St"})
+
+    error_info = exc_info.value.error_info
+    assert error_info.category == UiPathErrorCategory.USER
+    assert error_info.title == "Invalid input"
+    assert "ShippingInput" in error_info.detail
+    assert "zip_code" in error_info.detail
+
+
+@pytest.mark.asyncio
 async def test_invalid_input_error_lists_offending_fields(calculator_module):
     """The error detail names each invalid field with the validation message."""
     runtime = UiPathFunctionsRuntime(str(calculator_module), "main", "calculator")

--- a/packages/uipath/tests/functions/test_input_validation.py
+++ b/packages/uipath/tests/functions/test_input_validation.py
@@ -1,0 +1,77 @@
+"""Tests that invalid inputs surface as classified user errors, not crashes."""
+
+import textwrap
+
+import pytest
+
+from uipath.functions.runtime import UiPathFunctionsRuntime
+from uipath.runtime.errors import UiPathErrorCategory, UiPathRuntimeError
+
+
+@pytest.fixture
+def calculator_module(tmp_path):
+    """Create a module with a Pydantic-typed entrypoint."""
+    (tmp_path / "calculator.py").write_text(
+        textwrap.dedent("""\
+        from pydantic import BaseModel
+
+
+        class CalculatorInput(BaseModel):
+            a: int
+            b: int
+
+
+        class CalculatorOutput(BaseModel):
+            result: int
+
+
+        async def main(input: CalculatorInput) -> CalculatorOutput:
+            return CalculatorOutput(result=input.a + input.b)
+        """)
+    )
+    return tmp_path / "calculator.py"
+
+
+@pytest.mark.asyncio
+async def test_valid_input_executes(calculator_module):
+    """Sanity check: well-formed input still executes normally."""
+    runtime = UiPathFunctionsRuntime(str(calculator_module), "main", "calculator")
+    result = await runtime.execute({"a": 1, "b": 2})
+    assert result.output == {"result": 3}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        {"a": "hello", "b": 2},
+        {"a": None, "b": 2},
+        {"a": [1, 2], "b": 2},
+        {"a": {"x": 1}, "b": 2},
+    ],
+)
+async def test_invalid_input_raises_user_error(calculator_module, bad_input):
+    """Schema-mismatched input yields a USER-category error without a traceback."""
+    runtime = UiPathFunctionsRuntime(str(calculator_module), "main", "calculator")
+    with pytest.raises(UiPathRuntimeError) as exc_info:
+        await runtime.execute(bad_input)
+
+    error_info = exc_info.value.error_info
+    assert error_info.category == UiPathErrorCategory.USER
+    assert error_info.code == "Python.INPUT_INVALID_JSON"
+    assert error_info.title == "Invalid input"
+    assert "CalculatorInput" in error_info.detail
+    assert "main" in error_info.detail
+    assert "Traceback" not in error_info.detail
+
+
+@pytest.mark.asyncio
+async def test_invalid_input_error_lists_offending_fields(calculator_module):
+    """The error detail names each invalid field with the validation message."""
+    runtime = UiPathFunctionsRuntime(str(calculator_module), "main", "calculator")
+    with pytest.raises(UiPathRuntimeError) as exc_info:
+        await runtime.execute({"a": "hello", "b": "world"})
+
+    detail = exc_info.value.error_info.detail
+    assert "a:" in detail
+    assert "b:" in detail

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.7"
+version = "2.13.9"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

Fixes the root cause behind [SRE-618832](https://uipath.atlassian.net/browse/SRE-618832): eval runs feeding invalid inputs to typed agent functions (e.g. the SDK's own `crash-string-input-a/b` CI evals) surfaced as unhandled runtime crashes with `IsRuntimeException=True` and a full Python traceback in `ErrorMessage`, repeatedly firing the `agents-evalrun-failed-urt` App Insights alert. A schema-mismatched input is a user/test-data problem, not an eval infrastructure failure, and should be reported as such.

## Changes

**Functions runtime** (`functions/runtime.py`)
- Catch `ValidationError`/`TypeError`/`ValueError` at the `convert_to_class` input-conversion boundary and raise a `UiPathRuntimeError` with `UiPathErrorCategory.USER`, title `Invalid input`, a concise per-field message (e.g. `a: Input should be a valid integer`), and `include_traceback=False` — no more CI workspace paths or tracebacks in telemetry.
- Uses `UiPathErrorCode.INPUT_INVALID_JSON` as the closest existing code; `uipath-runtime` 0.12.x has no dedicated input-validation code yet (follow-up: add `INPUT_VALIDATION_ERROR` there).

**Eval runtime** (`eval/runtime/runtime.py`)
- `runtime_exception` is now only set to `True` when the root error is *not* a user-category `UiPathBaseRuntimeError`. User-category errors are correctly-reported workload failures of the agent under evaluation.

**Eval telemetry** (`_cli/_evals/_telemetry.py`)
- `EvalRun.Failed` events now include `ErrorCode` and `ErrorCategory` properties from the error contract, giving SRE a first-class KQL dimension (`ErrorCategory == "User"`) to filter alert noise instead of substring-matching messages or hardcoding CI org IDs.

## Behavior notes

- The crash-test evals still fail as designed — only the error classification and message quality change.
- Console reporter behavior improves for user errors: it prints the clean error message directly instead of the raw-logs panel.

## Test plan

- [x] New `tests/functions/test_input_validation.py`: string/None/list/dict inputs to a Pydantic-typed function yield USER-category `Invalid input` errors with per-field details and no traceback; valid input still executes.
- [x] New `tests/cli/eval/test_runtime_error_classification.py`: user vs system/unknown/plain-exception classification.
- [x] `tests/cli/eval/test_eval_telemetry.py`: user-category errors emit `ErrorCode`/`ErrorCategory` and `IsRuntimeException=False`.
- [x] Full `tests/functions/` + `tests/cli/eval/` suites pass (492 tests); ruff check/format and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SRE-618832]: https://uipath.atlassian.net/browse/SRE-618832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ