### PR TITLE
feat(cli): serve the pre-warmed runtime over uipath-ipc alongside HTTP [ROBO-5779]

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
   "uipath-runtime>=0.12.2, <0.13.0",
   "uipath-platform>=0.2.4, <0.3.0",
+  "uipath-ipc>=2.5.1",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",
@@ -171,10 +172,23 @@ exclude-newer = "2 days"
 uipath-core = false
 uipath-runtime = false
 uipath-platform = false
+uipath-ipc = false
 
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }
 uipath-platform = { path = "../uipath-platform", editable = true }
+# uipath-ipc is published to the (anonymously accessible) UiPath-Internal Azure
+# Artifacts feed, not PyPI. Pin it to that index so uv fetches ONLY uipath-ipc
+# there — this avoids a dependency-confusion exposure from a plain extra-index.
+# NOTE: this is uv/dev-and-CI resolution config only (not baked into the wheel);
+# `pip install uipath` from PyPI still needs uipath-ipc to be resolvable
+# (public-PyPI release or an optional extra) — a separate decision.
+uipath-ipc = { index = "uipath-internal" }
+
+[[tool.uv.index]]
+name = "uipath-internal"
+url = "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Internal/pypi/simple/"
+explicit = true
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
   "uipath-runtime>=0.12.2, <0.13.0",
   "uipath-platform>=0.2.4, <0.3.0",
-  "uipath-ipc>=2.5.1",
+  "uipath-ipc>=2.5.1,<2.6.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",
@@ -177,18 +177,7 @@ uipath-ipc = false
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }
 uipath-platform = { path = "../uipath-platform", editable = true }
-# uipath-ipc is published to the (anonymously accessible) UiPath-Internal Azure
-# Artifacts feed, not PyPI. Pin it to that index so uv fetches ONLY uipath-ipc
-# there — this avoids a dependency-confusion exposure from a plain extra-index.
-# NOTE: this is uv/dev-and-CI resolution config only (not baked into the wheel);
-# `pip install uipath` from PyPI still needs uipath-ipc to be resolvable
-# (public-PyPI release or an optional extra) — a separate decision.
-uipath-ipc = { index = "uipath-internal" }
-
-[[tool.uv.index]]
-name = "uipath-internal"
-url = "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Internal/pypi/simple/"
-explicit = true
+# uipath-ipc resolves from public PyPI (published there as of 2.5.2); no index pin.
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -46,6 +46,9 @@ Documentation = "https://uipath.github.io/uipath-python/"
 [project.scripts]
 uipath = "uipath._cli:cli"
 
+[project.optional-dependencies]
+ipc = ["uipath-ipc>=2.5.1,<2.6.0"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
   "uipath-runtime>=0.12.2, <0.13.0",
   "uipath-platform>=0.2.4, <0.3.0",
-  "uipath-ipc>=2.5.1,<2.6.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",
@@ -79,6 +78,7 @@ dev = [
   "types-toml>=0.10.8",
   "types-PyYAML>=6.0",
   "pytest-timeout>=2.4.0",
+  "uipath-ipc>=2.5.1,<2.6.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -177,7 +177,6 @@ uipath-ipc = false
 [tool.uv.sources]
 uipath-core = { path = "../uipath-core", editable = true }
 uipath-platform = { path = "../uipath-platform", editable = true }
-# uipath-ipc resolves from public PyPI (published there as of 2.5.2); no index pin.
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.17"
+version = "2.13.18"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/_server_core.py
+++ b/packages/uipath/src/uipath/_cli/_server_core.py
@@ -1,0 +1,108 @@
+"""Transport-agnostic job core shared by the HTTP and uipath-ipc channels."""
+
+import asyncio
+import os
+import shlex
+from typing import Any
+
+from .cli_debug import debug
+from .cli_eval import eval
+from .cli_run import run
+
+COMMANDS = {
+    "run": run,
+    "debug": debug,
+    "eval": eval,
+}
+
+
+class _ServerState:
+    """Mutable server state, initialized lazily at server startup."""
+
+    def __init__(self) -> None:
+        self.lock: asyncio.Lock | None = None
+        self.baseline_env: dict[str, str] | None = None
+
+    def init(self) -> None:
+        """Must be called inside a running event loop at server startup."""
+        if self.lock is not None:
+            return
+        self.lock = asyncio.Lock()
+        self.baseline_env = os.environ.copy()
+
+
+_state = _ServerState()
+
+
+def parse_args(args: str | list[str] | None) -> list[str]:
+    """Parse args into a list of strings."""
+    if args is None:
+        return []
+    if isinstance(args, list):
+        return args
+    if isinstance(args, str):
+        return shlex.split(args)
+    return []
+
+
+async def _run_command_isolated(
+    cmd: Any,
+    args: list[str],
+    env_vars: dict[str, str],
+    working_dir: str | None,
+) -> dict[str, Any]:
+    """Run one command with per-job env/cwd isolation (the shared job core)."""
+    if _state.lock is None or _state.baseline_env is None:
+        raise RuntimeError("Server state not initialized")
+
+    async with _state.lock:
+        original_cwd = os.getcwd()
+        try:
+            # Start from server baseline + request env vars only, so nothing from
+            # a previous job leaks through.
+            os.environ.clear()
+            os.environ.update(_state.baseline_env)
+            if isinstance(env_vars, dict):
+                os.environ.update(env_vars)
+
+            if working_dir and isinstance(working_dir, str):
+                try:
+                    os.chdir(working_dir)
+                except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+                    # Request-shaped error: the caller gave a bad working dir.
+                    # HTTP surfaces this as 400; IPC just returns ExitCode/Error.
+                    return {
+                        "ExitCode": 1,
+                        "Error": f"Cannot change to working directory: {e}",
+                        "Result": None,
+                        "Unexpected": False,
+                        "ClientError": True,
+                    }
+
+            result_value = await asyncio.to_thread(
+                cmd.main, args, standalone_mode=False
+            )
+            return {
+                "ExitCode": 0,
+                "Error": None,
+                "Result": result_value,
+                "Unexpected": False,
+            }
+        except SystemExit as e:
+            exit_code = e.code if isinstance(e.code, int) else 1
+            return {
+                "ExitCode": exit_code,
+                "Error": None if exit_code == 0 else f"Exit code: {exit_code}",
+                "Result": None,
+                "Unexpected": False,
+            }
+        except Exception as e:  # report any job failure as a result, not a fault
+            return {"ExitCode": 1, "Error": str(e), "Result": None, "Unexpected": True}
+        finally:
+            # Restore to server baseline.
+            try:
+                os.chdir(original_cwd)
+            except OSError:
+                pass
+            os.environ.clear()
+            os.environ.update(_state.baseline_env)

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -6,12 +6,15 @@ import shlex
 import sys
 import tempfile
 import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from importlib.util import find_spec
 from typing import Any
 
 import click
 from aiohttp import ClientSession, UnixConnector, web
+from uipath_ipc import IpcServer, NamedPipeServerTransport
 
 from ._telemetry import track_command
 from ._utils._console import ConsoleLogger
@@ -21,11 +24,11 @@ from .cli_run import run
 
 console = ConsoleLogger()
 
+IS_WINDOWS = sys.platform == "win32"
+
 SOCKET_ENV_VAR = "UIPATH_SERVER_SOCKET"
 DEFAULT_SOCKET_PATH = "/tmp/uipath-server.sock"
 DEFAULT_PORT = 8765
-
-IS_WINDOWS = sys.platform == "win32"
 
 COMMANDS = {
     "run": run,
@@ -97,7 +100,7 @@ def preload_modules() -> None:
 
 
 def generate_socket_path() -> str:
-    """Generate a unique socket path for the server to listen on."""
+    """Generate a unique socket path for the HTTP server to listen on."""
     return os.path.join(tempfile.gettempdir(), f"uipath-server-{os.getpid()}.sock")
 
 
@@ -118,6 +121,71 @@ def parse_args(args: str | list[str] | None) -> list[str]:
     if isinstance(args, str):
         return shlex.split(args)
     return []
+
+
+async def _run_command_isolated(
+    cmd: Any,
+    args: list[str],
+    env_vars: dict[str, str],
+    working_dir: str | None,
+) -> dict[str, Any]:
+    """Run one command with per-job env/cwd isolation (the shared job core)."""
+    if _state.lock is None or _state.baseline_env is None:
+        raise RuntimeError("Server state not initialized")
+
+    async with _state.lock:
+        original_cwd = os.getcwd()
+        try:
+            # Start from server baseline + request env vars only, so nothing from
+            # a previous job leaks through.
+            os.environ.clear()
+            os.environ.update(_state.baseline_env)
+            if isinstance(env_vars, dict):
+                os.environ.update(env_vars)
+
+            if working_dir and isinstance(working_dir, str):
+                try:
+                    os.chdir(working_dir)
+                except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+                    return {
+                        "ExitCode": 1,
+                        "Error": f"Cannot change to working directory: {e}",
+                        "Result": None,
+                        "Unexpected": False,
+                    }
+
+            result_value = await asyncio.to_thread(
+                cmd.main, args, standalone_mode=False
+            )
+            return {
+                "ExitCode": 0,
+                "Error": None,
+                "Result": result_value,
+                "Unexpected": False,
+            }
+        except SystemExit as e:
+            exit_code = e.code if isinstance(e.code, int) else 1
+            return {
+                "ExitCode": exit_code,
+                "Error": None if exit_code == 0 else f"Exit code: {exit_code}",
+                "Result": None,
+                "Unexpected": False,
+            }
+        except Exception as e:  # report any job failure as a result, not a fault
+            return {"ExitCode": 1, "Error": str(e), "Result": None, "Unexpected": True}
+        finally:
+            # Restore to server baseline.
+            try:
+                os.chdir(original_cwd)
+            except OSError:
+                pass
+            os.environ.clear()
+            os.environ.update(_state.baseline_env)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP transport (default) — aiohttp over a Unix socket / TCP, with ready-ACK  #
+# --------------------------------------------------------------------------- #
 
 
 async def send_ack(ack_socket_path: str, server_socket_path: str) -> None:
@@ -150,7 +218,7 @@ async def handle_health(request: web.Request) -> web.Response:
 
 
 async def handle_start(request: web.Request) -> web.Response:
-    """Handle POST /jobs/{job_key}/start endpoint."""
+    """Handle POST /jobs/{job_key}/start — runs a job via the shared core."""
     job_key = request.match_info.get("job_key")
     if not job_key:
         return web.json_response(
@@ -173,28 +241,10 @@ async def handle_start(request: web.Request) -> web.Response:
             status=400,
         )
 
-    args_raw = get_field(message, "args", "Args")
-    args = parse_args(args_raw)
-
+    args = parse_args(get_field(message, "args", "Args"))
     env_vars = get_field(message, "environmentVariables", "EnvironmentVariables") or {}
     working_dir = get_field(message, "workingDirectory", "WorkingDirectory")
 
-    console.info(f"Starting job {job_key}: {command_name} {args}")
-
-    cmd = COMMANDS.get(command_name)
-    if cmd is None:
-        return web.json_response(
-            {"success": False, "error": f"Unknown command: {command_name}"},
-            status=400,
-        )
-
-    console.info(f"Original cwd: {os.getcwd()}")
-    console.info(f"Requested working_dir: {working_dir}")
-
-    if _state.lock is None or _state.baseline_env is None:
-        raise RuntimeError("Server state not initialized")
-
-    # Validate environmentVariables type early
     if env_vars and not isinstance(env_vars, dict):
         return web.json_response(
             {
@@ -204,62 +254,29 @@ async def handle_start(request: web.Request) -> web.Response:
             status=400,
         )
 
-    # Serialize command execution to prevent concurrent os.environ mutation
-    async with _state.lock:
-        original_cwd = os.getcwd()
+    cmd = COMMANDS.get(command_name)
+    if cmd is None:
+        return web.json_response(
+            {"success": False, "error": f"Unknown command: {command_name}"},
+            status=400,
+        )
 
-        try:
-            # Start from server baseline + request env vars only.
-            # This ensures no env vars from previous requests leak through.
-            os.environ.clear()
-            os.environ.update(_state.baseline_env)
-            if isinstance(env_vars, dict):
-                os.environ.update(env_vars)
+    console.info(f"Starting job {job_key}: {command_name} {args}")
 
-            if working_dir and isinstance(working_dir, str):
-                try:
-                    os.chdir(working_dir)
-                except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
-                    return web.json_response(
-                        {
-                            "success": False,
-                            "job_key": job_key,
-                            "error": f"Cannot change to working directory: {e}",
-                        },
-                        status=400,
-                    )
+    result = await _run_command_isolated(cmd, args, env_vars, working_dir)
 
-            result = await asyncio.to_thread(cmd.main, args, standalone_mode=False)
-
-            return web.json_response(
-                {
-                    "success": True,
-                    "job_key": job_key,
-                    "result": result,
-                }
-            )
-        except SystemExit as e:
-            exit_code = e.code if isinstance(e.code, int) else 1
-            return web.json_response(
-                {
-                    "success": exit_code == 0,
-                    "job_key": job_key,
-                    "error": None if exit_code == 0 else f"Exit code: {exit_code}",
-                }
-            )
-        except Exception as e:
-            return web.json_response(
-                {"success": False, "job_key": job_key, "error": str(e)},
-                status=500,
-            )
-        finally:
-            # Restore to server baseline
-            try:
-                os.chdir(original_cwd)
-            except OSError:
-                pass
-            os.environ.clear()
-            os.environ.update(_state.baseline_env)
+    if result["Unexpected"]:
+        return web.json_response(
+            {"success": False, "job_key": job_key, "error": result["Error"]},
+            status=500,
+        )
+    if result["ExitCode"] == 0:
+        return web.json_response(
+            {"success": True, "job_key": job_key, "result": result["Result"]}
+        )
+    return web.json_response(
+        {"success": False, "job_key": job_key, "error": result["Error"]}
+    )
 
 
 ALLOWED_HOSTS = {"127.0.0.1", "localhost", "[::1]"}
@@ -350,29 +367,115 @@ async def start_tcp_server(host: str, port: int) -> None:
         await runner.cleanup()
 
 
+# --------------------------------------------------------------------------- #
+# uipath-ipc transport, served alongside HTTP                                 #
+# Older servers didn't; the Handler copes                                     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class PythonRunRequest:
+    """Mirrors the .NET PythonRunRequest DTO. PascalCase fields match the wire keys."""
+
+    JobKey: str = ""
+    Command: str = ""
+    Args: str | None = None
+    WorkingDirectory: str | None = None
+    EnvironmentVariables: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PythonRunResult:
+    """Mirrors the .NET PythonRunResult DTO."""
+
+    ExitCode: int = 0
+    Error: str | None = None
+
+
+class IPythonRuntimeServer(ABC):
+    """Contract the .NET job executor calls over uipath-ipc."""
+
+    @abstractmethod
+    async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
+        """Run a job → PythonRunResult(ExitCode, Error)."""
+
+    @abstractmethod
+    async def StopJob(self, job_key: str) -> bool:
+        """Cancel a running job by key (bool return avoids fire-and-forget)."""
+
+
+class PythonRuntimeService(IPythonRuntimeServer):
+    """``IPythonRuntimeServer`` implementation backed by run/debug/eval."""
+
+    async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
+        command_name = request.Command
+        if not isinstance(command_name, str) or not command_name:
+            return PythonRunResult(ExitCode=1, Error="Missing or invalid field: 'Command'")
+
+        cmd = COMMANDS.get(command_name)
+        if cmd is None:
+            return PythonRunResult(ExitCode=1, Error=f"Unknown command: {command_name}")
+
+        args = parse_args(request.Args)
+
+        console.info(f"Starting job {request.JobKey}: {command_name} {args}")
+
+        result = await _run_command_isolated(
+            cmd, args, request.EnvironmentVariables, request.WorkingDirectory
+        )
+        # IPC contract (PythonRunResult) carries only ExitCode + Error.
+        return PythonRunResult(ExitCode=result["ExitCode"], Error=result["Error"])
+
+    async def StopJob(self, job_key: str) -> bool:
+        # Cancellation is not wired into the job core yet — accept the request and
+        # no-op so the .NET side gets a clean response. Real cancellation lands here.
+        console.info(f"StopJob requested for {job_key} (no-op)")
+        return True
+
+
+async def start_ipc_server(pipe_name: str) -> None:
+    """Serve the Python runtime over a uipath-ipc named pipe until it is closed."""
+    _state.init()
+    server = IpcServer(
+        transport=NamedPipeServerTransport(pipe_name),
+        services={IPythonRuntimeServer: PythonRuntimeService()},
+        request_timeout=None,  # jobs are long-running; no server-side timeout
+    )
+    console.success(f"IPC server listening on pipe '{pipe_name}'")
+    async with server:
+        await server.serve_forever()
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                         #
+# --------------------------------------------------------------------------- #
+
+
 @click.command()
 @click.option(
     "--client-socket",
     type=str,
     default=None,
-    help=f"Unix socket path to send ready ack to (default: ${SOCKET_ENV_VAR} or {DEFAULT_SOCKET_PATH})",
+    help=f"Unix socket to send the ready ACK to (default: ${SOCKET_ENV_VAR} "
+    f"or {DEFAULT_SOCKET_PATH}).",
 )
 @click.option(
     "--server-socket",
     type=str,
     default=None,
-    help="Unix socket path the server listens on (default: auto-generated in tmp dir)",
+    help="Unix socket the HTTP server listens on; its basename is the uipath-ipc "
+    "pipe name (default: auto-generated in tmp).",
 )
 @click.option(
     "--port",
     type=int,
     default=None,
-    help=f"TCP port, used on Windows or when --tcp flag is set (default: {DEFAULT_PORT})",
+    help=f"TCP port, used on Windows or with --tcp (default: {DEFAULT_PORT}).",
 )
 @click.option(
     "--tcp",
     is_flag=True,
-    help="Force TCP mode even on Unix systems",
+    help="Force TCP mode even on Unix systems.",
 )
 @track_command("server")
 def server(
@@ -381,27 +484,62 @@ def server(
     port: int | None,
     tcp: bool,
 ) -> None:
-    """Start an HTTP server that forwards commands to run/debug/eval.
-
-    Creates its own socket to listen on and sends an ack to --client-socket with:
-    {"status": "ready", "socket": "/path/to/server.sock"}
-
-    Endpoint: POST /jobs/{job_key}/start
-    Body: {"command": "run", "args": "agent.json '{}'", "environmentVariables": {}, "workingDirectory": "/path"}
-
-    Endpoint: GET /health
-    """
-    use_tcp = IS_WINDOWS or tcp
-
+    """Serve run/debug/eval over HTTP, plus uipath-ipc when --server-socket is given."""
     preload_modules()
+    _run_server(client_socket, server_socket, port, tcp)
 
+
+async def _serve(
+    ack_socket_path: str,
+    server_socket: str | None,
+    port: int,
+    use_tcp: bool,
+) -> None:
+    """Run the HTTP channel and, when a server socket is given, the IPC channel too."""
+    _state.init()
+
+    tasks: list[Any] = []
+    if use_tcp:
+        tasks.append(start_tcp_server("127.0.0.1", port))
+    else:
+        tasks.append(start_unix_server(ack_socket_path, server_socket))
+
+    # The IPC pipe name is the HTTP UDS path's basename (directory stripped),
+    # identically to the .NET side (Path.GetFileName) — so the named-pipe transport
+    # resolves it to a socket distinct from the HTTP UDS and the two never collide.
+    if server_socket:
+        pipe_name = os.path.basename(server_socket)
+        tasks.append(start_ipc_server(pipe_name))
+    else:
+        console.warning("--server-socket not provided; serving HTTP only (no IPC channel).")
+
+    await asyncio.gather(*tasks)
+
+
+def _run_server(
+    client_socket: str | None,
+    server_socket: str | None,
+    port: int | None,
+    tcp: bool,
+) -> None:
+    """Drive ``_serve`` on the right event loop for the platform."""
+    use_tcp = IS_WINDOWS or tcp
+    ack_socket_path = (
+        client_socket or os.environ.get(SOCKET_ENV_VAR) or DEFAULT_SOCKET_PATH
+    )
+    coro = _serve(ack_socket_path, server_socket, port or DEFAULT_PORT, use_tcp)
     try:
-        if use_tcp:
-            asyncio.run(start_tcp_server("127.0.0.1", port or DEFAULT_PORT))
+        # Windows named pipes need the Proactor loop; build it explicitly since another
+        # lib (e.g. socketio) may have flipped the policy to Selector. Gate on the
+        # sys.platform literal so mypy narrows ProactorEventLoop (Windows-only) here.
+        if sys.platform == "win32":
+            loop = asyncio.ProactorEventLoop()
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(coro)
+            finally:
+                loop.close()
         else:
-            ack_socket_path = (
-                client_socket or os.environ.get(SOCKET_ENV_VAR) or DEFAULT_SOCKET_PATH
-            )
-            asyncio.run(start_unix_server(ack_socket_path, server_socket))
+            asyncio.run(coro)
     except KeyboardInterrupt:
         console.info("Shutting down")

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -450,7 +450,9 @@ async def _serve(
         pipe_name = os.path.basename(server_socket)
         tasks.append(start_ipc_server(pipe_name))
     else:
-        console.warning("--server-socket not provided; serving HTTP only (no IPC channel).")
+        console.warning(
+            "--server-socket not provided; serving HTTP only (no IPC channel)."
+        )
 
     await asyncio.gather(*tasks)
 

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -6,21 +6,34 @@ import shlex
 import sys
 import tempfile
 import time
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from importlib.util import find_spec
 from typing import Any
 
 import click
 from aiohttp import ClientSession, UnixConnector, web
-from uipath_ipc import IpcServer, NamedPipeServerTransport
 
 from ._telemetry import track_command
 from ._utils._console import ConsoleLogger
 from .cli_debug import debug
 from .cli_eval import eval
 from .cli_run import run
+from .cli_server_ipc import (
+    IPythonRuntimeServer,
+    PythonRunRequest,
+    PythonRunResult,
+    PythonRuntimeService,
+    start_ipc_server,
+)
+
+__all__ = [
+    "server",
+    "IPythonRuntimeServer",
+    "PythonRunRequest",
+    "PythonRunResult",
+    "PythonRuntimeService",
+    "start_ipc_server",
+]
 
 console = ConsoleLogger()
 
@@ -367,83 +380,9 @@ async def start_tcp_server(host: str, port: int) -> None:
         await runner.cleanup()
 
 
-# --------------------------------------------------------------------------- #
-# uipath-ipc transport, served alongside HTTP                                 #
-# Older servers didn't; the Handler copes                                     #
-# --------------------------------------------------------------------------- #
-
-
-@dataclass
-class PythonRunRequest:
-    """Mirrors the .NET PythonRunRequest DTO. PascalCase fields match the wire keys."""
-
-    JobKey: str = ""
-    Command: str = ""
-    Args: str | None = None
-    WorkingDirectory: str | None = None
-    EnvironmentVariables: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass
-class PythonRunResult:
-    """Mirrors the .NET PythonRunResult DTO."""
-
-    ExitCode: int = 0
-    Error: str | None = None
-
-
-class IPythonRuntimeServer(ABC):
-    """Contract the .NET job executor calls over uipath-ipc."""
-
-    @abstractmethod
-    async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
-        """Run a job → PythonRunResult(ExitCode, Error)."""
-
-    @abstractmethod
-    async def StopJob(self, job_key: str) -> bool:
-        """Cancel a running job by key (bool return avoids fire-and-forget)."""
-
-
-class PythonRuntimeService(IPythonRuntimeServer):
-    """``IPythonRuntimeServer`` implementation backed by run/debug/eval."""
-
-    async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
-        command_name = request.Command
-        if not isinstance(command_name, str) or not command_name:
-            return PythonRunResult(ExitCode=1, Error="Missing or invalid field: 'Command'")
-
-        cmd = COMMANDS.get(command_name)
-        if cmd is None:
-            return PythonRunResult(ExitCode=1, Error=f"Unknown command: {command_name}")
-
-        args = parse_args(request.Args)
-
-        console.info(f"Starting job {request.JobKey}: {command_name} {args}")
-
-        result = await _run_command_isolated(
-            cmd, args, request.EnvironmentVariables, request.WorkingDirectory
-        )
-        # IPC contract (PythonRunResult) carries only ExitCode + Error.
-        return PythonRunResult(ExitCode=result["ExitCode"], Error=result["Error"])
-
-    async def StopJob(self, job_key: str) -> bool:
-        # Cancellation is not wired into the job core yet — accept the request and
-        # no-op so the .NET side gets a clean response. Real cancellation lands here.
-        console.info(f"StopJob requested for {job_key} (no-op)")
-        return True
-
-
-async def start_ipc_server(pipe_name: str) -> None:
-    """Serve the Python runtime over a uipath-ipc named pipe until it is closed."""
-    _state.init()
-    server = IpcServer(
-        transport=NamedPipeServerTransport(pipe_name),
-        services={IPythonRuntimeServer: PythonRuntimeService()},
-        request_timeout=None,  # jobs are long-running; no server-side timeout
-    )
-    console.success(f"IPC server listening on pipe '{pipe_name}'")
-    async with server:
-        await server.serve_forever()
+# The uipath-ipc transport (contract, DTOs, service, ``start_ipc_server``) lives
+# in ``cli_server_ipc`` and is served alongside HTTP when ``--server-socket`` is
+# given. Older servers served HTTP only; the .NET Handler copes.
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -2,7 +2,6 @@ import asyncio
 import importlib
 import json
 import os
-import shlex
 import sys
 import tempfile
 import time
@@ -13,11 +12,14 @@ from typing import Any
 import click
 from aiohttp import ClientSession, UnixConnector, web
 
+from ._server_core import (
+    COMMANDS,
+    _run_command_isolated,
+    _state,
+    parse_args,
+)
 from ._telemetry import track_command
 from ._utils._console import ConsoleLogger
-from .cli_debug import debug
-from .cli_eval import eval
-from .cli_run import run
 from .cli_server_ipc import (
     IPythonRuntimeServer,
     PythonRunRequest,
@@ -42,30 +44,6 @@ IS_WINDOWS = sys.platform == "win32"
 SOCKET_ENV_VAR = "UIPATH_SERVER_SOCKET"
 DEFAULT_SOCKET_PATH = "/tmp/uipath-server.sock"
 DEFAULT_PORT = 8765
-
-COMMANDS = {
-    "run": run,
-    "debug": debug,
-    "eval": eval,
-}
-
-
-class _ServerState:
-    """Mutable server state, initialized lazily at server startup."""
-
-    def __init__(self) -> None:
-        self.lock: asyncio.Lock | None = None
-        self.baseline_env: dict[str, str] | None = None
-
-    def init(self) -> None:
-        """Must be called inside a running event loop at server startup."""
-        if self.lock is not None:
-            return
-        self.lock = asyncio.Lock()
-        self.baseline_env = os.environ.copy()
-
-
-_state = _ServerState()
 
 
 DEFAULT_PRELOAD_MODULES = [
@@ -123,80 +101,6 @@ def get_field(message: dict[str, Any], *keys: str) -> Any:
         if key in message:
             return message[key]
     return None
-
-
-def parse_args(args: str | list[str] | None) -> list[str]:
-    """Parse args into a list of strings."""
-    if args is None:
-        return []
-    if isinstance(args, list):
-        return args
-    if isinstance(args, str):
-        return shlex.split(args)
-    return []
-
-
-async def _run_command_isolated(
-    cmd: Any,
-    args: list[str],
-    env_vars: dict[str, str],
-    working_dir: str | None,
-) -> dict[str, Any]:
-    """Run one command with per-job env/cwd isolation (the shared job core)."""
-    if _state.lock is None or _state.baseline_env is None:
-        raise RuntimeError("Server state not initialized")
-
-    async with _state.lock:
-        original_cwd = os.getcwd()
-        try:
-            # Start from server baseline + request env vars only, so nothing from
-            # a previous job leaks through.
-            os.environ.clear()
-            os.environ.update(_state.baseline_env)
-            if isinstance(env_vars, dict):
-                os.environ.update(env_vars)
-
-            if working_dir and isinstance(working_dir, str):
-                try:
-                    os.chdir(working_dir)
-                except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
-                    # Request-shaped error: the caller gave a bad working dir.
-                    # HTTP surfaces this as 400; IPC just returns ExitCode/Error.
-                    return {
-                        "ExitCode": 1,
-                        "Error": f"Cannot change to working directory: {e}",
-                        "Result": None,
-                        "Unexpected": False,
-                        "ClientError": True,
-                    }
-
-            result_value = await asyncio.to_thread(
-                cmd.main, args, standalone_mode=False
-            )
-            return {
-                "ExitCode": 0,
-                "Error": None,
-                "Result": result_value,
-                "Unexpected": False,
-            }
-        except SystemExit as e:
-            exit_code = e.code if isinstance(e.code, int) else 1
-            return {
-                "ExitCode": exit_code,
-                "Error": None if exit_code == 0 else f"Exit code: {exit_code}",
-                "Result": None,
-                "Unexpected": False,
-            }
-        except Exception as e:  # report any job failure as a result, not a fault
-            return {"ExitCode": 1, "Error": str(e), "Result": None, "Unexpected": True}
-        finally:
-            # Restore to server baseline.
-            try:
-                os.chdir(original_cwd)
-            except OSError:
-                pass
-            os.environ.clear()
-            os.environ.update(_state.baseline_env)
 
 
 # --------------------------------------------------------------------------- #
@@ -479,16 +383,9 @@ def _run_server(
     )
     coro = _serve(ack_socket_path, server_socket, port or DEFAULT_PORT, use_tcp)
     try:
-        # Windows named pipes need the Proactor loop; build it explicitly since another
-        # lib (e.g. socketio) may have flipped the policy to Selector. Gate on the
-        # sys.platform literal so mypy narrows ProactorEventLoop (Windows-only) here.
         if sys.platform == "win32":
-            loop = asyncio.ProactorEventLoop()
-            asyncio.set_event_loop(loop)
-            try:
-                loop.run_until_complete(coro)
-            finally:
-                loop.close()
+            with asyncio.Runner(loop_factory=asyncio.ProactorEventLoop) as runner:
+                runner.run(coro)
         else:
             asyncio.run(coro)
     except KeyboardInterrupt:

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -160,11 +160,14 @@ async def _run_command_isolated(
                 try:
                     os.chdir(working_dir)
                 except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+                    # Request-shaped error: the caller gave a bad working dir.
+                    # HTTP surfaces this as 400; IPC just returns ExitCode/Error.
                     return {
                         "ExitCode": 1,
                         "Error": f"Cannot change to working directory: {e}",
                         "Result": None,
                         "Unexpected": False,
+                        "ClientError": True,
                     }
 
             result_value = await asyncio.to_thread(
@@ -282,6 +285,12 @@ async def handle_start(request: web.Request) -> web.Response:
         return web.json_response(
             {"success": False, "job_key": job_key, "error": result["Error"]},
             status=500,
+        )
+    if result.get("ClientError"):
+        # Request-shaped failure (e.g. bad working directory) — 4xx, not 200.
+        return web.json_response(
+            {"success": False, "job_key": job_key, "error": result["Error"]},
+            status=400,
         )
     if result["ExitCode"] == 0:
         return web.json_response(

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -294,8 +294,8 @@ async def start_tcp_server(host: str, port: int) -> None:
 
 
 # The uipath-ipc transport (contract, DTOs, service, ``start_ipc_server``) lives
-# in ``cli_server_ipc`` and is served alongside HTTP when ``--server-socket`` is
-# given. Older servers served HTTP only; the .NET Handler copes.
+# in ``cli_server_ipc`` and is served alongside HTTP when ``--ipc-pipe`` is given.
+# Older servers served HTTP only; the .NET Handler copes.
 
 
 # --------------------------------------------------------------------------- #
@@ -315,8 +315,14 @@ async def start_tcp_server(host: str, port: int) -> None:
     "--server-socket",
     type=str,
     default=None,
-    help="Unix socket the HTTP server listens on; its basename is the uipath-ipc "
-    "pipe name (default: auto-generated in tmp).",
+    help="Unix socket the HTTP server listens on (default: auto-generated in tmp).",
+)
+@click.option(
+    "--ipc-pipe",
+    type=str,
+    default=None,
+    help="Named pipe for the uipath-ipc channel. IPC is served only when this is "
+    "given; omit it for HTTP-only.",
 )
 @click.option(
     "--port",
@@ -333,21 +339,23 @@ async def start_tcp_server(host: str, port: int) -> None:
 def server(
     client_socket: str | None,
     server_socket: str | None,
+    ipc_pipe: str | None,
     port: int | None,
     tcp: bool,
 ) -> None:
-    """Serve run/debug/eval over HTTP, plus uipath-ipc when --server-socket is given."""
+    """Serve run/debug/eval over HTTP, plus uipath-ipc when --ipc-pipe is given."""
     preload_modules()
-    _run_server(client_socket, server_socket, port, tcp)
+    _run_server(client_socket, server_socket, ipc_pipe, port, tcp)
 
 
 async def _serve(
     ack_socket_path: str,
     server_socket: str | None,
+    ipc_pipe: str | None,
     port: int,
     use_tcp: bool,
 ) -> None:
-    """Run the HTTP channel and, when a server socket is given, the IPC channel too."""
+    """Run the HTTP channel, plus the uipath-ipc channel when a pipe name is given."""
     _state.init()
 
     tasks: list[Any] = []
@@ -356,16 +364,11 @@ async def _serve(
     else:
         tasks.append(start_unix_server(ack_socket_path, server_socket))
 
-    # The IPC pipe name is the HTTP UDS path's basename (directory stripped),
-    # identically to the .NET side (Path.GetFileName) — so the named-pipe transport
-    # resolves it to a socket distinct from the HTTP UDS and the two never collide.
-    if server_socket:
-        pipe_name = os.path.basename(server_socket)
-        tasks.append(start_ipc_server(pipe_name))
-    else:
-        console.warning(
-            "--server-socket not provided; serving HTTP only (no IPC channel)."
-        )
+    # IPC is opt-in and independent of the HTTP socket: it is served only when an
+    # explicit pipe name is given, which both sides agree on out of band (the .NET
+    # peer connects to the same name it passed — no derivation from the HTTP socket).
+    if ipc_pipe:
+        tasks.append(start_ipc_server(ipc_pipe))
 
     await asyncio.gather(*tasks)
 
@@ -373,6 +376,7 @@ async def _serve(
 def _run_server(
     client_socket: str | None,
     server_socket: str | None,
+    ipc_pipe: str | None,
     port: int | None,
     tcp: bool,
 ) -> None:
@@ -381,7 +385,9 @@ def _run_server(
     ack_socket_path = (
         client_socket or os.environ.get(SOCKET_ENV_VAR) or DEFAULT_SOCKET_PATH
     )
-    coro = _serve(ack_socket_path, server_socket, port or DEFAULT_PORT, use_tcp)
+    coro = _serve(
+        ack_socket_path, server_socket, ipc_pipe, port or DEFAULT_PORT, use_tcp
+    )
     try:
         if sys.platform == "win32":
             with asyncio.Runner(loop_factory=asyncio.ProactorEventLoop) as runner:

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -162,10 +162,10 @@ async def handle_start(request: web.Request) -> web.Response:
         )
 
     args = parse_args(get_field(message, "args", "Args"))
-    env_vars = get_field(message, "environmentVariables", "EnvironmentVariables") or {}
+    env_vars = get_field(message, "environmentVariables", "EnvironmentVariables")
     working_dir = get_field(message, "workingDirectory", "WorkingDirectory")
 
-    if env_vars and not isinstance(env_vars, dict):
+    if env_vars is not None and not isinstance(env_vars, dict):
         return web.json_response(
             {
                 "success": False,
@@ -173,6 +173,7 @@ async def handle_start(request: web.Request) -> web.Response:
             },
             status=400,
         )
+    env_vars = env_vars or {}
 
     cmd = COMMANDS.get(command_name)
     if cmd is None:

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -1,0 +1,100 @@
+"""uipath-ipc runtime transport — the IPC contract, DTOs, and service.
+
+Split out from ``cli_server`` so the wire-dictated PascalCase names (methods and
+DTO fields) live in one file. Their casing is forced by the .NET/CoreIpc peer:
+the serializer maps method and field names verbatim (no alias mechanism), so
+they cannot be Python-idiomatic without breaking interop. The Sonar naming
+rules (python:S100 methods, python:S116 fields) are suppressed for this file
+only (see ``sonar-project.properties``), keeping the rest of the tree strict.
+
+Served alongside the HTTP channel by ``cli_server`` whenever a ``--server-socket``
+is given. Older servers served HTTP only; the .NET Handler copes.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from uipath_ipc import IpcServer, NamedPipeServerTransport
+
+from ._utils._console import ConsoleLogger
+
+console = ConsoleLogger()
+
+
+@dataclass
+class PythonRunRequest:
+    """Mirrors the .NET PythonRunRequest DTO. PascalCase fields match the wire keys."""
+
+    JobKey: str = ""
+    Command: str = ""
+    Args: str | None = None
+    WorkingDirectory: str | None = None
+    EnvironmentVariables: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PythonRunResult:
+    """Mirrors the .NET PythonRunResult DTO."""
+
+    ExitCode: int = 0
+    Error: str | None = None
+
+
+class IPythonRuntimeServer(ABC):
+    """Contract the .NET job executor calls over uipath-ipc."""
+
+    @abstractmethod
+    async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
+        """Run a job → PythonRunResult(ExitCode, Error)."""
+
+    @abstractmethod
+    async def StopJob(self, job_key: str) -> bool:
+        """Cancel a running job by key (bool return avoids fire-and-forget)."""
+
+
+class PythonRuntimeService(IPythonRuntimeServer):
+    """``IPythonRuntimeServer`` implementation backed by run/debug/eval."""
+
+    async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
+        # Imported here (not at module top) to keep the job core one-directional:
+        # cli_server imports this module, so this module reaches back lazily.
+        from .cli_server import COMMANDS, _run_command_isolated, parse_args
+
+        command_name = request.Command
+        if not isinstance(command_name, str) or not command_name:
+            return PythonRunResult(ExitCode=1, Error="Missing or invalid field: 'Command'")
+
+        cmd = COMMANDS.get(command_name)
+        if cmd is None:
+            return PythonRunResult(ExitCode=1, Error=f"Unknown command: {command_name}")
+
+        args = parse_args(request.Args)
+
+        console.info(f"Starting job {request.JobKey}: {command_name} {args}")
+
+        result = await _run_command_isolated(
+            cmd, args, request.EnvironmentVariables, request.WorkingDirectory
+        )
+        # IPC contract (PythonRunResult) carries only ExitCode + Error.
+        return PythonRunResult(ExitCode=result["ExitCode"], Error=result["Error"])
+
+    async def StopJob(self, job_key: str) -> bool:
+        # Cancellation is not wired into the job core yet — accept the request and
+        # no-op so the .NET side gets a clean response. Real cancellation lands here.
+        console.info(f"StopJob requested for {job_key} (no-op)")
+        return True
+
+
+async def start_ipc_server(pipe_name: str) -> None:
+    """Serve the Python runtime over a uipath-ipc named pipe until it is closed."""
+    from .cli_server import _state
+
+    _state.init()
+    server = IpcServer(
+        transport=NamedPipeServerTransport(pipe_name),
+        services={IPythonRuntimeServer: PythonRuntimeService()},
+        request_timeout=None,  # jobs are long-running; no server-side timeout
+    )
+    console.success(f"IPC server listening on pipe '{pipe_name}'")
+    async with server:
+        await server.serve_forever()

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -62,7 +62,9 @@ class PythonRuntimeService(IPythonRuntimeServer):
 
         command_name = request.Command
         if not isinstance(command_name, str) or not command_name:
-            return PythonRunResult(ExitCode=1, Error="Missing or invalid field: 'Command'")
+            return PythonRunResult(
+                ExitCode=1, Error="Missing or invalid field: 'Command'"
+            )
 
         cmd = COMMANDS.get(command_name)
         if cmd is None:

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -1,14 +1,8 @@
 """uipath-ipc runtime transport — the IPC contract, DTOs, and service.
 
-Split out from ``cli_server`` so the wire-dictated PascalCase names (methods and
-DTO fields) live in one file. Their casing is forced by the .NET/CoreIpc peer:
-the serializer maps method and field names verbatim (no alias mechanism), so
-they cannot be Python-idiomatic without breaking interop. The Sonar naming
-rules (python:S100 methods, python:S116 fields) are suppressed for this file
-only (see ``sonar-project.properties``), keeping the rest of the tree strict.
-
-Served alongside the HTTP channel by ``cli_server`` whenever a ``--server-socket``
-is given. Older servers served HTTP only; the .NET Handler copes.
+The PascalCase method and field names are dictated by the .NET/CoreIpc peer
+(the serializer maps them verbatim), so Sonar's S100/S116 naming rules are
+suppressed for this file only (see ``sonar-project.properties``).
 """
 
 from abc import ABC, abstractmethod
@@ -16,6 +10,7 @@ from dataclasses import dataclass, field
 
 from uipath_ipc import IpcServer, NamedPipeServerTransport
 
+from ._server_core import COMMANDS, _run_command_isolated, _state, parse_args
 from ._utils._console import ConsoleLogger
 
 console = ConsoleLogger()
@@ -58,10 +53,6 @@ class PythonRuntimeService(IPythonRuntimeServer):
     """``IPythonRuntimeServer`` implementation backed by run/debug/eval."""
 
     async def StartJob(self, request: PythonRunRequest) -> PythonRunResult:
-        # Imported here (not at module top) to keep the job core one-directional:
-        # cli_server imports this module, so this module reaches back lazily.
-        from .cli_server import COMMANDS, _run_command_isolated, parse_args
-
         command_name = request.Command
         if not isinstance(command_name, str) or not command_name:
             return PythonRunResult(
@@ -91,8 +82,6 @@ class PythonRuntimeService(IPythonRuntimeServer):
 
 async def start_ipc_server(pipe_name: str) -> None:
     """Serve the Python runtime over a uipath-ipc named pipe until it is closed."""
-    from .cli_server import _state
-
     _state.init()
     server = IpcServer(
         transport=NamedPipeServerTransport(pipe_name),

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -77,8 +77,6 @@ class PythonRuntimeService(IPythonRuntimeServer):
         return PythonRunResult(ExitCode=result["ExitCode"], Error=result["Error"])
 
     async def StopJob(self, job_key: str) -> bool:
-        # Cancellation is not wired into the job core yet — accept the request and
-        # no-op so the .NET side gets a clean response. Real cancellation lands here.
         console.info(f"StopJob requested for {job_key} (no-op)")
         return True
 

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -4,9 +4,10 @@ The PascalCase method and field names are dictated by the .NET/CoreIpc peer
 (the serializer maps them verbatim), so Sonar's S100/S116 naming rules are
 suppressed for this file only (see ``sonar-project.properties``).
 
-``uipath-ipc`` is an optional runtime dependency: it is imported lazily inside
-``start_ipc_server`` so this module — and HTTP-only serving — works without it.
-The DTOs and the contract below are pure stdlib and never reference it.
+``uipath-ipc`` is an optional dependency (the ``ipc`` extra): it is imported
+lazily inside ``start_ipc_server`` so this module — and HTTP-only serving —
+works without it. The DTOs and the contract below are pure stdlib and never
+reference it.
 """
 
 from abc import ABC, abstractmethod
@@ -89,8 +90,8 @@ async def start_ipc_server(pipe_name: str) -> None:
     except ImportError as e:
         raise RuntimeError(
             "The uipath-ipc channel was requested (--ipc-pipe) but the 'uipath-ipc' "
-            "package is not installed in this environment. Install uipath-ipc, or omit "
-            "--ipc-pipe to serve HTTP only."
+            "package is not installed in this environment. Install it (pip install "
+            "'uipath[ipc]') or omit --ipc-pipe to serve HTTP only."
         ) from e
 
     _state.init()

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -27,7 +27,9 @@ class PythonRunRequest:
 
     JobKey: str = ""
     Command: str = ""
-    Args: str | None = None
+    # The .NET peer sends a single string; HTTP callers and tests may pass a
+    # pre-split list. parse_args accepts both.
+    Args: str | list[str] | None = None
     WorkingDirectory: str | None = None
     EnvironmentVariables: dict[str, str] = field(default_factory=dict)
 

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -3,12 +3,14 @@
 The PascalCase method and field names are dictated by the .NET/CoreIpc peer
 (the serializer maps them verbatim), so Sonar's S100/S116 naming rules are
 suppressed for this file only (see ``sonar-project.properties``).
+
+``uipath-ipc`` is an optional runtime dependency: it is imported lazily inside
+``start_ipc_server`` so this module — and HTTP-only serving — works without it.
+The DTOs and the contract below are pure stdlib and never reference it.
 """
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-
-from uipath_ipc import IpcServer, NamedPipeServerTransport
 
 from ._server_core import COMMANDS, _run_command_isolated, _state, parse_args
 from ._utils._console import ConsoleLogger
@@ -82,6 +84,15 @@ class PythonRuntimeService(IPythonRuntimeServer):
 
 async def start_ipc_server(pipe_name: str) -> None:
     """Serve the Python runtime over a uipath-ipc named pipe until it is closed."""
+    try:
+        from uipath_ipc import IpcServer, NamedPipeServerTransport
+    except ImportError as e:
+        raise RuntimeError(
+            "The uipath-ipc channel was requested (--ipc-pipe) but the 'uipath-ipc' "
+            "package is not installed in this environment. Install uipath-ipc, or omit "
+            "--ipc-pipe to serve HTTP only."
+        ) from e
+
     _state.init()
     server = IpcServer(
         transport=NamedPipeServerTransport(pipe_name),

--- a/packages/uipath/tests/cli/test_server.py
+++ b/packages/uipath/tests/cli/test_server.py
@@ -358,21 +358,21 @@ class TestServerEnvIsolation:
         """Start server with a spy command that captures os.environ."""
         import click
 
-        from uipath._cli import cli_server
+        from uipath._cli import _server_core
 
         @click.command()
         def spy_cmd():
             env_snapshots.append(dict(os.environ))
 
-        original_commands = cli_server.COMMANDS.copy()
-        cli_server.COMMANDS["spy"] = spy_cmd
+        original_commands = _server_core.COMMANDS.copy()
+        _server_core.COMMANDS["spy"] = spy_cmd
 
         start_cli_server_thread(server_port)
 
         yield server_port
 
-        cli_server.COMMANDS.clear()
-        cli_server.COMMANDS.update(original_commands)
+        _server_core.COMMANDS.clear()
+        _server_core.COMMANDS.update(original_commands)
 
     def test_env_vars_do_not_leak_between_requests(
         self, server_with_spy, env_snapshots
@@ -417,7 +417,7 @@ class TestServerEnvIsolation:
 
     def test_server_baseline_env_preserved(self, server_with_spy, env_snapshots):
         """Server baseline env vars (like PATH) should be available during command execution."""
-        from uipath._cli import cli_server
+        from uipath._cli import _server_core
 
         port = server_with_spy
 
@@ -435,7 +435,7 @@ class TestServerEnvIsolation:
         env_run = env_snapshots[0]
 
         # Baseline is captured at server start, not import time
-        baseline = cli_server._state.baseline_env
+        baseline = _server_core._state.baseline_env
         assert baseline is not None
 
         # Baseline env vars should be present
@@ -446,7 +446,7 @@ class TestServerEnvIsolation:
 
     def test_env_restored_after_request(self, server_with_spy):
         """os.environ should be restored to baseline after each request."""
-        from uipath._cli import cli_server
+        from uipath._cli import _server_core
 
         port = server_with_spy
 
@@ -460,7 +460,7 @@ class TestServerEnvIsolation:
             )
         )
 
-        baseline = cli_server._state.baseline_env
+        baseline = _server_core._state.baseline_env
         assert baseline is not None
 
         # After the request, os.environ should match baseline

--- a/packages/uipath/tests/cli/test_server.py
+++ b/packages/uipath/tests/cli/test_server.py
@@ -147,6 +147,27 @@ class TestServer:
         assert response["success"] is False
         assert "Unknown command" in response["error"]
 
+    def test_bad_working_directory_returns_400(self, server):
+        """A request-shaped error (bad working dir) is a 4xx, not a 200."""
+        port = server
+
+        async def send():
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"http://127.0.0.1:{port}/jobs/job-bad-cwd/start",
+                    json={
+                        "command": "run",
+                        "args": [],
+                        "workingDirectory": "/no/such/dir/xyz-does-not-exist",
+                    },
+                ) as response:
+                    return response.status, await response.json()
+
+        status, body = asyncio.run(send())
+        assert status == 400
+        assert body["success"] is False
+        assert "working directory" in body["error"]
+
     def test_start_job_missing_command(self, server):
         """Test starting a job without command field."""
         port = server

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -63,13 +63,16 @@ async def _with_proxy(pipe_name: str, fn: Callable[[Any], Awaitable[Any]]) -> An
     """Connect a uipath-ipc client to the pipe, run ``fn(proxy)``, then close."""
     client = IpcClient(transport=NamedPipeClientTransport(pipe_name))
     try:
-        proxy = client.get_proxy(IPythonRuntimeServer)
+        # get_proxy is by-contract; the abstract interface is exactly what it wants.
+        proxy = client.get_proxy(IPythonRuntimeServer)  # type: ignore[type-abstract]
         return await fn(proxy)
     finally:
         await client.aclose()
 
 
-def create_uipath_json(script_path: str, entrypoint_name: str = "main") -> dict:
+def create_uipath_json(
+    script_path: str, entrypoint_name: str = "main"
+) -> dict[str, Any]:
     return {"functions": {entrypoint_name: f"{script_path}:main"}}
 
 

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -1,0 +1,181 @@
+"""Tests for the uipath-ipc runtime server channel.
+
+The server always hosts ``IPythonRuntimeServer`` (StartJob / StopJob) on a named
+pipe alongside the HTTP channel when a ``--server-socket`` is given (see
+``test_server_transport.py`` for the channel composition). Mirrors
+``test_server.py`` (the HTTP path) but drives the pipe with a Python
+``uipath-ipc`` client.
+
+Requires ``uipath-ipc`` to be installed. ``StartJob`` success runs the real
+runtime (like ``test_server.test_start_job_success``); the rest exercise the IPC
+wiring and env isolation without it.
+"""
+
+import asyncio
+import json
+import os
+import threading
+import time
+from typing import Any, Awaitable, Callable
+
+import click
+import pytest
+from uipath_ipc import IpcClient, NamedPipeClientTransport
+
+from uipath._cli import cli_server
+from uipath._cli.cli_server import (
+    IPythonRuntimeServer,
+    start_ipc_server,
+)
+
+_pipe_counter = 0
+
+
+def _unique_pipe() -> str:
+    global _pipe_counter
+    _pipe_counter += 1
+    return f"uipath-ipc-test-{os.getpid()}-{_pipe_counter}"
+
+
+def _serve_in_background(pipe_name: str) -> None:
+    """Run the IPC server on its own event loop in a daemon thread.
+
+    ``asyncio.new_event_loop()`` yields the per-OS default loop — Proactor on
+    Windows (required for named pipes), Selector on Linux (CoreFxPipe UDS).
+    """
+
+    def run_server() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(start_ipc_server(pipe_name))
+        except asyncio.CancelledError:
+            pass
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=run_server, daemon=True)
+    thread.start()
+    time.sleep(0.5)
+
+
+async def _with_proxy(pipe_name: str, fn: Callable[[Any], Awaitable[Any]]) -> Any:
+    """Connect a uipath-ipc client to the pipe, run ``fn(proxy)``, then close."""
+    client = IpcClient(transport=NamedPipeClientTransport(pipe_name))
+    try:
+        proxy = client.get_proxy(IPythonRuntimeServer)
+        return await fn(proxy)
+    finally:
+        await client.aclose()
+
+
+def create_uipath_json(script_path: str, entrypoint_name: str = "main") -> dict:
+    return {"functions": {entrypoint_name: f"{script_path}:main"}}
+
+
+SIMPLE_SCRIPT = """
+from dataclasses import dataclass
+
+@dataclass
+class Input:
+    message: str
+    repeat: int = 1
+
+def main(input: Input) -> str:
+    return (input.message + " ") * input.repeat
+"""
+
+
+class TestIpcServer:
+    @pytest.fixture
+    def pipe(self):
+        pipe_name = _unique_pipe()
+        _serve_in_background(pipe_name)
+        # Daemon thread; the server blocks in serve_forever and is torn down when
+        # the process exits (mirrors test_server.py's background HTTP server).
+        yield pipe_name
+
+    def test_start_job_success(self, pipe, temp_dir):
+        """A real 'run' job executes and writes output.json (needs the runtime)."""
+        script_file = "entrypoint.py"
+        with open(os.path.join(temp_dir, script_file), "w") as f:
+            f.write(SIMPLE_SCRIPT)
+        with open(os.path.join(temp_dir, "uipath.json"), "w") as f:
+            json.dump(create_uipath_json(script_file), f)
+
+        input_file = os.path.join(temp_dir, "input.json")
+        with open(input_file, "w") as f:
+            json.dump({"message": "Hello", "repeat": 3}, f)
+        output_file = os.path.join(temp_dir, "output.json")
+
+        request = {
+            "JobKey": "job-123",
+            "Command": "run",
+            "Args": ["main", "--input-file", input_file, "--output-file", output_file],
+            "WorkingDirectory": temp_dir,
+            "EnvironmentVariables": {},
+        }
+        result = asyncio.run(_with_proxy(pipe, lambda p: p.StartJob(request)))
+
+        assert result.ExitCode == 0
+        assert result.Error is None
+        assert os.path.exists(output_file)
+        with open(output_file, "r") as f:
+            assert "Hello" in f.read()
+
+    def test_start_job_unknown_command(self, pipe):
+        request = {"JobKey": "job-1", "Command": "does_not_exist"}
+        result = asyncio.run(_with_proxy(pipe, lambda p: p.StartJob(request)))
+        assert result.ExitCode != 0
+        assert "Unknown command" in (result.Error or "")
+
+
+class TestIpcServerEnvIsolation:
+    """Env vars must not leak between sequential jobs (as on the HTTP path)."""
+
+    @pytest.fixture
+    def pipe_with_spy(self):
+        env_snapshots: list[dict[str, str]] = []
+
+        @click.command()
+        def spy_cmd() -> None:
+            env_snapshots.append(dict(os.environ))
+
+        original = cli_server.COMMANDS.copy()
+        cli_server.COMMANDS["spy"] = spy_cmd
+
+        pipe_name = _unique_pipe()
+        _serve_in_background(pipe_name)
+        try:
+            yield pipe_name, env_snapshots
+        finally:
+            cli_server.COMMANDS.clear()
+            cli_server.COMMANDS.update(original)
+
+    def test_env_vars_do_not_leak_between_jobs(self, pipe_with_spy):
+        pipe_name, env_snapshots = pipe_with_spy
+
+        async def run_two(proxy: Any) -> None:
+            await proxy.StartJob(
+                {
+                    "JobKey": "job-1",
+                    "Command": "spy",
+                    "EnvironmentVariables": {"TEST_VAR_A": "a"},
+                }
+            )
+            await proxy.StartJob(
+                {
+                    "JobKey": "job-2",
+                    "Command": "spy",
+                    "EnvironmentVariables": {"TEST_VAR_B": "b"},
+                }
+            )
+
+        asyncio.run(_with_proxy(pipe_name, run_two))
+
+        assert len(env_snapshots) == 2
+        run1, run2 = env_snapshots
+        assert run1["TEST_VAR_A"] == "a"
+        assert "TEST_VAR_B" not in run1
+        assert run2["TEST_VAR_B"] == "b"
+        assert "TEST_VAR_A" not in run2

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -129,6 +129,19 @@ class TestIpcServer:
         assert result.ExitCode != 0
         assert "Unknown command" in (result.Error or "")
 
+    def test_start_job_missing_command(self, pipe):
+        """Absent/empty Command is rejected before the job core is touched."""
+        result = asyncio.run(
+            _with_proxy(pipe, lambda p: p.StartJob({"JobKey": "job-1"}))
+        )
+        assert result.ExitCode != 0
+        assert "Command" in (result.Error or "")
+
+    def test_stop_job_returns_true(self, pipe):
+        """StopJob is a no-op stub today, but must ack (bool) so the call is awaitable."""
+        result = asyncio.run(_with_proxy(pipe, lambda p: p.StopJob("job-1")))
+        assert result is True
+
 
 class TestIpcServerEnvIsolation:
     """Env vars must not leak between sequential jobs (as on the HTTP path)."""

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -22,7 +22,7 @@ import click
 import pytest
 from uipath_ipc import IpcClient, NamedPipeClientTransport
 
-from uipath._cli import cli_server
+from uipath._cli import _server_core
 from uipath._cli.cli_server import (
     IPythonRuntimeServer,
     start_ipc_server,
@@ -177,16 +177,16 @@ class TestIpcServerEnvIsolation:
         def spy_cmd() -> None:
             env_snapshots.append(dict(os.environ))
 
-        original = cli_server.COMMANDS.copy()
-        cli_server.COMMANDS["spy"] = spy_cmd
+        original = _server_core.COMMANDS.copy()
+        _server_core.COMMANDS["spy"] = spy_cmd
 
         pipe_name = _unique_pipe()
         _serve_in_background(pipe_name)
         try:
             yield pipe_name, env_snapshots
         finally:
-            cli_server.COMMANDS.clear()
-            cli_server.COMMANDS.update(original)
+            _server_core.COMMANDS.clear()
+            _server_core.COMMANDS.update(original)
 
     def test_env_vars_do_not_leak_between_jobs(self, pipe_with_spy):
         pipe_name, env_snapshots = pipe_with_spy

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -1,7 +1,7 @@
 """Tests for the uipath-ipc runtime server channel.
 
-The server always hosts ``IPythonRuntimeServer`` (StartJob / StopJob) on a named
-pipe alongside the HTTP channel when a ``--server-socket`` is given (see
+The server hosts ``IPythonRuntimeServer`` (StartJob / StopJob) on a named pipe
+alongside the HTTP channel when ``--ipc-pipe`` names one (see
 ``test_server_transport.py`` for the channel composition). Mirrors
 ``test_server.py`` (the HTTP path) but drives the pipe with a Python
 ``uipath-ipc`` client.

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -113,8 +113,9 @@ def main(input: Input) -> str:
 def test_start_ipc_server_fails_fast_without_uipath_ipc(monkeypatch):
     """--ipc-pipe with uipath-ipc absent must fail loudly, not silently no-op."""
     monkeypatch.setitem(sys.modules, "uipath_ipc", None)
+    coro = start_ipc_server(_unique_pipe())
     with pytest.raises(RuntimeError, match="uipath-ipc"):
-        asyncio.run(start_ipc_server(_unique_pipe()))
+        asyncio.run(coro)
 
 
 class TestIpcServer:

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -14,6 +14,7 @@ wiring and env isolation without it.
 import asyncio
 import json
 import os
+import sys
 import threading
 import time
 from typing import Any, Awaitable, Callable
@@ -107,6 +108,13 @@ class Input:
 def main(input: Input) -> str:
     return (input.message + " ") * input.repeat
 """
+
+
+def test_start_ipc_server_fails_fast_without_uipath_ipc(monkeypatch):
+    """--ipc-pipe with uipath-ipc absent must fail loudly, not silently no-op."""
+    monkeypatch.setitem(sys.modules, "uipath_ipc", None)
+    with pytest.raises(RuntimeError, match="uipath-ipc"):
+        asyncio.run(start_ipc_server(_unique_pipe()))
 
 
 class TestIpcServer:

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -56,7 +56,7 @@ def _serve_in_background(pipe_name: str) -> None:
 
     thread = threading.Thread(target=run_server, daemon=True)
     thread.start()
-    time.sleep(0.5)
+    _wait_until_ready(pipe_name)
 
 
 async def _with_proxy(pipe_name: str, fn: Callable[[Any], Awaitable[Any]]) -> Any:
@@ -68,6 +68,26 @@ async def _with_proxy(pipe_name: str, fn: Callable[[Any], Awaitable[Any]]) -> An
         return await fn(proxy)
     finally:
         await client.aclose()
+
+
+def _wait_until_ready(pipe_name: str, timeout: float = 10.0) -> None:
+    """Poll the pipe until the IPC server answers, instead of a fixed sleep.
+
+    A fixed ``sleep`` races the server's startup under load; this connects a real
+    client and calls the no-op ``StopJob`` until it succeeds (or times out).
+    """
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            asyncio.run(_with_proxy(pipe_name, lambda p: p.StopJob("readiness-probe")))
+            return
+        except Exception as e:  # server not accepting connections yet
+            last_err = e
+            time.sleep(0.05)
+    raise TimeoutError(
+        f"IPC server on pipe {pipe_name!r} not ready within {timeout}s: {last_err}"
+    )
 
 
 def create_uipath_json(

--- a/packages/uipath/tests/cli/test_server_job_core.py
+++ b/packages/uipath/tests/cli/test_server_job_core.py
@@ -1,0 +1,67 @@
+"""Unit tests for ``_run_command_isolated`` — the shared job core behind both the
+HTTP and uipath-ipc channels. These drive its error branches directly (bad
+working dir, SystemExit, unexpected exception, uninitialized state) without
+standing up a transport, so they run fast on every OS/Python.
+"""
+
+import asyncio
+import os
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from uipath._cli import cli_server
+
+
+@pytest.fixture
+def restore_state():
+    """Save/restore the module-level _ServerState singleton around a test."""
+    saved_lock = cli_server._state.lock
+    saved_env = cli_server._state.baseline_env
+    try:
+        yield cli_server._state
+    finally:
+        cli_server._state.lock = saved_lock
+        cli_server._state.baseline_env = saved_env
+
+
+def _init(state: Any) -> None:
+    state.lock = asyncio.Lock()
+    state.baseline_env = dict(os.environ)
+
+
+async def test_requires_initialized_state(restore_state: Any) -> None:
+    restore_state.lock = None
+    restore_state.baseline_env = None
+    cmd = Mock()
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await cli_server._run_command_isolated(cmd, [], {}, None)
+
+
+async def test_rejects_bad_working_dir(restore_state: Any, tmp_path: Any) -> None:
+    _init(restore_state)
+    missing = str(tmp_path / "does-not-exist")
+    result = await cli_server._run_command_isolated(Mock(), [], {}, missing)
+    assert result["ExitCode"] == 1
+    assert "working directory" in result["Error"]
+    assert result["Unexpected"] is False
+
+
+async def test_maps_system_exit_code(restore_state: Any) -> None:
+    _init(restore_state)
+    cmd = Mock()
+    cmd.main.side_effect = SystemExit(2)
+    result = await cli_server._run_command_isolated(cmd, [], {}, None)
+    assert result["ExitCode"] == 2
+    assert result["Unexpected"] is False
+
+
+async def test_reports_unexpected_exception(restore_state: Any) -> None:
+    _init(restore_state)
+    cmd = Mock()
+    cmd.main.side_effect = ValueError("boom")
+    result = await cli_server._run_command_isolated(cmd, [], {}, None)
+    assert result["ExitCode"] == 1
+    assert result["Unexpected"] is True
+    assert "boom" in result["Error"]

--- a/packages/uipath/tests/cli/test_server_job_core.py
+++ b/packages/uipath/tests/cli/test_server_job_core.py
@@ -11,19 +11,19 @@ from unittest.mock import Mock
 
 import pytest
 
-from uipath._cli import cli_server
+from uipath._cli import _server_core
 
 
 @pytest.fixture
 def restore_state():
     """Save/restore the module-level _ServerState singleton around a test."""
-    saved_lock = cli_server._state.lock
-    saved_env = cli_server._state.baseline_env
+    saved_lock = _server_core._state.lock
+    saved_env = _server_core._state.baseline_env
     try:
-        yield cli_server._state
+        yield _server_core._state
     finally:
-        cli_server._state.lock = saved_lock
-        cli_server._state.baseline_env = saved_env
+        _server_core._state.lock = saved_lock
+        _server_core._state.baseline_env = saved_env
 
 
 def _init(state: Any) -> None:
@@ -36,13 +36,13 @@ async def test_requires_initialized_state(restore_state: Any) -> None:
     restore_state.baseline_env = None
     cmd = Mock()
     with pytest.raises(RuntimeError, match="not initialized"):
-        await cli_server._run_command_isolated(cmd, [], {}, None)
+        await _server_core._run_command_isolated(cmd, [], {}, None)
 
 
 async def test_rejects_bad_working_dir(restore_state: Any, tmp_path: Any) -> None:
     _init(restore_state)
     missing = str(tmp_path / "does-not-exist")
-    result = await cli_server._run_command_isolated(Mock(), [], {}, missing)
+    result = await _server_core._run_command_isolated(Mock(), [], {}, missing)
     assert result["ExitCode"] == 1
     assert "working directory" in result["Error"]
     assert result["Unexpected"] is False
@@ -53,7 +53,7 @@ async def test_maps_system_exit_code(restore_state: Any) -> None:
     _init(restore_state)
     cmd = Mock()
     cmd.main.side_effect = SystemExit(2)
-    result = await cli_server._run_command_isolated(cmd, [], {}, None)
+    result = await _server_core._run_command_isolated(cmd, [], {}, None)
     assert result["ExitCode"] == 2
     assert result["Unexpected"] is False
 
@@ -62,7 +62,7 @@ async def test_reports_unexpected_exception(restore_state: Any) -> None:
     _init(restore_state)
     cmd = Mock()
     cmd.main.side_effect = ValueError("boom")
-    result = await cli_server._run_command_isolated(cmd, [], {}, None)
+    result = await _server_core._run_command_isolated(cmd, [], {}, None)
     assert result["ExitCode"] == 1
     assert result["Unexpected"] is True
     assert "boom" in result["Error"]
@@ -74,7 +74,7 @@ async def test_reports_unexpected_exception(restore_state: Any) -> None:
 
 def test_parse_args_splits_a_string() -> None:
     # The real .NET-shaped Args: a single string, shlex-split into argv.
-    assert cli_server.parse_args("run --input-file in.json --flag") == [
+    assert _server_core.parse_args("run --input-file in.json --flag") == [
         "run",
         "--input-file",
         "in.json",
@@ -83,7 +83,7 @@ def test_parse_args_splits_a_string() -> None:
 
 
 def test_parse_args_passes_a_list_through() -> None:
-    assert cli_server.parse_args(["run", "--input-file", "in.json"]) == [
+    assert _server_core.parse_args(["run", "--input-file", "in.json"]) == [
         "run",
         "--input-file",
         "in.json",
@@ -91,4 +91,4 @@ def test_parse_args_passes_a_list_through() -> None:
 
 
 def test_parse_args_none_is_empty() -> None:
-    assert cli_server.parse_args(None) == []
+    assert _server_core.parse_args(None) == []

--- a/packages/uipath/tests/cli/test_server_job_core.py
+++ b/packages/uipath/tests/cli/test_server_job_core.py
@@ -46,6 +46,7 @@ async def test_rejects_bad_working_dir(restore_state: Any, tmp_path: Any) -> Non
     assert result["ExitCode"] == 1
     assert "working directory" in result["Error"]
     assert result["Unexpected"] is False
+    assert result["ClientError"] is True  # HTTP maps this to 400
 
 
 async def test_maps_system_exit_code(restore_state: Any) -> None:
@@ -65,3 +66,29 @@ async def test_reports_unexpected_exception(restore_state: Any) -> None:
     assert result["ExitCode"] == 1
     assert result["Unexpected"] is True
     assert "boom" in result["Error"]
+
+
+# parse_args accepts what every caller sends: the .NET peer sends a single
+# string (shlex-split), HTTP dicts / tests may send a pre-split list, or None.
+
+
+def test_parse_args_splits_a_string() -> None:
+    # The real .NET-shaped Args: a single string, shlex-split into argv.
+    assert cli_server.parse_args("run --input-file in.json --flag") == [
+        "run",
+        "--input-file",
+        "in.json",
+        "--flag",
+    ]
+
+
+def test_parse_args_passes_a_list_through() -> None:
+    assert cli_server.parse_args(["run", "--input-file", "in.json"]) == [
+        "run",
+        "--input-file",
+        "in.json",
+    ]
+
+
+def test_parse_args_none_is_empty() -> None:
+    assert cli_server.parse_args(None) == []

--- a/packages/uipath/tests/cli/test_server_transport.py
+++ b/packages/uipath/tests/cli/test_server_transport.py
@@ -13,6 +13,7 @@ through.
 """
 
 import asyncio
+from typing import Any
 
 from click.testing import CliRunner
 
@@ -20,7 +21,7 @@ import uipath._cli._telemetry as _telemetry
 from uipath._cli import cli_server
 
 
-def _stub_channels(monkeypatch) -> dict:
+def _stub_channels(monkeypatch) -> dict[str, Any]:
     """Stub the three channel runners + state init; record what ``_serve`` starts.
 
     Each runner is replaced with an async recorder that returns immediately, so
@@ -28,7 +29,7 @@ def _stub_channels(monkeypatch) -> dict:
     ``_state.init`` is stubbed too, so no event-loop-bound lock leaks between the
     per-test loops ``asyncio.run`` creates.
     """
-    calls: dict = {}
+    calls: dict[str, Any] = {}
 
     async def _rec_unix(ack_socket_path, server_socket_path=None):
         calls["unix"] = (ack_socket_path, server_socket_path)
@@ -62,9 +63,13 @@ def test_serve_runs_http_and_ipc_together(monkeypatch):
 def test_serve_derives_pipe_name_from_socket_basename(monkeypatch):
     calls = _stub_channels(monkeypatch)
     asyncio.run(
-        cli_server._serve("/tmp/ack.sock", "/var/tmp/uipath-server-42.sock", 8765, False)
+        cli_server._serve(
+            "/tmp/ack.sock", "/var/tmp/uipath-server-42.sock", 8765, False
+        )
     )
-    assert calls["ipc"] == "uipath-server-42.sock"  # basename (directory stripped, extension kept)
+    assert (
+        calls["ipc"] == "uipath-server-42.sock"
+    )  # basename (directory stripped, extension kept)
 
 
 def test_serve_rides_ipc_alongside_tcp(monkeypatch):
@@ -88,11 +93,11 @@ def test_serve_skips_ipc_without_server_socket(monkeypatch):
 # --------------------------------------------------------------------------- #
 
 
-def _capture_serve(monkeypatch) -> dict:
+def _capture_serve(monkeypatch) -> dict[str, Any]:
     """Replace ``_serve`` with an async recorder so ``_run_server`` runs to
     completion on its real per-OS loop (Proactor on Windows, ``asyncio.run`` on
     Linux) without actually serving anything."""
-    seen: dict = {}
+    seen: dict[str, Any] = {}
 
     async def _rec_serve(ack_socket_path, server_socket, port, use_tcp):
         seen.update(
@@ -142,9 +147,9 @@ def test_run_server_tcp_flag_forces_tcp(monkeypatch):
 # --------------------------------------------------------------------------- #
 
 
-def _stub_cli(monkeypatch) -> dict:
+def _stub_cli(monkeypatch) -> dict[str, Any]:
     """Disable telemetry + preload and record the args the CLI hands _run_server."""
-    seen: dict = {}
+    seen: dict[str, Any] = {}
     monkeypatch.setattr(_telemetry, "is_telemetry_enabled", lambda: False)
     monkeypatch.setattr(cli_server, "preload_modules", lambda: None)
     monkeypatch.setattr(

--- a/packages/uipath/tests/cli/test_server_transport.py
+++ b/packages/uipath/tests/cli/test_server_transport.py
@@ -1,0 +1,181 @@
+"""`uipath server` serves BOTH transports concurrently — never either/or.
+
+The HTTP channel (aiohttp over a Unix socket, or TCP on Windows / ``--tcp``) is
+ALWAYS started. The uipath-ipc named-pipe channel is started alongside it when a
+``--server-socket`` is given, with the pipe name the socket's basename (directory
+stripped, extension kept), matching the .NET side. The HTTP channel is never torn
+down.
+
+These tests stub the three channel runners (so ``_serve``'s ``asyncio.gather``
+returns at once instead of serving forever) and assert which channels ``_serve``
+composes, how ``_run_server`` resolves its arguments, and that the CLI wires them
+through.
+"""
+
+import asyncio
+
+from click.testing import CliRunner
+
+import uipath._cli._telemetry as _telemetry
+from uipath._cli import cli_server
+
+
+def _stub_channels(monkeypatch) -> dict:
+    """Stub the three channel runners + state init; record what ``_serve`` starts.
+
+    Each runner is replaced with an async recorder that returns immediately, so
+    ``_serve``'s ``asyncio.gather`` completes instead of blocking in serve-forever.
+    ``_state.init`` is stubbed too, so no event-loop-bound lock leaks between the
+    per-test loops ``asyncio.run`` creates.
+    """
+    calls: dict = {}
+
+    async def _rec_unix(ack_socket_path, server_socket_path=None):
+        calls["unix"] = (ack_socket_path, server_socket_path)
+
+    async def _rec_tcp(host, port):
+        calls["tcp"] = (host, port)
+
+    async def _rec_ipc(pipe_name):
+        calls["ipc"] = pipe_name
+
+    monkeypatch.setattr(cli_server._state, "init", lambda: None)
+    monkeypatch.setattr(cli_server, "start_unix_server", _rec_unix)
+    monkeypatch.setattr(cli_server, "start_tcp_server", _rec_tcp)
+    monkeypatch.setattr(cli_server, "start_ipc_server", _rec_ipc)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# _serve: channel composition                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_serve_runs_http_and_ipc_together(monkeypatch):
+    calls = _stub_channels(monkeypatch)
+    asyncio.run(cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", 8765, False))
+    assert calls["unix"] == ("/tmp/ack.sock", "/tmp/run-1.sock")
+    assert calls["ipc"] == "run-1.sock"  # pipe = socket basename (directory stripped)
+    assert "tcp" not in calls
+
+
+def test_serve_derives_pipe_name_from_socket_basename(monkeypatch):
+    calls = _stub_channels(monkeypatch)
+    asyncio.run(
+        cli_server._serve("/tmp/ack.sock", "/var/tmp/uipath-server-42.sock", 8765, False)
+    )
+    assert calls["ipc"] == "uipath-server-42.sock"  # basename (directory stripped, extension kept)
+
+
+def test_serve_rides_ipc_alongside_tcp(monkeypatch):
+    calls = _stub_channels(monkeypatch)
+    asyncio.run(cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", 9000, True))
+    assert calls["tcp"] == ("127.0.0.1", 9000)
+    assert "unix" not in calls
+    assert calls["ipc"] == "run-1.sock"  # IPC is served next to TCP too, not only UDS
+
+
+def test_serve_skips_ipc_without_server_socket(monkeypatch):
+    """No ``--server-socket`` ⇒ HTTP only (no pipe name to derive)."""
+    calls = _stub_channels(monkeypatch)
+    asyncio.run(cli_server._serve("/tmp/ack.sock", None, 8765, False))
+    assert calls["unix"] == ("/tmp/ack.sock", None)
+    assert "ipc" not in calls
+
+
+# --------------------------------------------------------------------------- #
+# _run_server: argument resolution + per-OS loop                              #
+# --------------------------------------------------------------------------- #
+
+
+def _capture_serve(monkeypatch) -> dict:
+    """Replace ``_serve`` with an async recorder so ``_run_server`` runs to
+    completion on its real per-OS loop (Proactor on Windows, ``asyncio.run`` on
+    Linux) without actually serving anything."""
+    seen: dict = {}
+
+    async def _rec_serve(ack_socket_path, server_socket, port, use_tcp):
+        seen.update(
+            ack=ack_socket_path,
+            server_socket=server_socket,
+            port=port,
+            use_tcp=use_tcp,
+        )
+
+    monkeypatch.setattr(cli_server, "_serve", _rec_serve)
+    return seen
+
+
+def test_run_server_defaults_ack_from_env(monkeypatch):
+    seen = _capture_serve(monkeypatch)
+    monkeypatch.setenv(cli_server.SOCKET_ENV_VAR, "/tmp/from-env.sock")
+    cli_server._run_server(None, "/tmp/s.sock", None, False)
+    assert seen["ack"] == "/tmp/from-env.sock"
+    assert seen["server_socket"] == "/tmp/s.sock"
+    assert seen["port"] == cli_server.DEFAULT_PORT
+    assert seen["use_tcp"] is cli_server.IS_WINDOWS  # UDS on Linux, TCP on Windows
+
+
+def test_run_server_prefers_explicit_client_socket(monkeypatch):
+    seen = _capture_serve(monkeypatch)
+    monkeypatch.setenv(cli_server.SOCKET_ENV_VAR, "/tmp/from-env.sock")
+    cli_server._run_server("/tmp/explicit.sock", "/tmp/s.sock", 1234, False)
+    assert seen["ack"] == "/tmp/explicit.sock"  # explicit arg beats the env var
+    assert seen["port"] == 1234
+
+
+def test_run_server_falls_back_to_default_ack(monkeypatch):
+    seen = _capture_serve(monkeypatch)
+    monkeypatch.delenv(cli_server.SOCKET_ENV_VAR, raising=False)
+    cli_server._run_server(None, "/tmp/s.sock", None, False)
+    assert seen["ack"] == cli_server.DEFAULT_SOCKET_PATH
+
+
+def test_run_server_tcp_flag_forces_tcp(monkeypatch):
+    seen = _capture_serve(monkeypatch)
+    cli_server._run_server("/tmp/a.sock", "/tmp/s.sock", None, True)
+    assert seen["use_tcp"] is True
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring (backward-compatible single --server-socket)                     #
+# --------------------------------------------------------------------------- #
+
+
+def _stub_cli(monkeypatch) -> dict:
+    """Disable telemetry + preload and record the args the CLI hands _run_server."""
+    seen: dict = {}
+    monkeypatch.setattr(_telemetry, "is_telemetry_enabled", lambda: False)
+    monkeypatch.setattr(cli_server, "preload_modules", lambda: None)
+    monkeypatch.setattr(
+        cli_server,
+        "_run_server",
+        lambda client_socket, server_socket, port, tcp: seen.update(
+            client_socket=client_socket,
+            server_socket=server_socket,
+            port=port,
+            tcp=tcp,
+        ),
+    )
+    return seen
+
+
+def test_cli_passes_socket_args_through(monkeypatch):
+    seen = _stub_cli(monkeypatch)
+    result = CliRunner().invoke(
+        cli_server.server,
+        ["--client-socket", "/tmp/ack.sock", "--server-socket", "/tmp/run.sock"],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["client_socket"] == "/tmp/ack.sock"
+    assert seen["server_socket"] == "/tmp/run.sock"
+    assert seen["tcp"] is False
+
+
+def test_cli_server_socket_is_optional(monkeypatch):
+    """No ``--server-socket`` is no longer an error: HTTP auto-generates one and
+    the IPC channel is simply skipped."""
+    seen = _stub_cli(monkeypatch)
+    result = CliRunner().invoke(cli_server.server, [])
+    assert result.exit_code == 0, result.output
+    assert seen["server_socket"] is None

--- a/packages/uipath/tests/cli/test_server_transport.py
+++ b/packages/uipath/tests/cli/test_server_transport.py
@@ -18,7 +18,7 @@ from typing import Any
 from click.testing import CliRunner
 
 import uipath._cli._telemetry as _telemetry
-from uipath._cli import cli_server
+from uipath._cli import _server_core, cli_server
 
 
 def _stub_channels(monkeypatch) -> dict[str, Any]:
@@ -40,7 +40,7 @@ def _stub_channels(monkeypatch) -> dict[str, Any]:
     async def _rec_ipc(pipe_name):
         calls["ipc"] = pipe_name
 
-    monkeypatch.setattr(cli_server._state, "init", lambda: None)
+    monkeypatch.setattr(_server_core._state, "init", lambda: None)
     monkeypatch.setattr(cli_server, "start_unix_server", _rec_unix)
     monkeypatch.setattr(cli_server, "start_tcp_server", _rec_tcp)
     monkeypatch.setattr(cli_server, "start_ipc_server", _rec_ipc)

--- a/packages/uipath/tests/cli/test_server_transport.py
+++ b/packages/uipath/tests/cli/test_server_transport.py
@@ -1,10 +1,10 @@
 """`uipath server` serves BOTH transports concurrently — never either/or.
 
 The HTTP channel (aiohttp over a Unix socket, or TCP on Windows / ``--tcp``) is
-ALWAYS started. The uipath-ipc named-pipe channel is started alongside it when a
-``--server-socket`` is given, with the pipe name the socket's basename (directory
-stripped, extension kept), matching the .NET side. The HTTP channel is never torn
-down.
+ALWAYS started. The uipath-ipc named-pipe channel is opt-in and independent of the
+HTTP socket: it is started alongside HTTP only when ``--ipc-pipe`` names a pipe,
+served verbatim on that name (both sides agree on it out of band). The HTTP channel
+is never torn down.
 
 These tests stub the three channel runners (so ``_serve``'s ``asyncio.gather``
 returns at once instead of serving forever) and assert which channels ``_serve``
@@ -54,37 +54,56 @@ def _stub_channels(monkeypatch) -> dict[str, Any]:
 
 def test_serve_runs_http_and_ipc_together(monkeypatch):
     calls = _stub_channels(monkeypatch)
-    asyncio.run(cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", 8765, False))
+    asyncio.run(
+        cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", "agent.pipe", 8765, False)
+    )
     assert calls["unix"] == ("/tmp/ack.sock", "/tmp/run-1.sock")
-    assert calls["ipc"] == "run-1.sock"  # pipe = socket basename (directory stripped)
+    assert calls["ipc"] == "agent.pipe"  # served on the explicit --ipc-pipe name
     assert "tcp" not in calls
 
 
-def test_serve_derives_pipe_name_from_socket_basename(monkeypatch):
+def test_serve_uses_the_explicit_ipc_pipe_name(monkeypatch):
+    """The IPC pipe name is taken verbatim from ``--ipc-pipe``, not derived from the
+    HTTP socket path."""
     calls = _stub_channels(monkeypatch)
     asyncio.run(
         cli_server._serve(
-            "/tmp/ack.sock", "/var/tmp/uipath-server-42.sock", 8765, False
+            "/tmp/ack.sock",
+            "/var/tmp/uipath-server-42.sock",
+            "my-agent-pipe",
+            8765,
+            False,
         )
     )
-    assert (
-        calls["ipc"] == "uipath-server-42.sock"
-    )  # basename (directory stripped, extension kept)
+    assert calls["ipc"] == "my-agent-pipe"  # verbatim, independent of the HTTP socket
+
+
+def test_serve_ipc_is_independent_of_the_http_socket(monkeypatch):
+    """``--ipc-pipe`` drives IPC even when HTTP auto-generates its socket
+    (``server_socket`` is ``None``)."""
+    calls = _stub_channels(monkeypatch)
+    asyncio.run(cli_server._serve("/tmp/ack.sock", None, "agent.pipe", 8765, False))
+    assert calls["unix"] == ("/tmp/ack.sock", None)  # HTTP auto-socket
+    assert calls["ipc"] == "agent.pipe"
 
 
 def test_serve_rides_ipc_alongside_tcp(monkeypatch):
     calls = _stub_channels(monkeypatch)
-    asyncio.run(cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", 9000, True))
+    asyncio.run(
+        cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", "agent.pipe", 9000, True)
+    )
     assert calls["tcp"] == ("127.0.0.1", 9000)
     assert "unix" not in calls
-    assert calls["ipc"] == "run-1.sock"  # IPC is served next to TCP too, not only UDS
+    assert calls["ipc"] == "agent.pipe"  # IPC rides next to TCP too, not only UDS
 
 
-def test_serve_skips_ipc_without_server_socket(monkeypatch):
-    """No ``--server-socket`` ⇒ HTTP only (no pipe name to derive)."""
+def test_serve_skips_ipc_without_ipc_pipe(monkeypatch):
+    """No ``--ipc-pipe`` ⇒ HTTP only, regardless of the HTTP socket."""
     calls = _stub_channels(monkeypatch)
-    asyncio.run(cli_server._serve("/tmp/ack.sock", None, 8765, False))
-    assert calls["unix"] == ("/tmp/ack.sock", None)
+    asyncio.run(
+        cli_server._serve("/tmp/ack.sock", "/tmp/run-1.sock", None, 8765, False)
+    )
+    assert calls["unix"] == ("/tmp/ack.sock", "/tmp/run-1.sock")
     assert "ipc" not in calls
 
 
@@ -99,10 +118,11 @@ def _capture_serve(monkeypatch) -> dict[str, Any]:
     Linux) without actually serving anything."""
     seen: dict[str, Any] = {}
 
-    async def _rec_serve(ack_socket_path, server_socket, port, use_tcp):
+    async def _rec_serve(ack_socket_path, server_socket, ipc_pipe, port, use_tcp):
         seen.update(
             ack=ack_socket_path,
             server_socket=server_socket,
+            ipc_pipe=ipc_pipe,
             port=port,
             use_tcp=use_tcp,
         )
@@ -114,9 +134,10 @@ def _capture_serve(monkeypatch) -> dict[str, Any]:
 def test_run_server_defaults_ack_from_env(monkeypatch):
     seen = _capture_serve(monkeypatch)
     monkeypatch.setenv(cli_server.SOCKET_ENV_VAR, "/tmp/from-env.sock")
-    cli_server._run_server(None, "/tmp/s.sock", None, False)
+    cli_server._run_server(None, "/tmp/s.sock", "agent.pipe", None, False)
     assert seen["ack"] == "/tmp/from-env.sock"
     assert seen["server_socket"] == "/tmp/s.sock"
+    assert seen["ipc_pipe"] == "agent.pipe"
     assert seen["port"] == cli_server.DEFAULT_PORT
     assert seen["use_tcp"] is cli_server.IS_WINDOWS  # UDS on Linux, TCP on Windows
 
@@ -124,7 +145,7 @@ def test_run_server_defaults_ack_from_env(monkeypatch):
 def test_run_server_prefers_explicit_client_socket(monkeypatch):
     seen = _capture_serve(monkeypatch)
     monkeypatch.setenv(cli_server.SOCKET_ENV_VAR, "/tmp/from-env.sock")
-    cli_server._run_server("/tmp/explicit.sock", "/tmp/s.sock", 1234, False)
+    cli_server._run_server("/tmp/explicit.sock", "/tmp/s.sock", None, 1234, False)
     assert seen["ack"] == "/tmp/explicit.sock"  # explicit arg beats the env var
     assert seen["port"] == 1234
 
@@ -132,18 +153,18 @@ def test_run_server_prefers_explicit_client_socket(monkeypatch):
 def test_run_server_falls_back_to_default_ack(monkeypatch):
     seen = _capture_serve(monkeypatch)
     monkeypatch.delenv(cli_server.SOCKET_ENV_VAR, raising=False)
-    cli_server._run_server(None, "/tmp/s.sock", None, False)
+    cli_server._run_server(None, "/tmp/s.sock", None, None, False)
     assert seen["ack"] == cli_server.DEFAULT_SOCKET_PATH
 
 
 def test_run_server_tcp_flag_forces_tcp(monkeypatch):
     seen = _capture_serve(monkeypatch)
-    cli_server._run_server("/tmp/a.sock", "/tmp/s.sock", None, True)
+    cli_server._run_server("/tmp/a.sock", "/tmp/s.sock", None, None, True)
     assert seen["use_tcp"] is True
 
 
 # --------------------------------------------------------------------------- #
-# CLI wiring (backward-compatible single --server-socket)                     #
+# CLI wiring                                                                  #
 # --------------------------------------------------------------------------- #
 
 
@@ -155,9 +176,10 @@ def _stub_cli(monkeypatch) -> dict[str, Any]:
     monkeypatch.setattr(
         cli_server,
         "_run_server",
-        lambda client_socket, server_socket, port, tcp: seen.update(
+        lambda client_socket, server_socket, ipc_pipe, port, tcp: seen.update(
             client_socket=client_socket,
             server_socket=server_socket,
+            ipc_pipe=ipc_pipe,
             port=port,
             tcp=tcp,
         ),
@@ -169,18 +191,26 @@ def test_cli_passes_socket_args_through(monkeypatch):
     seen = _stub_cli(monkeypatch)
     result = CliRunner().invoke(
         cli_server.server,
-        ["--client-socket", "/tmp/ack.sock", "--server-socket", "/tmp/run.sock"],
+        [
+            "--client-socket",
+            "/tmp/ack.sock",
+            "--server-socket",
+            "/tmp/run.sock",
+            "--ipc-pipe",
+            "agent.pipe",
+        ],
     )
     assert result.exit_code == 0, result.output
     assert seen["client_socket"] == "/tmp/ack.sock"
     assert seen["server_socket"] == "/tmp/run.sock"
+    assert seen["ipc_pipe"] == "agent.pipe"
     assert seen["tcp"] is False
 
 
-def test_cli_server_socket_is_optional(monkeypatch):
-    """No ``--server-socket`` is no longer an error: HTTP auto-generates one and
-    the IPC channel is simply skipped."""
+def test_cli_ipc_pipe_is_optional(monkeypatch):
+    """No ``--ipc-pipe`` ⇒ HTTP only; the server still starts (IPC simply skipped)."""
     seen = _stub_cli(monkeypatch)
     result = CliRunner().invoke(cli_server.server, [])
     assert result.exit_code == 0, result.output
     assert seen["server_socket"] is None
+    assert seen["ipc_pipe"] is None

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -7,6 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P2D"
 
 [options.exclude-newer-package]
+uipath-ipc = false
 uipath-runtime = false
 uipath-platform = false
 uipath-core = false
@@ -2619,6 +2620,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "truststore" },
     { name = "uipath-core" },
+    { name = "uipath-ipc" },
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
@@ -2673,6 +2675,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
+    { name = "uipath-ipc", specifier = ">=2.5.1", index = "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Internal/pypi/simple/" },
     { name = "uipath-platform", editable = "../uipath-platform" },
     { name = "uipath-runtime", specifier = ">=0.12.2,<0.13.0" },
 ]
@@ -2737,6 +2740,15 @@ dev = [
     { name = "pytest-trio", specifier = ">=0.8.0" },
     { name = "ruff", specifier = ">=0.9.4" },
     { name = "rust-just", specifier = ">=1.39.0" },
+]
+
+[[package]]
+name = "uipath-ipc"
+version = "2.5.1+20260625.1"
+source = { registry = "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Internal/pypi/simple/" }
+sdist = { url = "https://pkgs.dev.azure.com/uipath/5b98d55c-1b14-4a03-893f-7a59746f1246/_packaging/788028a9-5a01-48ee-b925-3af51ae46294/pypi/download/uipath-ipc/2.5.1+20260625.1/uipath_ipc-2.5.1+20260625.1.tar.gz", hash = "sha256:bc202fef26d8ecae6b8bcfaccd6bcfb4675e0160faabf8d9281f1028643adee9" }
+wheels = [
+    { url = "https://pkgs.dev.azure.com/uipath/5b98d55c-1b14-4a03-893f-7a59746f1246/_packaging/788028a9-5a01-48ee-b925-3af51ae46294/pypi/download/uipath-ipc/2.5.1+20260625.1/uipath_ipc-2.5.1+20260625.1-py3-none-any.whl", hash = "sha256:0e90b0198b9afa8a1fa832e010aa1160914391d9b5610684a3bf582704f41773" },
 ]
 
 [[package]]

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2675,7 +2675,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
-    { name = "uipath-ipc", specifier = ">=2.5.1", index = "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Internal/pypi/simple/" },
+    { name = "uipath-ipc", specifier = ">=2.5.1,<2.6.0" },
     { name = "uipath-platform", editable = "../uipath-platform" },
     { name = "uipath-runtime", specifier = ">=0.12.2,<0.13.0" },
 ]
@@ -2744,11 +2744,11 @@ dev = [
 
 [[package]]
 name = "uipath-ipc"
-version = "2.5.1+20260625.1"
-source = { registry = "https://pkgs.dev.azure.com/uipath/Public.Feeds/_packaging/UiPath-Internal/pypi/simple/" }
-sdist = { url = "https://pkgs.dev.azure.com/uipath/5b98d55c-1b14-4a03-893f-7a59746f1246/_packaging/788028a9-5a01-48ee-b925-3af51ae46294/pypi/download/uipath-ipc/2.5.1+20260625.1/uipath_ipc-2.5.1+20260625.1.tar.gz", hash = "sha256:bc202fef26d8ecae6b8bcfaccd6bcfb4675e0160faabf8d9281f1028643adee9" }
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/6b/53d9725d6abd1dab447300a7f999332f530678e3fabd38fc31171a5a9a6f/uipath_ipc-2.5.2.tar.gz", hash = "sha256:d69c3d7c1ad1a25ef7f9f1d78c505f5d2ed7daa7227bb202404fa3d47e0ba12e", size = 86360, upload-time = "2026-07-24T09:44:35.159Z" }
 wheels = [
-    { url = "https://pkgs.dev.azure.com/uipath/5b98d55c-1b14-4a03-893f-7a59746f1246/_packaging/788028a9-5a01-48ee-b925-3af51ae46294/pypi/download/uipath-ipc/2.5.1+20260625.1/uipath_ipc-2.5.1+20260625.1-py3-none-any.whl", hash = "sha256:0e90b0198b9afa8a1fa832e010aa1160914391d9b5610684a3bf582704f41773" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/6def505a0d351119da27b342c11eb0767a31a7f100022d35e349c5194eb3/uipath_ipc-2.5.2-py3-none-any.whl", hash = "sha256:617f25f35377d87956165a875b0966a3cd69ae6724fcd533c93a7a6a9460fc4f", size = 50345, upload-time = "2026-07-24T09:44:33.7Z" },
 ]
 
 [[package]]

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.17"
+version = "2.13.18"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2624,6 +2624,11 @@ dependencies = [
     { name = "uipath-runtime" },
 ]
 
+[package.optional-dependencies]
+ipc = [
+    { name = "uipath-ipc" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
@@ -2675,9 +2680,11 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
+    { name = "uipath-ipc", marker = "extra == 'ipc'", specifier = ">=2.5.1,<2.6.0" },
     { name = "uipath-platform", editable = "../uipath-platform" },
     { name = "uipath-runtime", specifier = ">=0.12.2,<0.13.0" },
 ]
+provides-extras = ["ipc"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2620,7 +2620,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "truststore" },
     { name = "uipath-core" },
-    { name = "uipath-ipc" },
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
@@ -2652,6 +2651,7 @@ dev = [
     { name = "tomli-w" },
     { name = "types-pyyaml" },
     { name = "types-toml" },
+    { name = "uipath-ipc" },
     { name = "virtualenv" },
 ]
 
@@ -2675,7 +2675,6 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "truststore", specifier = ">=0.10.1" },
     { name = "uipath-core", editable = "../uipath-core" },
-    { name = "uipath-ipc", specifier = ">=2.5.1,<2.6.0" },
     { name = "uipath-platform", editable = "../uipath-platform" },
     { name = "uipath-runtime", specifier = ">=0.12.2,<0.13.0" },
 ]
@@ -2707,6 +2706,7 @@ dev = [
     { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "types-toml", specifier = ">=0.10.8" },
+    { name = "uipath-ipc", specifier = ">=2.5.1,<2.6.0" },
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,16 @@ sonar.exclusions=**/samples/**,**/testcases/**,**/template/**,**/_resources/**
 
 sonar.cpd.exclusions=**/__init__.py
 
+# The uipath-ipc runtime contract (methods + DTO fields) is PascalCase because
+# the wire keys and method names are dictated by the .NET/CoreIpc peer — the
+# serializer maps them verbatim (no alias mechanism), so the names cannot be
+# Python-idiomatic without breaking interop. It is isolated in cli_server_ipc.py
+# so this suppression of method-naming (S100) and field-naming (S116) touches
+# that file only.
+sonar.issue.ignore.multicriteria=ipc1,ipc2
+sonar.issue.ignore.multicriteria.ipc1.ruleKey=python:S100
+sonar.issue.ignore.multicriteria.ipc1.resourcePath=**/cli_server_ipc.py
+sonar.issue.ignore.multicriteria.ipc2.ruleKey=python:S116
+sonar.issue.ignore.multicriteria.ipc2.resourcePath=**/cli_server_ipc.py
+
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,8 +20,8 @@ sonar.cpd.exclusions=**/__init__.py
 # that file only.
 sonar.issue.ignore.multicriteria=ipc1,ipc2
 sonar.issue.ignore.multicriteria.ipc1.ruleKey=python:S100
-sonar.issue.ignore.multicriteria.ipc1.resourcePath=**/cli_server_ipc.py
+sonar.issue.ignore.multicriteria.ipc1.resourceKey=**/cli_server_ipc.py
 sonar.issue.ignore.multicriteria.ipc2.ruleKey=python:S116
-sonar.issue.ignore.multicriteria.ipc2.resourcePath=**/cli_server_ipc.py
+sonar.issue.ignore.multicriteria.ipc2.resourceKey=**/cli_server_ipc.py
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Adds a uipath-ipc named-pipe transport to `uipath server`, served **alongside** the existing HTTP-over-socket path (ROBO-5779).

## What
- `uipath server` serves **both channels concurrently**: HTTP (aiohttp over a Unix socket, or TCP on Windows) and — when `--server-socket` is given — a uipath-ipc named pipe. HTTP is never torn down; the IPC pipe name is the socket's basename, so the executor spawns the server the same way regardless of channel.
- IPC hosts `IPythonRuntimeServer` (`StartJob` / `StopJob`) via `NamedPipeServerTransport`; both edges run jobs through one env/cwd-isolated core (`_run_command_isolated`).
- Contract DTOs are typed dataclasses (`PythonRunRequest` / `PythonRunResult`) mirroring the .NET side. `StopJob` returns a `bool` so CoreIPC treats it as request/response, not fire-and-forget — cancellation itself is a no-op for now (Phase 1).
- Adds `uipath-ipc>=2.5.1` (internal Azure Artifacts feed for now — see the `pyproject` note; a public-PyPI `uipath-ipc` release is a prerequisite for a public `pip install uipath`).
- Tests: `test_server_ipc.py` (IPC server) and `test_server_transport.py` (channel composition / `_run_server` arg resolution / CLI wiring).

## Notes
- Which transport a given job uses is decided on the .NET Handler side (the `PythonRuntimePreferIpc` FPS feature flag, Low-Code only) — separate PR in `UiPath/hdens`.
- Rebased onto current `main`; pending green CI (cross-tests + Sonar) before ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
