### PR TITLE
fix(eval): apply resource overwrites and NoMemory override correctly

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.10"
+version = "2.13.11"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_eval.py
+++ b/packages/uipath/src/uipath/_cli/cli_eval.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import uuid
+from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import Any
 
@@ -468,40 +469,42 @@ def eval(
                             )
                         )
 
-                        runtime = await runtime_factory.new_runtime(
-                            entrypoint=eval_context.entrypoint or "",
-                            runtime_id=eval_context.execution_id,
-                            settings=settings_override,
-                            agent_memory_settings=agent_memory_settings_override,
-                        )
+                        # Resource overwrites must be in scope before any runtime is
+                        # created: building the agent graph resolves folder-scoped
+                        # resources (e.g. escalation memory spaces) at tool-creation
+                        # time, and those lookups need the overwritten folder paths.
+                        async with AsyncExitStack() as stack:
+                            if project_id:
+                                studio_client = StudioClient(project_id)
 
-                        eval_context.runtime_schema = await runtime.get_schema()
-
-                        eval_context.evaluators = await EvalHelpers.load_evaluators(
-                            resolved_eval_set_path,
-                            eval_context.evaluation_set,
-                            get_agent_model(eval_context.runtime_schema),
-                        )
-
-                        # Runtime is not required anymore.
-                        await runtime.dispose()
-
-                        if project_id:
-                            studio_client = StudioClient(project_id)
-
-                            async with ResourceOverwritesContext(
-                                lambda: studio_client.get_resource_overwrites()
-                            ):
-                                ctx.result = await evaluate(
-                                    runtime_factory,
-                                    trace_manager,
-                                    eval_context,
-                                    event_bus,
+                                await stack.enter_async_context(
+                                    ResourceOverwritesContext(
+                                        lambda: studio_client.get_resource_overwrites()
+                                    )
                                 )
-                        else:
-                            logger.debug(
-                                "No UIPATH_PROJECT_ID configured, executing evaluation without resource overwrites"
+                            else:
+                                logger.debug(
+                                    "No UIPATH_PROJECT_ID configured, executing evaluation without resource overwrites"
+                                )
+
+                            runtime = await runtime_factory.new_runtime(
+                                entrypoint=eval_context.entrypoint or "",
+                                runtime_id=eval_context.execution_id,
+                                settings=settings_override,
+                                agent_memory_settings=agent_memory_settings_override,
                             )
+
+                            eval_context.runtime_schema = await runtime.get_schema()
+
+                            eval_context.evaluators = await EvalHelpers.load_evaluators(
+                                resolved_eval_set_path,
+                                eval_context.evaluation_set,
+                                get_agent_model(eval_context.runtime_schema),
+                            )
+
+                            # Runtime is not required anymore.
+                            await runtime.dispose()
+
                             ctx.result = await evaluate(
                                 runtime_factory,
                                 trace_manager,

--- a/packages/uipath/src/uipath/_cli/cli_eval.py
+++ b/packages/uipath/src/uipath/_cli/cli_eval.py
@@ -139,6 +139,13 @@ def _resolve_agent_memory_settings_override(
     if not evaluation_set.agent_memory_enabled:
         return {"enabled": False}
 
+    # "NoMemory" is a sentinel id meaning "run without memory", matching the
+    # Agents backend (ApplyAgentMemorySettingsOverride removes the memorySpace
+    # feature for a null or "NoMemory" setting). Its entry's field values are
+    # also "NoMemory" strings, so it must never be applied as real settings.
+    if agent_memory_settings_id == "NoMemory":
+        return {"enabled": False}
+
     memory_settings = evaluation_set.agent_memory_settings
     target = None
     if agent_memory_settings_id:
@@ -154,6 +161,9 @@ def _resolve_agent_memory_settings_override(
             )
     if target is None:
         target = memory_settings[0] if memory_settings else None
+
+    if target is not None and target.id == "NoMemory":
+        return {"enabled": False}
 
     if target is None:
         # Memory enabled but no settings configured: keep the agent's own configuration

--- a/packages/uipath/src/uipath/_cli/cli_eval.py
+++ b/packages/uipath/src/uipath/_cli/cli_eval.py
@@ -494,16 +494,20 @@ def eval(
                                 agent_memory_settings=agent_memory_settings_override,
                             )
 
-                            eval_context.runtime_schema = await runtime.get_schema()
+                            # The runtime is only needed for schema/evaluator
+                            # loading; dispose it before evaluation starts.
+                            try:
+                                eval_context.runtime_schema = await runtime.get_schema()
 
-                            eval_context.evaluators = await EvalHelpers.load_evaluators(
-                                resolved_eval_set_path,
-                                eval_context.evaluation_set,
-                                get_agent_model(eval_context.runtime_schema),
-                            )
-
-                            # Runtime is not required anymore.
-                            await runtime.dispose()
+                                eval_context.evaluators = (
+                                    await EvalHelpers.load_evaluators(
+                                        resolved_eval_set_path,
+                                        eval_context.evaluation_set,
+                                        get_agent_model(eval_context.runtime_schema),
+                                    )
+                                )
+                            finally:
+                                await runtime.dispose()
 
                             ctx.result = await evaluate(
                                 runtime_factory,

--- a/packages/uipath/tests/cli/eval/test_agent_memory_settings.py
+++ b/packages/uipath/tests/cli/eval/test_agent_memory_settings.py
@@ -205,3 +205,53 @@ class TestResolveAgentMemorySettingsOverride:
         override = _resolve_agent_memory_settings_override("default", eval_set)
 
         assert override == {"enabled": True}
+
+    def test_no_memory_id_disables_memory(self):
+        # Selecting "No memory" in the eval settings passes the "NoMemory"
+        # sentinel id; its entry stores "NoMemory" field values that must not
+        # be applied as real settings.
+        eval_set = make_eval_set(
+            agentMemoryEnabled=True,
+            agentMemorySettings=[
+                {"id": "s1", "searchMode": "hybrid"},
+                {
+                    "id": "NoMemory",
+                    "resultCount": "NoMemory",
+                    "searchMode": "semantic",
+                    "threshold": "NoMemory",
+                },
+            ],
+        )
+
+        override = _resolve_agent_memory_settings_override("NoMemory", eval_set)
+
+        assert override == {"enabled": False}
+
+    def test_no_memory_id_disables_memory_without_matching_entry(self):
+        # The sentinel disables memory even when the eval set has no
+        # "NoMemory" entry; it must not fall back to the first setting.
+        eval_set = make_eval_set(
+            agentMemoryEnabled=True,
+            agentMemorySettings=[{"id": "s1", "searchMode": "hybrid"}],
+        )
+
+        override = _resolve_agent_memory_settings_override("NoMemory", eval_set)
+
+        assert override == {"enabled": False}
+
+    def test_fallback_to_no_memory_entry_disables_memory(self):
+        eval_set = make_eval_set(
+            agentMemoryEnabled=True,
+            agentMemorySettings=[
+                {
+                    "id": "NoMemory",
+                    "resultCount": "NoMemory",
+                    "searchMode": "semantic",
+                    "threshold": "NoMemory",
+                }
+            ],
+        )
+
+        override = _resolve_agent_memory_settings_override("default", eval_set)
+
+        assert override == {"enabled": False}

--- a/packages/uipath/tests/cli/eval/test_eval_resource_overwrites.py
+++ b/packages/uipath/tests/cli/eval/test_eval_resource_overwrites.py
@@ -1,0 +1,185 @@
+"""Tests for resource overwrites context ordering in the eval CLI.
+
+The overwrites context must be entered before the runtime is created:
+building the agent graph resolves folder-scoped resources (e.g. escalation
+memory spaces) at tool-creation time, and those lookups need the
+overwritten folder paths.
+"""
+
+import json
+import os
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from uipath._cli import cli
+from uipath._cli.middlewares import MiddlewareResult
+from uipath.platform.common._bindings import _resource_overwrites
+
+
+def _middleware_continue() -> MiddlewareResult:
+    return MiddlewareResult(
+        should_continue=True,
+        error_message=None,
+        should_include_stacktrace=False,
+    )
+
+
+def _write_project_files() -> None:
+    with open("uipath.json", "w") as f:
+        json.dump({"functions": {"agent": "main.py:main"}}, f)
+
+    os.makedirs("evaluations/eval-sets", exist_ok=True)
+    eval_set = {
+        "version": "1.0",
+        "id": "test-set",
+        "name": "Test Set",
+        "evaluatorRefs": [],
+        "evaluations": [],
+    }
+    with open("evaluations/eval-sets/test-set.json", "w") as f:
+        json.dump(eval_set, f)
+
+
+def _make_mock_runtime() -> Mock:
+    mock_runtime = Mock()
+    mock_runtime.get_schema = AsyncMock(
+        return_value=Mock(metadata=None, input_schema=None, output_schema=None)
+    )
+    mock_runtime.dispose = AsyncMock()
+    return mock_runtime
+
+
+def _make_mock_factory(mock_runtime: Mock) -> Mock:
+    mock_factory = Mock()
+    mock_factory.discover_entrypoints.return_value = ["agent"]
+    mock_factory.get_settings = AsyncMock(return_value=None)
+    mock_factory.dispose = AsyncMock()
+    mock_factory.new_runtime = AsyncMock(return_value=mock_runtime)
+    return mock_factory
+
+
+def _enter_base_patches(stack: ExitStack, mock_factory: Mock) -> None:
+    stack.enter_context(
+        patch(
+            "uipath._cli.cli_eval.Middlewares.next",
+            return_value=_middleware_continue(),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "uipath._cli.cli_eval.UiPathRuntimeFactoryRegistry.get",
+            return_value=mock_factory,
+        )
+    )
+    stack.enter_context(
+        patch("uipath._cli.cli_eval.setup_reporting_prereq", return_value=False)
+    )
+    stack.enter_context(
+        patch(
+            "uipath._cli.cli_eval.EvalHelpers.load_evaluators",
+            new=AsyncMock(return_value=[]),
+        )
+    )
+    stack.enter_context(
+        patch("uipath._cli.cli_eval.evaluate", new=AsyncMock(return_value=None))
+    )
+
+
+class TestEvalResourceOverwritesOrdering:
+    def test_overwrites_context_active_when_runtime_is_created(
+        self, runner: CliRunner, temp_dir: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """new_runtime must run inside the resource overwrites context."""
+        monkeypatch.setenv("UIPATH_PROJECT_ID", "project-123")
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            _write_project_files()
+
+            overwrite = Mock()
+            overwrites = {"memorySpace.MemorySpace": overwrite}
+            overwrites_seen_by_new_runtime: list[Any] = []
+
+            mock_runtime = _make_mock_runtime()
+
+            async def new_runtime(*args: Any, **kwargs: Any) -> Mock:
+                overwrites_seen_by_new_runtime.append(_resource_overwrites.get())
+                return mock_runtime
+
+            mock_factory = _make_mock_factory(mock_runtime)
+            mock_factory.new_runtime = AsyncMock(side_effect=new_runtime)
+
+            mock_studio_client = Mock()
+            mock_studio_client.get_resource_overwrites = AsyncMock(
+                return_value=overwrites
+            )
+
+            with ExitStack() as stack:
+                _enter_base_patches(stack, mock_factory)
+                stack.enter_context(
+                    patch(
+                        "uipath._cli.cli_eval.StudioClient",
+                        return_value=mock_studio_client,
+                    )
+                )
+                result = runner.invoke(cli, ["eval"])
+
+            assert result.exit_code == 0
+            mock_studio_client.get_resource_overwrites.assert_awaited_once()
+            assert overwrites_seen_by_new_runtime == [overwrites]
+            mock_runtime.dispose.assert_awaited_once()
+
+    def test_no_project_id_runs_without_overwrites(
+        self, runner: CliRunner, temp_dir: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("UIPATH_PROJECT_ID", raising=False)
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            _write_project_files()
+
+            overwrites_seen_by_new_runtime: list[Any] = []
+            mock_runtime = _make_mock_runtime()
+
+            async def new_runtime(*args: Any, **kwargs: Any) -> Mock:
+                overwrites_seen_by_new_runtime.append(_resource_overwrites.get())
+                return mock_runtime
+
+            mock_factory = _make_mock_factory(mock_runtime)
+            mock_factory.new_runtime = AsyncMock(side_effect=new_runtime)
+
+            with ExitStack() as stack:
+                _enter_base_patches(stack, mock_factory)
+                mock_studio_client_cls = stack.enter_context(
+                    patch("uipath._cli.cli_eval.StudioClient")
+                )
+                result = runner.invoke(cli, ["eval"])
+
+            assert result.exit_code == 0
+            mock_studio_client_cls.assert_not_called()
+            assert overwrites_seen_by_new_runtime == [None]
+            mock_runtime.dispose.assert_awaited_once()
+
+    def test_runtime_disposed_when_schema_loading_fails(
+        self, runner: CliRunner, temp_dir: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("UIPATH_PROJECT_ID", raising=False)
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            _write_project_files()
+
+            mock_runtime = _make_mock_runtime()
+            mock_runtime.get_schema = AsyncMock(
+                side_effect=RuntimeError("schema loading failed")
+            )
+            mock_factory = _make_mock_factory(mock_runtime)
+
+            with ExitStack() as stack:
+                _enter_base_patches(stack, mock_factory)
+                stack.enter_context(patch("uipath._cli.cli_eval.StudioClient"))
+                result = runner.invoke(cli, ["eval"])
+
+            assert result.exit_code != 0
+            mock_runtime.dispose.assert_awaited_once()

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.10"
+version = "2.13.11"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Problem

Two related issues in `uipath eval` runs:

1. **Escalation memory spaces bound via solution resource overwrites fail to resolve** (`Escalation memory space 'MemorySpace' was not found`), while the same space resolves for the episodic few-shot feature.
2. **Selecting "No memory" in the eval agent-memory settings actually runs episodic memory** with the agent's own configuration.

## Root causes

**1. Overwrites context entered too late.** `ResourceOverwritesContext` only wrapped `evaluate()`, but `runtime_factory.new_runtime()` — called earlier to fetch the schema and load evaluators — builds the full agent graph, and tool creation resolves folder-scoped resources at that point. Those lookups ran with `_resource_overwrites` unset, so the `memorySpace.<name>` folder override was never applied and resolution fell back to the sentinel `folderPath` (`solution_folder`) → execution folder, where the memory space does not exist. The episodic lookup only appeared to work by accident: it passes the literal `solution_folder` string as a folder path, the folder-key lookup finds nothing, and the ECS query goes out with no folder header (unscoped). `uipath run` and `uipath debug` already enter the context before creating the runtime; only the eval path had the ordering inverted.

**2. Missing "NoMemory" sentinel handling.** Selecting "No memory" passes the `NoMemory` settings id, whose persisted entry stores `"NoMemory"` field values. The override resolver matched it like a real entry and returned `enabled=True`, so the factory force-enabled the memorySpace feature, rejected `"NoMemory"` as an invalid resultCount/threshold, and kept the agent's own values — the opposite of what the user selected. The Agents backend (`ApplyAgentMemorySettingsOverride`) removes the memory feature for a null or `NoMemory` setting.

## Fixes

- Wrap runtime creation, schema/evaluator loading, and `evaluate()` in a single `AsyncExitStack` that enters `ResourceOverwritesContext` first, matching the run/debug ordering.
- Dispose the schema-probe runtime in a `try/finally` so it is not leaked when schema or evaluator loading raises.
- Treat a `NoMemory` requested id or resolved entry as memory disabled (`{"enabled": False}`), before the first-entry fallback can apply unrelated settings.
- Bump `uipath` to 2.13.11.

## Testing

- New `test_eval_resource_overwrites.py`: overwrites context is active when `new_runtime()` is called; no-project-id path runs without overwrites; runtime disposed on schema failure.
- New `NoMemory` cases in `test_agent_memory_settings.py`: sentinel id disables memory (with and without a persisted entry), and the default fallback to a `NoMemory` entry disables memory.
- `pytest tests/cli/eval/` — 456 passed; `ruff` / `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)