### PR TITLE
test: add protocol conformance pins for runtime implementations

### DIFF
--- a/packages/uipath/tests/cli/unit/test_runtime_protocol_conformance.py
+++ b/packages/uipath/tests/cli/unit/test_runtime_protocol_conformance.py
@@ -1,0 +1,79 @@
+"""Protocol conformance for uipath-runtime protocol implementations.
+
+Every protocol-annotated assignment below is a typed boundary: mypy verifies
+the implementation against the protocol surface of the installed
+uipath-runtime version. A dependency bump that adds or changes protocol
+members fails typecheck on these lines until the implementations catch up.
+
+Deliberately construction-only: no runtime behavior is exercised here.
+"""
+
+import uuid
+
+from uipath.core.events import EventBus
+from uipath.core.tracing import UiPathTraceManager
+from uipath.eval.runtime import UiPathEvalContext, UiPathEvalRuntime
+from uipath.functions import (
+    UiPathDebugFunctionsRuntime,
+    UiPathFunctionsRuntime,
+    UiPathFunctionsRuntimeFactory,
+)
+from uipath.platform.resume_triggers import (
+    UiPathResumeTriggerCreator,
+    UiPathResumeTriggerReader,
+)
+from uipath.runtime import (
+    UiPathRuntimeFactoryProtocol,
+    UiPathRuntimeProtocol,
+)
+from uipath.runtime.resumable.protocols import (
+    UiPathResumeTriggerCreatorProtocol,
+    UiPathResumeTriggerReaderProtocol,
+)
+
+
+def test_functions_runtime_satisfies_runtime_protocol() -> None:
+    runtime: UiPathRuntimeProtocol = UiPathFunctionsRuntime(
+        file_path="main.py",
+        function_name="main",
+        entrypoint_name="main",
+    )
+
+    # the debug wrapper's `delegate` parameter is protocol-typed: passing the
+    # real functions runtime through it is a second typed boundary, and the
+    # wrapper itself must satisfy the protocol too
+    debug_runtime: UiPathRuntimeProtocol = UiPathDebugFunctionsRuntime(
+        delegate=runtime,
+        entrypoint_path="main.py",
+        function_name="main",
+    )
+
+    assert debug_runtime is not None
+
+
+def test_functions_factory_satisfies_factory_protocol() -> None:
+    factory: UiPathRuntimeFactoryProtocol = UiPathFunctionsRuntimeFactory()
+
+    # the eval runtime's `factory` parameter is protocol-typed: the real
+    # functions factory flows through it. UiPathEvalRuntime itself is a
+    # specialized runtime (no stream, argument-less execute) and is
+    # deliberately NOT pinned against UiPathRuntimeProtocol.
+    context = UiPathEvalContext()
+    context.execution_id = str(uuid.uuid4())
+    eval_runtime = UiPathEvalRuntime(
+        context=context,
+        factory=factory,
+        trace_manager=UiPathTraceManager(),
+        event_bus=EventBus(),
+    )
+
+    assert eval_runtime is not None
+
+
+def test_standalone_trigger_classes_satisfy_protocols() -> None:
+    # cover direct consumers of the standalone creator/reader classes
+    creator: UiPathResumeTriggerCreatorProtocol = UiPathResumeTriggerCreator()
+    reader: UiPathResumeTriggerReaderProtocol = UiPathResumeTriggerReader()
+
+    assert creator is not None
+    assert reader is not None


### PR DESCRIPTION
## Summary

Static conformance pins for the `uipath-runtime` protocol implementations that #1792 does not cover: `UiPathFunctionsRuntime`, `UiPathDebugFunctionsRuntime`, `UiPathFunctionsRuntimeFactory`, and the standalone `UiPathResumeTriggerCreator`/`UiPathResumeTriggerReader` classes.

Each protocol-annotated assignment is a typed boundary: mypy verifies the implementation against the protocol surface of the **installed** uipath-runtime version. When a future runtime bump adds or changes protocol members (the uipath-runtime#138 / #1764 scenario), the ordinary `lint-packages` mypy job fails on these pre-existing lines, naming the exact class and missing member — no one needs to know about the protocol change in advance.

Construction-only by design: real implementations, real constructors, pins flowing through protocol-typed parameters (`UiPathDebugFunctionsRuntime(delegate=...)`, `UiPathEvalRuntime(factory=...)`); no behavior is exercised. Behavioral coverage stays in `test_runtime_protocol_compat.py`.

Note: `UiPathEvalRuntime` is deliberately **not** pinned against `UiPathRuntimeProtocol` — it does not conform (no `stream`, argument-less `execute`); it participates only as the protocol-typed consumer of the factory pin.

## Verification

Simulated a protocol change by installing a locally modified uipath-runtime (new `create_triggers_v2` member on `UiPathResumeTriggerCreatorProtocol`): mypy failed on the pins in this file and in `test_runtime_protocol_compat.py`, each error naming `create_triggers_v2`. Restored to the lockfile: green. Tests pass, mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)