### PR TITLE
feat(agent): add http-request internal tool type

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.13.15"
+version = "2.13.16"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -1047,7 +1047,7 @@ class AgentInternalBatchTransformToolProperties(BaseResourceProperties):
     settings: AgentInternalBatchTransformSettings = Field(..., alias="settings")
 
 
-class AgentInternalHttpRequestProperties(BaseResourceProperties):
+class AgentInternalHttpRequestToolProperties(BaseResourceProperties):
     """Agent internal http request tool properties model."""
 
     tool_type: Literal[AgentInternalToolType.HTTP_REQUEST] = Field(
@@ -1060,7 +1060,7 @@ AgentInternalToolProperties = Annotated[
         AgentInternalAnalyzeFilesToolProperties,
         AgentInternalDeepRagToolProperties,
         AgentInternalBatchTransformToolProperties,
-        AgentInternalHttpRequestProperties,
+        AgentInternalHttpRequestToolProperties,
     ],
     Field(discriminator="tool_type"),
     _case_insensitive_enum_validator("tool_type", AgentInternalToolType, "toolType"),

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -127,6 +127,7 @@ class AgentInternalToolType(str, CaseInsensitiveEnum):
     ANALYZE_FILES = "analyze-attachments"
     DEEP_RAG = "deep-rag"
     BATCH_TRANSFORM = "batch-transform"
+    HTTP_REQUEST = "http-request"
 
 
 class AgentEscalationRecipientType(str, CaseInsensitiveEnum):
@@ -1046,11 +1047,20 @@ class AgentInternalBatchTransformToolProperties(BaseResourceProperties):
     settings: AgentInternalBatchTransformSettings = Field(..., alias="settings")
 
 
+class AgentInternalHttpRequestProperties(BaseResourceProperties):
+    """Agent internal http request tool properties model."""
+
+    tool_type: Literal[AgentInternalToolType.HTTP_REQUEST] = Field(
+        alias="toolType", default=AgentInternalToolType.HTTP_REQUEST, frozen=True
+    )
+
+
 AgentInternalToolProperties = Annotated[
     Union[
         AgentInternalAnalyzeFilesToolProperties,
         AgentInternalDeepRagToolProperties,
         AgentInternalBatchTransformToolProperties,
+        AgentInternalHttpRequestProperties,
     ],
     Field(discriminator="tool_type"),
     _case_insensitive_enum_validator("tool_type", AgentInternalToolType, "toolType"),

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -27,6 +27,7 @@ from uipath.agent.models.agent import (
     AgentIntegrationToolResourceConfig,
     AgentInternalBatchTransformToolProperties,
     AgentInternalDeepRagToolProperties,
+    AgentInternalHttpRequestToolProperties,
     AgentInternalToolResourceConfig,
     AgentInternalToolType,
     AgentIxpExtractionResourceConfig,
@@ -3157,6 +3158,24 @@ class TestAgentBuilderConfig:
                     "description": "Test batch transform tool",
                     "isEnabled": True,
                 },
+                {
+                    "$resourceType": "Tool",
+                    "type": "Internal",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                    "outputSchema": {"type": "object", "properties": {}},
+                    "arguments": {},
+                    "settings": {"timeout": 0, "maxAttempts": 0, "retryDelay": 0},
+                    "properties": {
+                        "toolType": "Http-Request",
+                    },
+                    "argumentProperties": {},
+                    "name": "HTTP Request Tool",
+                    "description": "Test http request tool",
+                    "isEnabled": True,
+                },
             ],
             "guardrails": [
                 {
@@ -3277,6 +3296,15 @@ class TestAgentBuilderConfig:
         assert (
             batch_tool.properties.settings.web_search_grounding.value
             == BatchTransformWebSearchGrounding.ENABLED
+        )
+
+        http_request_tool = config.resources[5]
+        assert isinstance(http_request_tool, AgentInternalToolResourceConfig)
+        assert isinstance(
+            http_request_tool.properties, AgentInternalHttpRequestToolProperties
+        )
+        assert (
+            http_request_tool.properties.tool_type == AgentInternalToolType.HTTP_REQUEST
         )
 
         assert config.guardrails is not None

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.15"
+version = "2.13.16"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary
- Add `HTTP_REQUEST` (`http-request`) to `AgentInternalToolType`
- Add `AgentInternalHttpRequestProperties` model and register it in the `AgentInternalToolProperties` discriminated union
- Bump `uipath` version to 2.13.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)