### PR TITLE
feat(agent): add modelSettings to agent settings [PC-4672]

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.14.10"
+version = "2.14.11"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.14.5"
+version = "2.15.0"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -1417,6 +1417,14 @@ class AgentByomProperties(BaseCfg):
     connector_key: str = Field(alias="connectorKey")
 
 
+class ModelSettings(BaseCfg):
+    """Provider-native model settings bag (``settings.modelSettings``).
+
+    Keys are the target model's own parameter names, forwarded verbatim — no fixed
+    schema; discovery is the source of truth for the shape.
+    """
+
+
 class AgentSettings(BaseCfg):
     """Agent settings model."""
 
@@ -1427,6 +1435,7 @@ class AgentSettings(BaseCfg):
     byom_properties: Optional[AgentByomProperties] = Field(None, alias="byomProperties")
     max_iterations: Optional[int] = Field(None, alias="maxIterations")
     persona: Optional[str] = Field(None, alias="persona")
+    model_settings: Optional[ModelSettings] = Field(None, alias="modelSettings")
 
 
 class AgentDefinition(BaseModel):

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -39,6 +39,7 @@ from uipath.agent.models.agent import (
     AgentProcessToolResourceConfig,
     AgentQuickFormChannelProperties,
     AgentResourceType,
+    AgentSettings,
     AgentToolArgumentPropertiesVariant,
     AgentToolType,
     AgentUnknownGuardrail,
@@ -4750,3 +4751,30 @@ class TestToolOutputRecipientDeserialization:
         ).validate_python(payload)
         assert isinstance(recipient, CustomAssigneesRecipient)
         assert not isinstance(recipient, ToolOutputRecipient)
+
+
+class TestAgentModelSettings:
+    """settings.modelSettings is a native bag forwarded verbatim (no schema)."""
+
+    def _agent_settings(self, **extra: Any) -> dict[str, Any]:
+        return {
+            "engine": "basic-v2",
+            "model": "anthropic.claude-opus-4-6-v1",
+            "maxTokens": 49047,
+            "temperature": 0.63,
+            **extra,
+        }
+
+    def test_absent_model_settings_is_none(self):
+        settings = AgentSettings.model_validate(self._agent_settings())
+        assert settings.model_settings is None
+
+    def test_native_bag_survives_verbatim_by_alias(self):
+        native = {
+            "thinking": {"type": "enabled", "budget_tokens": 2048},
+            "output_config": {"effort": "high"},
+        }
+        settings = AgentSettings.model_validate(
+            self._agent_settings(modelSettings=native)
+        )
+        assert settings.model_dump(by_alias=True)["modelSettings"] == native

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.5"
+version = "2.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.10"
+version = "2.14.11"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
Add a `modelSettings` block to `settings` in agent.json, parsed into `AgentSettings.model_settings`. It's a native bag (`ModelSettings(BaseCfg)`, no declared fields); keys are the target model's own parameter names and are forwarded verbatim, so discovery stays the source of truth for the shape. Absent `modelSettings` parses to None, keeping existing agent.json working.