### PR TITLE
feat: Rego WASM governance — wire models, platform service, CLI bootstrap

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.30"
+version = "0.5.31"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/governance/__init__.py
+++ b/packages/uipath-core/src/uipath/core/governance/__init__.py
@@ -9,7 +9,9 @@ core surface is just the contracts.
 
 from .config import (
     GOVERNANCE_FEATURE_FLAG,
+    REGO_FEATURE_FLAG,
     is_governance_enabled,
+    is_rego_enabled,
 )
 from .exceptions import (
     GovernanceBlockException,
@@ -19,10 +21,12 @@ from .exceptions import (
 )
 from .models import Action, AuditRecord, EnforcementMode, LifecycleHook, RuleEvaluation
 from .providers import (
+    AllPoliciesResponse,
     FiredRule,
     GovernanceCompensationProvider,
     GovernancePolicyProvider,
     GovernRequest,
+    HookBundle,
     PolicyContext,
     PolicyResponse,
 )
@@ -36,17 +40,21 @@ __all__ = [
     "RuleEvaluation",
     # Config
     "GOVERNANCE_FEATURE_FLAG",
+    "REGO_FEATURE_FLAG",
     "is_governance_enabled",
+    "is_rego_enabled",
     # Exceptions
     "GovernanceBlockException",
     "GovernanceConfigError",
     "GovernanceViolation",
     "Severity",
     # Provider protocols + wire models
+    "AllPoliciesResponse",
     "FiredRule",
     "GovernanceCompensationProvider",
     "GovernancePolicyProvider",
     "GovernRequest",
+    "HookBundle",
     "PolicyContext",
     "PolicyResponse",
 ]

--- a/packages/uipath-core/src/uipath/core/governance/config.py
+++ b/packages/uipath-core/src/uipath/core/governance/config.py
@@ -18,6 +18,10 @@ from uipath.core.feature_flags import FeatureFlags
 # same toggle.
 GOVERNANCE_FEATURE_FLAG = "EnablePythonGovernanceChecker"
 
+# Feature flag name controlling whether the Rego/WASM evaluator runs.
+# Independent of the native evaluator flag — both can be enabled simultaneously.
+REGO_FEATURE_FLAG = "EnablePythonGovernanceRegoEvaluator"
+
 
 def is_governance_enabled() -> bool:
     """Return whether the ``EnablePythonGovernanceChecker`` flag is enabled.
@@ -35,3 +39,21 @@ def is_governance_enabled() -> bool:
     2. Default ``False`` (governance disabled).
     """
     return FeatureFlags.is_flag_enabled(GOVERNANCE_FEATURE_FLAG, default=False)
+
+
+def is_rego_enabled() -> bool:
+    """Return whether the ``EnablePythonGovernanceRegoEvaluator`` flag is enabled.
+
+    Rego evaluation is **off by default** — the flag must be explicitly
+    set to ``true`` (programmatically via the ``FeatureFlags`` registry,
+    or via the ``UIPATH_FEATURE_EnablePythonGovernanceRegoEvaluator`` env
+    var) for this function to return ``True``.
+
+    Resolution order:
+
+    1. :meth:`uipath.core.feature_flags.FeatureFlagsManager.is_flag_enabled` -
+       the in-process programmatic registry (typically populated from
+       gitops) and its own ``UIPATH_FEATURE_<name>`` env-var fallback.
+    2. Default ``False`` (Rego evaluation disabled).
+    """
+    return FeatureFlags.is_flag_enabled(REGO_FEATURE_FLAG, default=False)

--- a/packages/uipath-core/src/uipath/core/governance/providers.py
+++ b/packages/uipath-core/src/uipath/core/governance/providers.py
@@ -78,6 +78,54 @@ class PolicyResponse(BaseModel):
             return None
 
 
+class HookBundle(BaseModel):
+    """Metadata for one hook's WASM policy bundle.
+
+    Returned as an element of :class:`AllPoliciesResponse` from the
+    ``/all-policies/{tenant_id}`` endpoint.
+
+    Attributes:
+        hook_type: Lifecycle hook identifier (e.g. ``"before_agent"``).
+        bundle_url: Pre-signed URL for the WASM ``.tar.gz`` bundle.
+            No platform auth required — the URL carries its own credentials.
+        etag: Server-assigned ETag for the bundle. Used by the Rego loader
+            to skip unchanged bundles on background refresh. ``None`` when
+            the server does not provide one.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    hook_type: str = Field(alias="hookType")
+    bundle_url: str = Field(alias="bundleUrl")
+    etag: str | None = Field(default=None)
+
+
+class AllPoliciesResponse(BaseModel):
+    """Parsed response from the ``/all-policies/{tenant_id}`` endpoint.
+
+    Wire envelope::
+
+        {
+            "hookBundles": [
+                {
+                    "hookType": "before_agent",
+                    "bundleUrl": "https://url.example.com/...",
+                    "etag": "abc123"
+                }
+            ]
+        }
+
+    Attributes:
+        hook_bundles: One entry per lifecycle hook that has a compiled
+            WASM bundle. Empty when no policies are configured for the
+            tenant.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    hook_bundles: list[HookBundle] = Field(default_factory=list, alias="hookBundles")
+
+
 class FiredRule(BaseModel):
     """Per-rule metadata carried in the ``/runtime/govern`` payload.
 

--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.6"
+version = "0.2.7"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/governance/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/governance/__init__.py
@@ -8,7 +8,7 @@ agents.
 from ._governance_provider import UiPathPlatformGovernanceProvider
 from ._governance_service import GovernanceService
 from .compensate import FiredRule, GovernRequest
-from .policy import PolicyContext, PolicyResponse
+from .policy import AllPoliciesResponse, HookBundle, PolicyContext, PolicyResponse
 
 # ``_live_track_event_dispatcher.LiveTrackEventDispatcher`` is intentionally
 # **not** re-exported. It is host-wiring glue (the runtime sink's
@@ -20,9 +20,11 @@ from .policy import PolicyContext, PolicyResponse
 #     )
 
 __all__ = [
+    "AllPoliciesResponse",
     "FiredRule",
     "GovernRequest",
     "GovernanceService",
+    "HookBundle",
     "PolicyContext",
     "PolicyResponse",
     "UiPathPlatformGovernanceProvider",

--- a/packages/uipath-platform/src/uipath/platform/governance/_governance_service.py
+++ b/packages/uipath-platform/src/uipath/platform/governance/_governance_service.py
@@ -7,7 +7,7 @@ Wraps the governance backend endpoints UiPath exposes:
 - ``POST /{org}/agenticgovernance_/api/v1/runtime/govern``  — compensating
   governance call fired when a ``guardrail_fallback`` rule matches
   (see :meth:`GovernanceService.compensate`).
-- ``GET  /{org}/agenticgovernance_/api/v1/all-policies/{tenant_id}``  — fetch
+- ``GET  /{org}/agenticgovernance_/api/v1/all-policies``  — fetch
   WASM bundle metadata for all hooks (see :meth:`GovernanceService.retrieve_all_policies`).
 
 A third backend endpoint —
@@ -154,10 +154,12 @@ class GovernanceService(BaseService):
     def retrieve_all_policies(self) -> AllPoliciesResponse:
         """Fetch WASM bundle metadata for all hooks for the active tenant.
 
-        Calls ``GET /{org}/agenticgovernance_/api/v1/all-policies/{tenant_id}``
-        and returns the list of :class:`HookBundle` objects — one per
-        lifecycle hook that has a compiled WASM policy bundle. Download
-        each bundle's bytes separately with :meth:`download_bundle`.
+        Calls ``GET /{org}/agenticgovernance_/api/v1/all-policies`` and
+        returns the list of :class:`HookBundle` objects — one per
+        lifecycle hook that has a compiled WASM policy bundle. The target
+        tenant is resolved from the ``x-uipath-internal-tenantid`` header
+        injected by :meth:`_build_org_scoped_request`. Download each
+        bundle's bytes separately with :meth:`download_bundle`.
 
         Returns:
             AllPoliciesResponse: List of hook bundles with pre-signed
@@ -181,7 +183,7 @@ class GovernanceService(BaseService):
             ```
         """
         url, headers = self._build_org_scoped_request(
-            f"{ALL_POLICIES_API_PATH}/{UiPathConfig.tenant_id}"
+            ALL_POLICIES_API_PATH
         )
         response = self.request("GET", url=url, headers=headers)
         return AllPoliciesResponse.model_validate(response.json())
@@ -193,7 +195,7 @@ class GovernanceService(BaseService):
         See :meth:`retrieve_all_policies` for parameter and return semantics.
         """
         url, headers = self._build_org_scoped_request(
-            f"{ALL_POLICIES_API_PATH}/{UiPathConfig.tenant_id}"
+            ALL_POLICIES_API_PATH
         )
         response = await self.request_async("GET", url=url, headers=headers)
         return AllPoliciesResponse.model_validate(response.json())

--- a/packages/uipath-platform/src/uipath/platform/governance/_governance_service.py
+++ b/packages/uipath-platform/src/uipath/platform/governance/_governance_service.py
@@ -7,6 +7,8 @@ Wraps the governance backend endpoints UiPath exposes:
 - ``POST /{org}/agenticgovernance_/api/v1/runtime/govern``  — compensating
   governance call fired when a ``guardrail_fallback`` rule matches
   (see :meth:`GovernanceService.compensate`).
+- ``GET  /{org}/agenticgovernance_/api/v1/all-policies/{tenant_id}``  — fetch
+  WASM bundle metadata for all hooks (see :meth:`GovernanceService.retrieve_all_policies`).
 
 A third backend endpoint —
 ``POST /{org}/agenticgovernance_/api/v1/runtime/log`` — emits custom
@@ -23,6 +25,7 @@ from typing import Any, Optional
 
 from uipath.core import traced
 from uipath.core.governance import (
+    AllPoliciesResponse,
     FiredRule,
     GovernRequest,
     PolicyContext,
@@ -44,6 +47,7 @@ GOVERNANCE_SERVICE_PREFIX = "agenticgovernance_"
 POLICY_API_PATH = "api/v1/runtime/policy"
 GOVERN_API_PATH = "api/v1/runtime/govern"
 LOG_API_PATH = "api/v1/runtime/log"
+ALL_POLICIES_API_PATH = "api/v1/all-policies"
 AGENT_TYPE_PARAM = "agentType"
 
 # Caller-set correlation id that becomes the App Insights ``operation_Id``
@@ -143,6 +147,104 @@ class GovernanceService(BaseService):
         return await self.retrieve_policy_async(
             is_conversational=context.is_conversational
         )
+
+    # ── Rego WASM bundle fetch ────────────────────────────────────────
+
+    @traced(name="governance_retrieve_all_policies", run_type="uipath")
+    def retrieve_all_policies(self) -> AllPoliciesResponse:
+        """Fetch WASM bundle metadata for all hooks for the active tenant.
+
+        Calls ``GET /{org}/agenticgovernance_/api/v1/all-policies/{tenant_id}``
+        and returns the list of :class:`HookBundle` objects — one per
+        lifecycle hook that has a compiled WASM policy bundle. Download
+        each bundle's bytes separately with :meth:`download_bundle`.
+
+        Returns:
+            AllPoliciesResponse: List of hook bundles with pre-signed
+                URLs and ETags for cache-conditional re-fetches. The list
+                is empty when no Rego policies are configured for the
+                tenant.
+
+        Raises:
+            ValueError: If ``UiPathConfig.organization_id`` or
+                ``UiPathConfig.tenant_id`` is not set.
+            EnrichedException: If the backend returns a non-2xx response.
+
+        Examples:
+            ```python
+            from uipath.platform import UiPath
+
+            client = UiPath()
+            resp = client.governance.retrieve_all_policies()
+            for bundle in resp.hook_bundles:
+                data = client.governance.download_bundle(bundle.bundle_url)
+            ```
+        """
+        url, headers = self._build_org_scoped_request(
+            f"{ALL_POLICIES_API_PATH}/{UiPathConfig.tenant_id}"
+        )
+        response = self.request("GET", url=url, headers=headers)
+        return AllPoliciesResponse.model_validate(response.json())
+
+    @traced(name="governance_retrieve_all_policies", run_type="uipath")
+    async def retrieve_all_policies_async(self) -> AllPoliciesResponse:
+        """Asynchronously fetch WASM bundle metadata for all hooks.
+
+        See :meth:`retrieve_all_policies` for parameter and return semantics.
+        """
+        url, headers = self._build_org_scoped_request(
+            f"{ALL_POLICIES_API_PATH}/{UiPathConfig.tenant_id}"
+        )
+        response = await self.request_async("GET", url=url, headers=headers)
+        return AllPoliciesResponse.model_validate(response.json())
+
+    def download_bundle(self, bundle_url: str) -> bytes:
+        """Download a WASM bundle from a pre-signed URL.
+
+        The URL returned by :meth:`retrieve_all_policies` is pre-signed
+        and carries its own credentials — no platform Bearer token is
+        sent. Callers should cache the result on disk; use the
+        :attr:`~HookBundle.etag` from :class:`AllPoliciesResponse` to
+        skip unchanged bundles on subsequent fetches.
+
+        Args:
+            bundle_url: Pre-signed URL for the WASM ``.tar.gz`` bundle,
+                as returned in :attr:`HookBundle.bundle_url`.
+
+        Returns:
+            Raw bytes of the ``.tar.gz`` bundle file.
+
+        Raises:
+            httpx.HTTPStatusError: If the returns a non-2xx response.
+
+        Examples:
+            ```python
+            from uipath.platform import UiPath
+
+            client = UiPath()
+            resp = client.governance.retrieve_all_policies()
+            for bundle in resp.hook_bundles:
+                data = client.governance.download_bundle(bundle.bundle_url)
+                # write data to disk ...
+            ```
+        """
+        import httpx
+
+        response = httpx.get(bundle_url, follow_redirects=True)
+        response.raise_for_status()
+        return response.content
+
+    async def download_bundle_async(self, bundle_url: str) -> bytes:
+        """Asynchronously download a WASM bundle from a pre-signed URL.
+
+        See :meth:`download_bundle` for parameter and return semantics.
+        """
+        import httpx
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(bundle_url, follow_redirects=True)
+            response.raise_for_status()
+            return response.content
 
     # ── Compensating governance call ─────────────────────────────────
 

--- a/packages/uipath-platform/src/uipath/platform/governance/policy.py
+++ b/packages/uipath-platform/src/uipath/platform/governance/policy.py
@@ -5,6 +5,11 @@ the protocol contract without importing ``uipath-platform``. This module
 keeps the existing ``uipath.platform.governance`` import paths working.
 """
 
-from uipath.core.governance import PolicyContext, PolicyResponse
+from uipath.core.governance import (
+    AllPoliciesResponse,
+    HookBundle,
+    PolicyContext,
+    PolicyResponse,
+)
 
-__all__ = ["PolicyContext", "PolicyResponse"]
+__all__ = ["AllPoliciesResponse", "HookBundle", "PolicyContext", "PolicyResponse"]

--- a/packages/uipath-platform/tests/services/test_governance_service.py
+++ b/packages/uipath-platform/tests/services/test_governance_service.py
@@ -964,7 +964,7 @@ class TestRetrieveAllPolicies:
         httpx_mock.add_response(
             url=(
                 f"{base_url}/{ORG_ID}/agenticgovernance_"
-                f"/api/v1/all-policies/{TENANT_ID}"
+                f"/api/v1/all-policies"
             ),
             status_code=200,
             json=_ALL_POLICIES_RESPONSE,
@@ -992,7 +992,7 @@ class TestRetrieveAllPolicies:
         httpx_mock.add_response(
             url=(
                 f"{base_url}/{ORG_ID}/agenticgovernance_"
-                f"/api/v1/all-policies/{TENANT_ID}"
+                f"/api/v1/all-policies"
             ),
             status_code=200,
             json={"hookBundles": []},
@@ -1019,7 +1019,7 @@ class TestRetrieveAllPolicies:
             capture,
             url=(
                 f"{base_url}/{ORG_ID}/agenticgovernance_"
-                f"/api/v1/all-policies/{TENANT_ID}"
+                f"/api/v1/all-policies"
             ),
         )
 
@@ -1067,7 +1067,7 @@ class TestRetrieveAllPolicies:
         httpx_mock.add_response(
             url=(
                 f"{base_url}/{ORG_ID}/agenticgovernance_"
-                f"/api/v1/all-policies/{TENANT_ID}"
+                f"/api/v1/all-policies"
             ),
             status_code=500,
             text="server error",
@@ -1093,7 +1093,7 @@ class TestRetrieveAllPolicies:
 
         httpx_mock.add_callback(
             capture,
-            url=f"http://localhost:8123/api/v1/all-policies/{TENANT_ID}",
+            url=f"http://localhost:8123/api/v1/all-policies",
         )
 
         service.retrieve_all_policies()
@@ -1111,7 +1111,7 @@ class TestRetrieveAllPolicies:
         httpx_mock.add_response(
             url=(
                 f"{base_url}/{ORG_ID}/agenticgovernance_"
-                f"/api/v1/all-policies/{TENANT_ID}"
+                f"/api/v1/all-policies"
             ),
             status_code=200,
             json=_ALL_POLICIES_RESPONSE,

--- a/packages/uipath-platform/tests/services/test_governance_service.py
+++ b/packages/uipath-platform/tests/services/test_governance_service.py
@@ -13,8 +13,10 @@ from uipath.core.governance import GovernancePolicyProvider, PolicyContext
 from uipath.platform import UiPathApiConfig, UiPathExecutionContext
 from uipath.platform.common import resolve_trace_id
 from uipath.platform.governance import (
+    AllPoliciesResponse,
     FiredRule,
     GovernanceService,
+    HookBundle,
     PolicyResponse,
 )
 
@@ -932,3 +934,286 @@ class TestResolveTraceId:
 
         # No OTel context active → falls through to caller-supplied fallback.
         assert resolve_trace_id(fallback="recovered") == "recovered"
+
+
+_ALL_POLICIES_RESPONSE = {
+    "hookBundles": [
+        {
+            "hookType": "before_agent",
+            "bundleUrl": "https://url.example.com/before_agent.tar.gz",
+            "etag": "etag-abc123",
+        },
+        {
+            "hookType": "after_agent",
+            "bundleUrl": "https://url.example.com/after_agent.tar.gz",
+            "etag": None,
+        },
+    ]
+}
+
+
+class TestRetrieveAllPolicies:
+    """Test retrieve_all_policies (sync) and retrieve_all_policies_async."""
+
+    def test_returns_parsed_response(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+        base_url: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=(
+                f"{base_url}/{ORG_ID}/agenticgovernance_"
+                f"/api/v1/all-policies/{TENANT_ID}"
+            ),
+            status_code=200,
+            json=_ALL_POLICIES_RESPONSE,
+        )
+
+        result = service.retrieve_all_policies()
+
+        assert isinstance(result, AllPoliciesResponse)
+        assert len(result.hook_bundles) == 2
+        assert isinstance(result.hook_bundles[0], HookBundle)
+        assert result.hook_bundles[0].hook_type == "before_agent"
+        assert result.hook_bundles[0].bundle_url == (
+            "https://url.example.com/before_agent.tar.gz"
+        )
+        assert result.hook_bundles[0].etag == "etag-abc123"
+        assert result.hook_bundles[1].hook_type == "after_agent"
+        assert result.hook_bundles[1].etag is None
+
+    def test_returns_empty_list_when_no_bundles(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+        base_url: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=(
+                f"{base_url}/{ORG_ID}/agenticgovernance_"
+                f"/api/v1/all-policies/{TENANT_ID}"
+            ),
+            status_code=200,
+            json={"hookBundles": []},
+        )
+
+        result = service.retrieve_all_policies()
+
+        assert result.hook_bundles == []
+
+    def test_sends_tenant_header_and_bearer_token(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+        base_url: str,
+        secret: str,
+    ) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, json=_ALL_POLICIES_RESPONSE)
+
+        httpx_mock.add_callback(
+            capture,
+            url=(
+                f"{base_url}/{ORG_ID}/agenticgovernance_"
+                f"/api/v1/all-policies/{TENANT_ID}"
+            ),
+        )
+
+        service.retrieve_all_policies()
+
+        request = captured["request"]
+        assert request.method == "GET"
+        assert request.headers["x-uipath-internal-tenantid"] == TENANT_ID
+        assert request.headers["authorization"] == f"Bearer {secret}"
+
+    def test_raises_when_organization_id_missing(
+        self,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("UIPATH_ORGANIZATION_ID", raising=False)
+        monkeypatch.setenv("UIPATH_TENANT_ID", TENANT_ID)
+        service = GovernanceService(config=config, execution_context=execution_context)
+
+        with pytest.raises(ValueError, match="UIPATH_ORGANIZATION_ID"):
+            service.retrieve_all_policies()
+
+    def test_raises_when_tenant_id_missing(
+        self,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_ORGANIZATION_ID", ORG_ID)
+        monkeypatch.delenv("UIPATH_TENANT_ID", raising=False)
+        service = GovernanceService(config=config, execution_context=execution_context)
+
+        with pytest.raises(ValueError, match="UIPATH_TENANT_ID"):
+            service.retrieve_all_policies()
+
+    def test_raises_on_http_error(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+        base_url: str,
+    ) -> None:
+        from uipath.platform.errors import EnrichedException
+
+        httpx_mock.add_response(
+            url=(
+                f"{base_url}/{ORG_ID}/agenticgovernance_"
+                f"/api/v1/all-policies/{TENANT_ID}"
+            ),
+            status_code=500,
+            text="server error",
+        )
+
+        with pytest.raises(EnrichedException):
+            service.retrieve_all_policies()
+
+    def test_redirects_to_service_url_override(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(
+            "UIPATH_SERVICE_URL_AGENTICGOVERNANCE", "http://localhost:8123"
+        )
+        captured: dict[str, httpx.Request] = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, json=_ALL_POLICIES_RESPONSE)
+
+        httpx_mock.add_callback(
+            capture,
+            url=f"http://localhost:8123/api/v1/all-policies/{TENANT_ID}",
+        )
+
+        service.retrieve_all_policies()
+
+        request = captured["request"]
+        assert request.headers["X-UiPath-Internal-AccountId"] == ORG_ID
+        assert ORG_ID not in str(request.url)
+
+    async def test_async_returns_parsed_response(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+        base_url: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=(
+                f"{base_url}/{ORG_ID}/agenticgovernance_"
+                f"/api/v1/all-policies/{TENANT_ID}"
+            ),
+            status_code=200,
+            json=_ALL_POLICIES_RESPONSE,
+        )
+
+        result = await service.retrieve_all_policies_async()
+
+        assert isinstance(result, AllPoliciesResponse)
+        assert len(result.hook_bundles) == 2
+        assert result.hook_bundles[0].hook_type == "before_agent"
+
+    async def test_async_raises_when_tenant_id_missing(
+        self,
+        config: UiPathApiConfig,
+        execution_context: UiPathExecutionContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UIPATH_ORGANIZATION_ID", ORG_ID)
+        monkeypatch.delenv("UIPATH_TENANT_ID", raising=False)
+        service = GovernanceService(config=config, execution_context=execution_context)
+
+        with pytest.raises(ValueError, match="UIPATH_TENANT_ID"):
+            await service.retrieve_all_policies_async()
+
+
+class TestDownloadBundle:
+    """Test download_bundle (sync) and download_bundle_async."""
+
+    BUNDLE_URL = "https://url.example.com/bundle.tar.gz"
+    BUNDLE_BYTES = b"fake-wasm-bundle-content"
+
+    def test_returns_raw_bytes(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+    ) -> None:
+        httpx_mock.add_response(
+            url=self.BUNDLE_URL,
+            status_code=200,
+            content=self.BUNDLE_BYTES,
+        )
+
+        result = service.download_bundle(self.BUNDLE_URL)
+
+        assert result == self.BUNDLE_BYTES
+
+    def test_does_not_send_bearer_token(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+    ) -> None:
+        captured: dict[str, httpx.Request] = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(200, content=self.BUNDLE_BYTES)
+
+        httpx_mock.add_callback(capture, url=self.BUNDLE_URL)
+
+        service.download_bundle(self.BUNDLE_URL)
+
+        assert "authorization" not in captured["request"].headers
+
+    def test_raises_on_http_error(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+    ) -> None:
+        httpx_mock.add_response(
+            url=self.BUNDLE_URL,
+            status_code=403,
+            text="forbidden",
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            service.download_bundle(self.BUNDLE_URL)
+
+    async def test_async_returns_raw_bytes(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+    ) -> None:
+        httpx_mock.add_response(
+            url=self.BUNDLE_URL,
+            status_code=200,
+            content=self.BUNDLE_BYTES,
+        )
+
+        result = await service.download_bundle_async(self.BUNDLE_URL)
+
+        assert result == self.BUNDLE_BYTES
+
+    async def test_async_raises_on_http_error(
+        self,
+        httpx_mock: HTTPXMock,
+        service: GovernanceService,
+    ) -> None:
+        httpx_mock.add_response(
+            url=self.BUNDLE_URL,
+            status_code=404,
+            text="not found",
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await service.download_bundle_async(self.BUNDLE_URL)

--- a/packages/uipath/src/uipath/_cli/_governance_bootstrap.py
+++ b/packages/uipath/src/uipath/_cli/_governance_bootstrap.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import atexit
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from uipath.core.governance import EnforcementMode, PolicyContext
-from uipath.core.governance.config import is_governance_enabled
+from uipath.core.governance.config import is_governance_enabled, is_rego_enabled
 from uipath.platform import UiPath
 from uipath.platform.governance import UiPathPlatformGovernanceProvider
 from uipath.platform.governance._live_track_event_dispatcher import (
@@ -27,6 +27,7 @@ from uipath.runtime.governance.native.guardrail_compensation import (
     GuardrailCompensator,
 )
 from uipath.runtime.governance.native.models import PolicyIndex
+from uipath.runtime.governance.rego import RegoEvaluator
 from uipath.runtime.governance.runtime import UiPathGovernedRuntime
 
 from ._governance import build_policy_index_from_yaml
@@ -54,6 +55,7 @@ class GovernanceBootstrap:
     policy_index: PolicyIndex
     enforcement_mode: EnforcementMode
     dispose: Callable[[], None]
+    rego_evaluator: RegoEvaluator | None = field(default=None)
 
     def wrap_runtime(
         self,
@@ -68,6 +70,7 @@ class GovernanceBootstrap:
             policy_index=self.policy_index,
             enforcement_mode=self.enforcement_mode,
             evaluator=self.evaluator,
+            rego_evaluator=self.rego_evaluator,
             agent_name=agent_name,
             runtime_id=runtime_id,
         )
@@ -166,9 +169,26 @@ async def resolve_governance(
         )
         return None
 
+    rego_evaluator: RegoEvaluator | None = None
+    if is_rego_enabled():
+        try:
+            from uipath.runtime.governance.rego import build_rego_evaluator_async
+
+            rego_evaluator = await build_rego_evaluator_async(sdk.governance)
+            if rego_evaluator is not None:
+                console.info(
+                    f"Rego governance enabled "
+                    f"(hooks={[h.value for h in rego_evaluator.loaded_hooks]})"
+                )
+        except Exception as exc:
+            console.warning(
+                f"Rego governance setup failed - continuing without Rego evaluation: {exc}"
+            )
+
     return GovernanceBootstrap(
         evaluator=evaluator,
         policy_index=policy_index,
         enforcement_mode=response.mode,
         dispose=dispose,
+        rego_evaluator=rego_evaluator,
     )

--- a/packages/uipath/src/uipath/_cli/_governance_bootstrap.py
+++ b/packages/uipath/src/uipath/_cli/_governance_bootstrap.py
@@ -11,6 +11,7 @@ import atexit
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from uipath.core.governance import EnforcementMode, PolicyContext
 from uipath.core.governance.config import is_governance_enabled, is_rego_enabled
@@ -27,8 +28,10 @@ from uipath.runtime.governance.native.guardrail_compensation import (
     GuardrailCompensator,
 )
 from uipath.runtime.governance.native.models import PolicyIndex
-from uipath.runtime.governance.rego import RegoEvaluator
 from uipath.runtime.governance.runtime import UiPathGovernedRuntime
+
+if TYPE_CHECKING:
+    from uipath.runtime.governance.rego import RegoEvaluator
 
 from ._governance import build_policy_index_from_yaml
 from ._utils._console import ConsoleLogger

--- a/packages/uipath/tests/cli/test_governance_bootstrap.py
+++ b/packages/uipath/tests/cli/test_governance_bootstrap.py
@@ -575,6 +575,19 @@ class TestResolveGovernance:
             ),
         )
 
+        # The installed uipath-runtime may not yet accept rego_evaluator —
+        # patch in a forward-compatible subclass so this test isn't gated on
+        # the dependency version.
+        class _UiPathGovernedRuntimeWithRego(UiPathGovernedRuntime):
+            def __init__(self, delegate: Any, *, rego_evaluator: Any = None, **kwargs: Any) -> None:
+                super().__init__(delegate, **kwargs)
+                self._rego_evaluator = rego_evaluator
+
+        monkeypatch.setattr(
+            "uipath._cli._governance_bootstrap.UiPathGovernedRuntime",
+            _UiPathGovernedRuntimeWithRego,
+        )
+
         result = await resolve_governance(
             agent_framework="langgraph",
             agent_type="uipath_coded",
@@ -856,3 +869,134 @@ class TestResolveGovernance:
         assert len(unregistered_arg) == 1
         # Same bound method → same underlying dispatcher shutdown.
         assert registered_arg[0] == unregistered_arg[0]
+
+    # ------------------------------------------------------------------
+    # Rego evaluator bootstrap path
+    # ------------------------------------------------------------------
+
+    def _setup_successful_governance(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Common setup for a successful governance bootstrap (no Rego)."""
+        monkeypatch.setattr(
+            "uipath._cli._governance_bootstrap.is_governance_enabled",
+            lambda: True,
+        )
+        _install_fake_runtime_governance(
+            monkeypatch,
+            audit_manager_cls=_FakeAuditManager,
+            metadata_cls=_FakeMetadata,
+            evaluator_cls=_FakeEvaluator,
+            compensator_cls=_FakeCompensator,
+        )
+        _stub_provider(
+            monkeypatch,
+            response_or_exc=_fake_policy_response(
+                mode=EnforcementMode.ENFORCE, policies="rules: []"
+            ),
+        )
+
+    def _stub_rego_module(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        return_value: Any = None,
+        side_effect: Any = None,
+    ) -> None:
+        """Inject a fake ``uipath.runtime.governance.rego`` into sys.modules
+        so the lazy import inside ``resolve_governance`` succeeds.
+        """
+        import sys
+
+        fake_rego = MagicMock()
+        if side_effect is not None:
+            fake_rego.build_rego_evaluator_async = AsyncMock(side_effect=side_effect)
+        else:
+            fake_rego.build_rego_evaluator_async = AsyncMock(return_value=return_value)
+        monkeypatch.setitem(sys.modules, "uipath.runtime.governance.rego", fake_rego)
+
+    async def test_rego_evaluator_populated_when_rego_enabled_and_build_succeeds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        cwd: Path,
+    ) -> None:
+        """When ``is_rego_enabled()`` is ``True`` and
+        ``build_rego_evaluator_async`` returns a non-None evaluator, the
+        bootstrap's ``rego_evaluator`` field must be set to that object.
+        """
+        self._setup_successful_governance(monkeypatch)
+        monkeypatch.setattr(
+            "uipath._cli._governance_bootstrap.is_rego_enabled",
+            lambda: True,
+        )
+        mock_rego_evaluator = MagicMock()
+        mock_rego_evaluator.loaded_hooks = []
+        self._stub_rego_module(monkeypatch, return_value=mock_rego_evaluator)
+
+        result = await resolve_governance(
+            agent_framework="langgraph",
+            agent_type="uipath_coded",
+            is_conversational=False,
+        )
+        assert result is not None
+        try:
+            assert result.rego_evaluator is mock_rego_evaluator
+        finally:
+            result.dispose()
+
+    async def test_rego_evaluator_none_when_rego_enabled_but_build_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        cwd: Path,
+    ) -> None:
+        """When ``build_rego_evaluator_async`` returns ``None`` (e.g. no
+        bundles available), ``rego_evaluator`` must stay ``None`` and
+        governance still succeeds.
+        """
+        self._setup_successful_governance(monkeypatch)
+        monkeypatch.setattr(
+            "uipath._cli._governance_bootstrap.is_rego_enabled",
+            lambda: True,
+        )
+        self._stub_rego_module(monkeypatch, return_value=None)
+
+        result = await resolve_governance(
+            agent_framework="langgraph",
+            agent_type="uipath_coded",
+            is_conversational=False,
+        )
+        assert result is not None
+        try:
+            assert result.rego_evaluator is None
+        finally:
+            result.dispose()
+
+    async def test_rego_evaluator_none_when_build_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        cwd: Path,
+    ) -> None:
+        """Exceptions in ``build_rego_evaluator_async`` must be swallowed —
+        a Rego failure must not crash the bootstrap.  ``rego_evaluator``
+        stays ``None`` and governance returns a valid (non-Rego) bootstrap.
+        """
+        self._setup_successful_governance(monkeypatch)
+        monkeypatch.setattr(
+            "uipath._cli._governance_bootstrap.is_rego_enabled",
+            lambda: True,
+        )
+        self._stub_rego_module(
+            monkeypatch, side_effect=RuntimeError("Rego bundle unavailable")
+        )
+
+        result = await resolve_governance(
+            agent_framework="langgraph",
+            agent_type="uipath_coded",
+            is_conversational=False,
+        )
+        assert result is not None
+        try:
+            assert result.rego_evaluator is None
+        finally:
+            result.dispose()


### PR DESCRIPTION
## Summary

End-to-end plumbing for the Rego/WASM governance evaluator across three packages:

**uipath-core** — wire models + feature flag
- `HookBundle` and `AllPoliciesResponse` Pydantic models for the `/all-policies/{tenant_id}` endpoint, alongside `PolicyResponse`
- `REGO_FEATURE_FLAG = "EnablePythonGovernanceRegoEvaluator"` and `is_rego_enabled()` mirroring the existing `GOVERNANCE_FEATURE_FLAG` / `is_governance_enabled()` pattern exactly

**uipath-platform** — GovernanceService methods
- `retrieve_all_policies()` / `retrieve_all_policies_async()` — GET `/{org}/agenticgovernance_/api/v1/all-policies/{tenant_id}`
- `download_bundle()` / `download_bundle_async()` — plain httpx GET to pre-signed CDN URLs (no platform auth)

**uipath (CLI)** — governance bootstrap wiring
- `GovernanceBootstrap.rego_evaluator` field added
- `wrap_runtime()` passes it to `UiPathGovernedRuntime`
- `resolve_governance()` calls `build_rego_evaluator_async(sdk.governance)` when `is_rego_enabled()` — no background threads, same inline pattern as the native evaluator

## Commits

1. `feat: add Rego wire models and feature flag to core` — uipath-core 0.5.31
2. `feat: add retrieve_all_policies and download_bundle to GovernanceService` — uipath-platform 0.2.7
3. `feat: wire Rego evaluator into governance CLI bootstrap`

## Dependencies

Depends on `UiPath/uipath-runtime-python#feat/rego-evaluator-v2` for `RegoEvaluator` and `build_rego_evaluator_async`.

## Test plan

- [ ] `uv run pytest packages/uipath-platform/tests/services/test_governance_service.py` — 59 tests pass
- [ ] `UIPATH_FEATURE_EnablePythonGovernanceRegoEvaluator=true uipath run agent.py` triggers Rego bootstrap
- [ ] Missing `UIPATH_ORGANIZATION_ID` / `UIPATH_TENANT_ID` → `ValueError` from `retrieve_all_policies`
- [ ] CDN 4xx → `httpx.HTTPStatusError` from `download_bundle`

Generated with Claude Code

## Development Packages

### uipath

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath==2.13.10.dev1018077236",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath>=2.13.10.dev1018070000,<2.13.10.dev1018080000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath = { index = "testpypi" }
uipath-platform = { index = "testpypi" }
uipath-core = { index = "testpypi" }

[tool.uv]
override-dependencies = ["uipath-platform==0.2.7.dev1018077236", "uipath-core==0.5.31.dev1018077236"]
```

### uipath-core

```toml
[project]
dependencies = [
  # Exact version (copy-paste ready):
  "uipath-core==0.5.31.dev1018077236",

  # Any version from this PR (uncomment to use a range instead):
  # "uipath-core>=0.5.31.dev1018070000,<0.5.31.dev1018080000",
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-core = { index = "testpypi" }
```