### PR TITLE
fix(eval): reject out-of-range scores from LLM judge tool calls

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.13"
+version = "2.13.14"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_llm_helpers.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_llm_helpers.py
@@ -93,27 +93,18 @@ def extract_tool_call_response(response: Any, model: str) -> LLMResponse:
         score = float(arguments["score"])
         justification = str(arguments["justification"])
 
-        if not math.isfinite(score):
+        # Models occasionally emit corrupted numeric tool arguments despite the
+        # 0-100 range stated in the tool schema (e.g. gemini-2.5-flash returning
+        # 989898 or 950). Unvalidated, such a value poisons every run-level
+        # aggregate downstream, so reject it and let the evaluation surface as
+        # an error instead of recording a fabricated score.
+        if not math.isfinite(score) or score < 0.0 or score > 100.0:
             error_msg = (
-                f"Non-finite score {score!r} in tool call arguments from model {model}"
+                f"Invalid score {score!r} in tool call arguments from model {model}: "
+                f"expected a number between 0 and 100"
             )
             logger.error(f"❌ {error_msg}")
             raise ValueError(error_msg)
-
-        # Models occasionally emit corrupted numeric tool arguments despite the
-        # 0-100 range stated in the tool schema (e.g. gemini-2.5-flash returning
-        # 989898 or 950). An unclamped value poisons every run-level aggregate
-        # downstream, so clamp here and surface the correction in the justification.
-        if score < 0.0 or score > 100.0:
-            clamped = max(0.0, min(100.0, score))
-            logger.warning(
-                f"⚠️ Model {model} returned out-of-range score {score}; clamping to {clamped}"
-            )
-            justification = (
-                f"[Warning: model returned out-of-range score {score}; "
-                f"clamped to {clamped}.]\n{justification}"
-            )
-            score = clamped
 
         logger.debug(
             f"✅ Extracted score: {score}, justification length: {len(justification)} chars"

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_llm_helpers.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_llm_helpers.py
@@ -90,7 +90,17 @@ def extract_tool_call_response(response: Any, model: str) -> LLMResponse:
             logger.debug(f"Arguments: {arguments}")
             raise ValueError(error_msg)
 
-        score = float(arguments["score"])
+        try:
+            score = float(arguments["score"])
+        except (ValueError, TypeError) as e:
+            error_msg = (
+                f"Non-numeric score {arguments['score']!r} in tool call arguments "
+                f"from model {model}: expected a number between 0 and 100"
+            )
+            logger.error(f"❌ {error_msg}")
+            logger.debug(f"Arguments: {arguments}")
+            raise ValueError(error_msg) from e
+
         justification = str(arguments["justification"])
 
         # Models occasionally emit corrupted numeric tool arguments despite the

--- a/packages/uipath/src/uipath/eval/evaluators/legacy_llm_helpers.py
+++ b/packages/uipath/src/uipath/eval/evaluators/legacy_llm_helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for legacy LLM evaluators using function calling."""
 
 import logging
+import math
 from typing import Any
 
 from uipath.platform.chat.llm_gateway import (
@@ -91,6 +92,28 @@ def extract_tool_call_response(response: Any, model: str) -> LLMResponse:
 
         score = float(arguments["score"])
         justification = str(arguments["justification"])
+
+        if not math.isfinite(score):
+            error_msg = (
+                f"Non-finite score {score!r} in tool call arguments from model {model}"
+            )
+            logger.error(f"❌ {error_msg}")
+            raise ValueError(error_msg)
+
+        # Models occasionally emit corrupted numeric tool arguments despite the
+        # 0-100 range stated in the tool schema (e.g. gemini-2.5-flash returning
+        # 989898 or 950). An unclamped value poisons every run-level aggregate
+        # downstream, so clamp here and surface the correction in the justification.
+        if score < 0.0 or score > 100.0:
+            clamped = max(0.0, min(100.0, score))
+            logger.warning(
+                f"⚠️ Model {model} returned out-of-range score {score}; clamping to {clamped}"
+            )
+            justification = (
+                f"[Warning: model returned out-of-range score {score}; "
+                f"clamped to {clamped}.]\n{justification}"
+            )
+            score = clamped
 
         logger.debug(
             f"✅ Extracted score: {score}, justification length: {len(justification)} chars"

--- a/packages/uipath/tests/evaluators/test_legacy_llm_helpers.py
+++ b/packages/uipath/tests/evaluators/test_legacy_llm_helpers.py
@@ -1,0 +1,81 @@
+"""Tests for legacy LLM helper functions (submit_evaluation tool-call parsing)."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from uipath.eval.evaluators.legacy_llm_helpers import extract_tool_call_response
+
+
+def _make_response(arguments: dict[str, Any]) -> Any:
+    """Build a minimal chat-completions response carrying a submit_evaluation tool call."""
+    tool_call = SimpleNamespace(arguments=arguments)
+    message = SimpleNamespace(tool_calls=[tool_call])
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+class TestExtractToolCallResponse:
+    """Test extract_tool_call_response score validation and clamping."""
+
+    def test_valid_score_passes_through(self) -> None:
+        response = _make_response({"score": 88, "justification": "ok"})
+
+        result = extract_tool_call_response(response, "gemini-2.5-flash")
+
+        assert result.score == 88.0
+        assert result.justification == "ok"
+
+    def test_out_of_range_score_is_clamped_to_100(self) -> None:
+        # Real payload observed in production: gemini-2.5-flash returned
+        # score=989898 in its submit_evaluation tool call while the justification
+        # said the outputs "match perfectly". Unclamped, this single value blew a
+        # 64-item run-level average up to 15559.13%.
+        response = _make_response(
+            {"score": 989898, "justification": "matches perfectly"}
+        )
+
+        result = extract_tool_call_response(response, "gemini-2.5-flash")
+
+        assert result.score == 100.0
+        assert "out-of-range score 989898" in result.justification
+        assert "matches perfectly" in result.justification
+
+    def test_out_of_range_950_is_clamped(self) -> None:
+        # Second production occurrence from the same eval run: score=950
+        # (the model most likely intended 95).
+        response = _make_response({"score": 950, "justification": "equivalent"})
+
+        result = extract_tool_call_response(response, "gemini-2.5-flash")
+
+        assert result.score == 100.0
+        assert "out-of-range score 950" in result.justification
+
+    def test_negative_score_is_clamped_to_0(self) -> None:
+        response = _make_response({"score": -5, "justification": "bad"})
+
+        result = extract_tool_call_response(response, "gpt-4o")
+
+        assert result.score == 0.0
+
+    @pytest.mark.parametrize("boundary", [0, 100])
+    def test_boundary_scores_not_modified(self, boundary: int) -> None:
+        response = _make_response({"score": boundary, "justification": "j"})
+
+        result = extract_tool_call_response(response, "m")
+
+        assert result.score == float(boundary)
+        assert result.justification == "j"
+
+    def test_non_finite_score_raises(self) -> None:
+        response = _make_response({"score": float("nan"), "justification": "j"})
+
+        with pytest.raises(ValueError, match="Non-finite score"):
+            extract_tool_call_response(response, "m")
+
+    def test_missing_score_raises(self) -> None:
+        response = _make_response({"justification": "j"})
+
+        with pytest.raises(ValueError, match="Missing 'score'"):
+            extract_tool_call_response(response, "m")

--- a/packages/uipath/tests/evaluators/test_legacy_llm_helpers.py
+++ b/packages/uipath/tests/evaluators/test_legacy_llm_helpers.py
@@ -17,7 +17,7 @@ def _make_response(arguments: dict[str, Any]) -> Any:
 
 
 class TestExtractToolCallResponse:
-    """Test extract_tool_call_response score validation and clamping."""
+    """Test extract_tool_call_response score validation."""
 
     def test_valid_score_passes_through(self) -> None:
         response = _make_response({"score": 88, "justification": "ok"})
@@ -27,40 +27,35 @@ class TestExtractToolCallResponse:
         assert result.score == 88.0
         assert result.justification == "ok"
 
-    def test_out_of_range_score_is_clamped_to_100(self) -> None:
+    def test_out_of_range_score_is_rejected(self) -> None:
         # Real payload observed in production: gemini-2.5-flash returned
         # score=989898 in its submit_evaluation tool call while the justification
-        # said the outputs "match perfectly". Unclamped, this single value blew a
-        # 64-item run-level average up to 15559.13%.
+        # said the outputs "match perfectly". Unvalidated, this single value blew
+        # a 64-item run-level average up to 15559.13%. The evaluation must surface
+        # as an error rather than record a fabricated score.
         response = _make_response(
             {"score": 989898, "justification": "matches perfectly"}
         )
 
-        result = extract_tool_call_response(response, "gemini-2.5-flash")
+        with pytest.raises(ValueError, match="Invalid score 989898"):
+            extract_tool_call_response(response, "gemini-2.5-flash")
 
-        assert result.score == 100.0
-        assert "out-of-range score 989898" in result.justification
-        assert "matches perfectly" in result.justification
-
-    def test_out_of_range_950_is_clamped(self) -> None:
+    def test_out_of_range_950_is_rejected(self) -> None:
         # Second production occurrence from the same eval run: score=950
         # (the model most likely intended 95).
         response = _make_response({"score": 950, "justification": "equivalent"})
 
-        result = extract_tool_call_response(response, "gemini-2.5-flash")
+        with pytest.raises(ValueError, match="Invalid score 950"):
+            extract_tool_call_response(response, "gemini-2.5-flash")
 
-        assert result.score == 100.0
-        assert "out-of-range score 950" in result.justification
-
-    def test_negative_score_is_clamped_to_0(self) -> None:
+    def test_negative_score_is_rejected(self) -> None:
         response = _make_response({"score": -5, "justification": "bad"})
 
-        result = extract_tool_call_response(response, "gpt-4o")
-
-        assert result.score == 0.0
+        with pytest.raises(ValueError, match="Invalid score -5"):
+            extract_tool_call_response(response, "gpt-4o")
 
     @pytest.mark.parametrize("boundary", [0, 100])
-    def test_boundary_scores_not_modified(self, boundary: int) -> None:
+    def test_boundary_scores_accepted(self, boundary: int) -> None:
         response = _make_response({"score": boundary, "justification": "j"})
 
         result = extract_tool_call_response(response, "m")
@@ -68,10 +63,11 @@ class TestExtractToolCallResponse:
         assert result.score == float(boundary)
         assert result.justification == "j"
 
-    def test_non_finite_score_raises(self) -> None:
-        response = _make_response({"score": float("nan"), "justification": "j"})
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_score_is_rejected(self, value: float) -> None:
+        response = _make_response({"score": value, "justification": "j"})
 
-        with pytest.raises(ValueError, match="Non-finite score"):
+        with pytest.raises(ValueError, match="Invalid score"):
             extract_tool_call_response(response, "m")
 
     def test_missing_score_raises(self) -> None:

--- a/packages/uipath/tests/evaluators/test_legacy_llm_helpers.py
+++ b/packages/uipath/tests/evaluators/test_legacy_llm_helpers.py
@@ -75,3 +75,10 @@ class TestExtractToolCallResponse:
 
         with pytest.raises(ValueError, match="Missing 'score'"):
             extract_tool_call_response(response, "m")
+
+    @pytest.mark.parametrize("value", ["not-a-number", None, [95]])
+    def test_non_numeric_score_is_rejected(self, value: Any) -> None:
+        response = _make_response({"score": value, "justification": "j"})
+
+        with pytest.raises(ValueError, match="Non-numeric score"):
+            extract_tool_call_response(response, "m")

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.13"
+version = "2.13.14"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
# fix(eval): reject out-of-range scores from LLM judge tool calls

## Problem

`extract_tool_call_response` in `legacy_llm_helpers.py` takes the `score` argument from the judge model's `submit_evaluation` tool call and passes it through with **no range validation** (`score = float(arguments["score"])`), even though the tool schema declares "Numeric score between 0 and 100".

gemini-2.5-flash occasionally emits corrupted numeric tool arguments (digit repetition). When that happens, the raw value flows through `LegacyLlmAsAJudgeEvaluator` → eval runtime → backend storage, and **no layer on the serverless eval path validates it**. A single corrupted item then poisons the run-level evaluator average.

## Production proof

Eval run for the "Donor Eligibility Triage Agent" (64 items, default Gemini 2.5 + Sonnet trajectory evaluators). The run list UI showed the Gemini evaluator column as **15559.13%** (screenshot in comments / Slack thread).

Trace 1 — [trace-1784158433174.json](https://uipath.enterprise.slack.com/files/U03Q0EK39FF/F0BHQ8XLB25/trace-1784158433174.json) (`STANDARD - Thalassemia` item), raw gemini-2.5-flash response:

```json
{
  "name": "submit_evaluation",
  "arguments": {
    "justification": "The core meaning and all key facts match perfectly between the expected and actual outputs. ...",
    "score": 989898
  }
}
```

Trace 2 — [trace-1784158524459.json](https://uipath.enterprise.slack.com/files/U03Q0EK39FF/F0BH70R5PKR/trace-1784158524459.json) (`STANDARD - Topical Medications` item), raw gemini-2.5-flash response:

```json
{
  "name": "submit_evaluation",
  "arguments": {
    "score": 950,
    "justification": "The actual output is semantically equivalent to the expected output. All key facts are present and accurate. ..."
  }
}
```

Both justifications describe a near-perfect match — the model clearly intended ~98-100 and ~95. One item at 989,898 averaged over 64 items ≈ 15,559 — exactly the corrupted aggregate shown in the UI.

Note the trace's `Evaluation output` span shows the **display** value clamped to 100 (`_spans.py` `normalize_score_to_100`), which masks the corruption at item level while the raw value still poisons the run aggregate — that inconsistency is what made this hard to spot.

## Repro

- **Deterministic:** `pytest packages/uipath/tests/evaluators/test_legacy_llm_helpers.py` — the new tests feed the exact production payloads (989898, 950) into `extract_tool_call_response`.
- **End-to-end:** run any eval set using a legacy LLM-judge evaluator (e.g. "Default Evaluator - Gemini 2.5") on `gemini-2.5-flash` over a reasonably large set; the corruption is stochastic (~2 out of ~128 judge calls in the run above). Point the evaluator at a mock LLM gateway returning `score: 989898` to force it on the first item.

## Fix

Reject invalid scores (out-of-range or non-finite) with a `ValueError`. The `track_evaluation_metrics` decorator on the legacy evaluators converts the exception into an `ErrorEvaluationResult` (`score=0`, `ScoreType.ERROR`) with the invalid value in the details, so **the eval item surfaces as an evaluator error** in the UI instead of silently recording a fabricated score.

> Design note: an earlier revision clamped the score to 0-100 with a warning in the justification. Review feedback (Anirudh) rightly pointed out that clamping fabricates a score the model never gave (950 → 100 when the model likely meant 95), so this now fails the evaluation explicitly.

A companion defense-in-depth PR (UiPath/Agents#5831) makes the backend aggregation treat out-of-range stored values like error scores.

## Testing

- `packages/uipath/tests/evaluators/test_legacy_llm_helpers.py`: 10 tests (production payloads 989898/950, negative, boundaries, NaN/±inf, missing field) — all pass.
- Full `tests/evaluators/` suite: 507 passed, no regressions.
- `ruff check`, `ruff format --check`, `mypy` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
