### PR TITLE
fix: support process entry point selection (#1508)

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.12"
+version = "0.2.13"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_processes_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_processes_service.py
@@ -50,6 +50,7 @@ class ProcessesService(FolderContext, BaseService):
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
         attachments: Optional[list[Attachment]] = None,
+        entry_point: Optional[str] = None,
         parent_operation_id: Optional[str] = None,
         run_as_me: Optional[bool] = None,
         **kwargs: Any,
@@ -64,6 +65,7 @@ class ProcessesService(FolderContext, BaseService):
             attachments (Optional[list]): List of Attachment objects to pass to the process.
             folder_key (Optional[str]): The key of the folder to execute the process in. Override the default one set in the SDK config.
             folder_path (Optional[str]): The path of the folder to execute the process in. Override the default one set in the SDK config.
+            entry_point (Optional[str]): The entry point to execute in a multi-entry-point process package.
             parent_operation_id (Optional[str]): The parent operation ID for BTS tracking correlation.
             run_as_me (Optional[bool]): If True, the job will run under the calling user's identity.
 
@@ -101,6 +103,7 @@ class ProcessesService(FolderContext, BaseService):
             input_data=input_data,
             folder_key=folder_key,
             folder_path=folder_path,
+            entry_point=entry_point,
             parent_span_id=kwargs.get("parent_span_id"),
             parent_operation_id=parent_operation_id,
             run_as_me=run_as_me,
@@ -126,6 +129,7 @@ class ProcessesService(FolderContext, BaseService):
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
         attachments: Optional[list[Attachment]] = None,
+        entry_point: Optional[str] = None,
         parent_operation_id: Optional[str] = None,
         run_as_me: Optional[bool] = None,
         **kwargs: Any,
@@ -140,6 +144,7 @@ class ProcessesService(FolderContext, BaseService):
             attachments (Optional[list]): List of Attachment objects to pass to the process.
             folder_key (Optional[str]): The key of the folder to execute the process in. Override the default one set in the SDK config.
             folder_path (Optional[str]): The path of the folder to execute the process in. Override the default one set in the SDK config.
+            entry_point (Optional[str]): The entry point to execute in a multi-entry-point process package.
             parent_operation_id (Optional[str]): The parent operation ID for BTS tracking correlation.
             run_as_me (Optional[bool]): If True, the job will run under the calling user's identity.
 
@@ -172,6 +177,7 @@ class ProcessesService(FolderContext, BaseService):
             input_data=input_data,
             folder_key=folder_key,
             folder_path=folder_path,
+            entry_point=entry_point,
             parent_span_id=kwargs.get("parent_span_id"),
             parent_operation_id=parent_operation_id,
             run_as_me=run_as_me,
@@ -318,6 +324,7 @@ class ProcessesService(FolderContext, BaseService):
         *,
         folder_key: Optional[str] = None,
         folder_path: Optional[str] = None,
+        entry_point: Optional[str] = None,
         parent_span_id: Optional[str] = None,
         parent_operation_id: Optional[str] = None,
         run_as_me: Optional[bool] = None,
@@ -328,6 +335,9 @@ class ProcessesService(FolderContext, BaseService):
             "Source": "AgentService",
         }
         self._add_tracing(payload, UiPathConfig.trace_id, parent_span_id)
+
+        if entry_point:
+            payload["EntryPointPath"] = entry_point
 
         if parent_operation_id:
             payload["ParentOperationId"] = parent_operation_id

--- a/packages/uipath-platform/tests/services/test_processes_service.py
+++ b/packages/uipath-platform/tests/services/test_processes_service.py
@@ -40,6 +40,7 @@ class TestProcessesService:
     ) -> None:
         process_name = "test-process"
         input_arguments = {"key": "value"}
+        entry_point = "invoice_tools/extract.py:extract_invoice_data"
         httpx_mock.add_response(
             url=f"{base_url}{org}{tenant}/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs",
             status_code=200,
@@ -56,7 +57,7 @@ class TestProcessesService:
             },
         )
 
-        job = service.invoke(process_name, input_arguments)
+        job = service.invoke(process_name, input_arguments, entry_point=entry_point)
 
         assert isinstance(job, Job)
         assert job.key == "test-job-key"
@@ -80,6 +81,7 @@ class TestProcessesService:
                     "ReleaseName": process_name,
                     "InputArguments": json.dumps(input_arguments),
                     "Source": "AgentService",
+                    "EntryPointPath": entry_point,
                 }
             },
             separators=(",", ":"),
@@ -263,6 +265,7 @@ class TestProcessesService:
     ) -> None:
         process_name = "test-process"
         input_arguments = {"key": "value"}
+        entry_point = "invoice_tools/extract.py:extract_invoice_data"
         httpx_mock.add_response(
             url=f"{base_url}{org}{tenant}/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs",
             status_code=200,
@@ -279,7 +282,9 @@ class TestProcessesService:
             },
         )
 
-        job = await service.invoke_async(process_name, input_arguments)
+        job = await service.invoke_async(
+            process_name, input_arguments, entry_point=entry_point
+        )
 
         assert isinstance(job, Job)
         assert job.key == "test-job-key"
@@ -303,6 +308,7 @@ class TestProcessesService:
                     "ReleaseName": process_name,
                     "InputArguments": json.dumps(input_arguments),
                     "Source": "AgentService",
+                    "EntryPointPath": entry_point,
                 }
             },
             separators=(",", ":"),

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2741,7 +2741,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- add an explicit entry_point argument to synchronous and asynchronous process invocation
- forward the selected entry point as EntryPointPath in the Orchestrator StartJobs payload
- cover both invocation paths and bump the uipath-platform patch version with dependent lockfiles

## Why

Multi-entry-point packages currently always run their default entry point because ProcessesService drops the requested path. This keeps the existing fire-and-forget behavior while allowing callers to select the intended entry point.

Addresses part of #1508

## Validation

- uv run --no-sync pytest tests/services/test_processes_service.py (9 passed)
- uv run --no-sync pytest (1590 passed, 7 skipped, 4 deselected)
- uv run --no-sync ruff check .
- uv run --no-sync ruff format --check .
- uv run --no-sync mypy src tests
- git diff --check