### PR TITLE
fix(platform): close service http clients

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "uipath-platform"
-version = "0.2.12"
+version = "0.2.13"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
+  "anyio>=4.0.0",
   "httpx>=0.28.1",
   "tenacity>=9.0.0",
   "truststore>=0.10.1",

--- a/packages/uipath-platform/src/uipath/platform/common/_base_service.py
+++ b/packages/uipath-platform/src/uipath/platform/common/_base_service.py
@@ -3,6 +3,7 @@ import types
 from logging import getLogger
 from typing import Any, Literal, Union
 
+from anyio import to_thread
 from httpx import (
     URL,
     AsyncClient,
@@ -170,6 +171,18 @@ class BaseService:
         self._logger.debug(f"HEADERS: {self.default_headers}")
 
         super().__init__()
+
+    async def aclose(self) -> None:
+        """Close the HTTP clients owned by this service.
+
+        The asynchronous client is closed by the active async backend. Closing the
+        synchronous client can block while its transport is torn down, so that work
+        runs in a backend-neutral worker thread.
+        """
+        try:
+            await self._client_async.aclose()
+        finally:
+            await to_thread.run_sync(self._client.close)
 
     @retry(
         retry=(

--- a/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
@@ -112,6 +112,19 @@ class EntitiesService(BaseService):
             folders_service=folders_service,
         )
 
+    async def aclose(self) -> None:
+        """Close this facade and the services it creates."""
+        try:
+            await self._schema.aclose()
+        finally:
+            try:
+                await self._data.aclose()
+            finally:
+                try:
+                    await self._ontology.aclose()
+                finally:
+                    await super().aclose()
+
     # ------------------------------------------------------------------
     # Schema operations — delegate to EntitySchemaService
     # ------------------------------------------------------------------

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_buckets_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_buckets_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import httpx
+from anyio import to_thread
 from uipath.core.tracing import traced
 
 from ..common._base_service import BaseService
@@ -36,6 +37,16 @@ class BucketsService(FolderContext, BaseService):
         super().__init__(config=config, execution_context=execution_context)
         self.custom_client = httpx.Client(**get_httpx_client_kwargs())
         self.custom_client_async = httpx.AsyncClient(**get_httpx_client_kwargs())
+
+    async def aclose(self) -> None:
+        """Close the additional HTTP clients used for bucket transfers."""
+        try:
+            await self.custom_client_async.aclose()
+        finally:
+            try:
+                await to_thread.run_sync(self.custom_client.close)
+            finally:
+                await super().aclose()
 
     @traced(name="buckets_list", run_type="uipath")
     def list(

--- a/packages/uipath-platform/src/uipath/platform/orchestrator/_jobs_service.py
+++ b/packages/uipath-platform/src/uipath/platform/orchestrator/_jobs_service.py
@@ -43,6 +43,13 @@ class JobsService(FolderContext, BaseService):
         self._temp_dir = os.path.join(tempfile.gettempdir(), TEMP_ATTACHMENTS_FOLDER)
         os.makedirs(self._temp_dir, exist_ok=True)
 
+    async def aclose(self) -> None:
+        """Close this service and the attachment service it owns."""
+        try:
+            await self._attachments_service.aclose()
+        finally:
+            await super().aclose()
+
     @overload
     def resume(self, *, inbox_id: str, payload: Any) -> None: ...
 

--- a/packages/uipath-platform/tests/services/test_base_service.py
+++ b/packages/uipath-platform/tests/services/test_base_service.py
@@ -18,6 +18,14 @@ class TestBaseService:
     def test_init_base_service(self, service: BaseService):
         assert service is not None
 
+    @pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+    @pytest.mark.anyio
+    async def test_aclose_closes_owned_http_clients(self, service: BaseService):
+        await service.aclose()
+
+        assert service._client.is_closed
+        assert service._client_async.is_closed
+
     def test_base_service_default_headers(self, service: BaseService, secret: str):
         assert service.default_headers == {
             "Accept": "application/json",

--- a/packages/uipath-platform/tests/services/test_buckets_service.py
+++ b/packages/uipath-platform/tests/services/test_buckets_service.py
@@ -27,6 +27,18 @@ def temp_file(tmp_path):
 
 
 class TestBucketsService:
+    @pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+    @pytest.mark.anyio
+    async def test_aclose_closes_all_owned_http_clients(
+        self, service: BucketsService
+    ) -> None:
+        await service.aclose()
+
+        assert service._client.is_closed
+        assert service._client_async.is_closed
+        assert service.custom_client.is_closed
+        assert service.custom_client_async.is_closed
+
     class TestRetrieve:
         def test_retrieve_by_key(
             self,

--- a/packages/uipath-platform/tests/services/test_entities_service.py
+++ b/packages/uipath-platform/tests/services/test_entities_service.py
@@ -55,6 +55,20 @@ def record_schema_optional(request):
 
 
 class TestEntitiesService:
+    @pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
+    @pytest.mark.anyio
+    async def test_aclose_closes_owned_services(self, service: EntitiesService):
+        await service.aclose()
+
+        assert service._client.is_closed
+        assert service._client_async.is_closed
+        assert service._schema._client.is_closed
+        assert service._schema._client_async.is_closed
+        assert service._data._client.is_closed
+        assert service._data._client_async.is_closed
+        assert service._ontology._client.is_closed
+        assert service._ontology._client_async.is_closed
+
     def test_query_entity_records_has_datafabric_error_mapping(self) -> None:
         assert (
             EntitiesService.query_entity_records.__uipath_datafabric_method__  # type: ignore[attr-defined]

--- a/packages/uipath-platform/tests/services/test_jobs_service.py
+++ b/packages/uipath-platform/tests/services/test_jobs_service.py
@@ -101,6 +101,15 @@ def local_attachment_file(
 
 
 class TestJobsService:
+    @pytest.mark.anyio
+    async def test_aclose_closes_owned_services(self, service: JobsService):
+        await service.aclose()
+
+        assert service._client.is_closed
+        assert service._client_async.is_closed
+        assert service._attachments_service._client.is_closed
+        assert service._attachments_service._client_async.is_closed
+
     def test_retrieve(
         self,
         httpx_mock: HTTPXMock,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,9 +1095,10 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "pydantic-function-models" },
     { name = "sqlparse" },
@@ -1123,6 +1124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-function-models", specifier = ">=0.1.11" },
     { name = "sqlparse", specifier = ">=0.5.5" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2741,9 +2741,10 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "../uipath-platform" }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "pydantic-function-models" },
     { name = "sqlparse" },
@@ -2754,6 +2755,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-function-models", specifier = ">=0.1.11" },
     { name = "sqlparse", specifier = ">=0.5.5" },


### PR DESCRIPTION
## Summary
- expose async cleanup for platform services
- close nested job attachment clients with their owner

## Why

Runtime integrations can now release the HTTP clients they create without reaching into private SDK attributes.