### PR TITLE
feat: preserve conversation content-part metadata

### DIFF
--- a/packages/uipath-core/pyproject.toml
+++ b/packages/uipath-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-core"
-version = "0.5.30"
+version = "0.5.31"
 description = "UiPath Core abstractions"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-core/src/uipath/core/chat/content.py
+++ b/packages/uipath-core/src/uipath/core/chat/content.py
@@ -96,6 +96,7 @@ class UiPathConversationContentPartData(BaseModel):
 
     mime_type: str = Field(..., alias="mimeType")
     data: InlineOrExternal
+    metadata: dict[str, Any] | None = Field(None, alias="metaData")
     citations: Sequence[UiPathConversationCitationData] = Field(default_factory=list)
     is_transcript: bool | None = Field(None, alias="isTranscript")
     is_incomplete: bool | None = Field(None, alias="isIncomplete")

--- a/packages/uipath-core/tests/chat/test_message.py
+++ b/packages/uipath-core/tests/chat/test_message.py
@@ -57,3 +57,31 @@ def test_explicit_ids_are_preserved() -> None:
     assert (
         msg.content_parts[0].content_part_id == "00000000-0000-0000-0000-000000000002"
     )
+
+
+def test_content_part_metadata_is_preserved() -> None:
+    msg = UiPathConversationMessage.model_validate(
+        {
+            "role": "assistant",
+            "contentParts": [
+                {
+                    "mimeType": "text/markdown",
+                    "name": "plan.md",
+                    "data": {
+                        "uri": "urn:uipath:cas:file:orchestrator:"
+                        "00000000-0000-0000-0000-000000000003"
+                    },
+                    "metaData": {"fileKind": "workspace", "sha256": "abc123"},
+                }
+            ],
+        }
+    )
+
+    assert msg.content_parts[0].metadata == {
+        "fileKind": "workspace",
+        "sha256": "abc123",
+    }
+    assert msg.model_dump(by_alias=True)["contentParts"][0]["metaData"] == {
+        "fileKind": "workspace",
+        "sha256": "abc123",
+    }

--- a/packages/uipath-core/uv.lock
+++ b/packages/uipath-core/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.30"
+version = "0.5.31"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.30"
+version = "0.5.31"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2709,7 +2709,7 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.30"
+version = "0.5.31"
 source = { editable = "../uipath-core" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },


### PR DESCRIPTION
## Summary
- preserve content-part metadata when conversation history is deserialized
- keep the wire alias compatible with the existing conversation contract
- cover serialization and deserialization round trips

## Validation
- full uipath-core test suite passes
- ruff and focused mypy pass
- lockfile is current