### PR TITLE
fix: categorize missing HITL index as deployment

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.15"
+version = "0.2.16"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/resume_triggers/_protocol.py
+++ b/packages/uipath-platform/src/uipath/platform/resume_triggers/_protocol.py
@@ -60,6 +60,7 @@ from uipath.platform.context_grounding.context_grounding_index import (
 from uipath.platform.errors import (
     BatchTransformFailedException,
     BatchTransformNotCompleteException,
+    ContextGroundingIndexNotFoundError,
     OperationNotCompleteException,
 )
 from uipath.platform.orchestrator.job import JobState
@@ -544,6 +545,8 @@ class UiPathResumeTriggerCreator:
                         f"Unexpected model received"
                         f"{type(suspend_value)} is not a valid Human-In-The-Loop model",
                     )
+        except UiPathFaultedTriggerError:
+            raise
         except Exception as e:
             raise UiPathFaultedTriggerError(
                 ErrorCategory.SYSTEM,
@@ -697,28 +700,35 @@ class UiPathResumeTriggerCreator:
             resume_trigger.item_key = value.deep_rag.id
         elif isinstance(value, CreateDeepRag):
             uipath = UiPath()
-            if value.is_ephemeral_index:
-                deep_rag = (
-                    await uipath.context_grounding.start_deep_rag_ephemeral_async(
+            try:
+                if value.is_ephemeral_index:
+                    deep_rag = (
+                        await uipath.context_grounding.start_deep_rag_ephemeral_async(
+                            name=value.name,
+                            index_id=value.index_id,
+                            prompt=value.prompt,
+                            glob_pattern=value.glob_pattern,
+                            citation_mode=value.citation_mode,
+                        )
+                    )
+                else:
+                    deep_rag = await uipath.context_grounding.start_deep_rag_async(
                         name=value.name,
+                        index_name=value.index_name,
                         index_id=value.index_id,
                         prompt=value.prompt,
                         glob_pattern=value.glob_pattern,
                         citation_mode=value.citation_mode,
+                        folder_path=value.index_folder_path,
+                        folder_key=value.index_folder_key,
                     )
-                )
-
-            else:
-                deep_rag = await uipath.context_grounding.start_deep_rag_async(
-                    name=value.name,
-                    index_name=value.index_name,
-                    index_id=value.index_id,
-                    prompt=value.prompt,
-                    glob_pattern=value.glob_pattern,
-                    citation_mode=value.citation_mode,
-                    folder_path=value.index_folder_path,
-                    folder_key=value.index_folder_key,
-                )
+            except ContextGroundingIndexNotFoundError as e:
+                raise UiPathFaultedTriggerError(
+                    ErrorCategory.DEPLOYMENT,
+                    "Context grounding index not found. Check that the index is "
+                    "deployed and available in the configured folder.",
+                    str(e),
+                ) from e
             if not deep_rag:
                 raise Exception("Failed to start deep rag")
 
@@ -778,27 +788,35 @@ class UiPathResumeTriggerCreator:
             resume_trigger.item_key = value.batch_transform.id
         elif isinstance(value, CreateBatchTransform):
             uipath = UiPath()
-            if value.is_ephemeral_index:
-                batch_transform = await uipath.context_grounding.start_batch_transform_ephemeral_async(
-                    name=value.name,
-                    index_id=value.index_id,
-                    prompt=value.prompt,
-                    output_columns=value.output_columns,
-                    storage_bucket_folder_path_prefix=value.storage_bucket_folder_path_prefix,
-                    enable_web_search_grounding=value.enable_web_search_grounding,
-                )
-            else:
-                batch_transform = await uipath.context_grounding.start_batch_transform_async(
-                    name=value.name,
-                    index_name=value.index_name,
-                    index_id=value.index_id,
-                    prompt=value.prompt,
-                    output_columns=value.output_columns,
-                    storage_bucket_folder_path_prefix=value.storage_bucket_folder_path_prefix,
-                    enable_web_search_grounding=value.enable_web_search_grounding,
-                    folder_path=value.index_folder_path,
-                    folder_key=value.index_folder_key,
-                )
+            try:
+                if value.is_ephemeral_index:
+                    batch_transform = await uipath.context_grounding.start_batch_transform_ephemeral_async(
+                        name=value.name,
+                        index_id=value.index_id,
+                        prompt=value.prompt,
+                        output_columns=value.output_columns,
+                        storage_bucket_folder_path_prefix=value.storage_bucket_folder_path_prefix,
+                        enable_web_search_grounding=value.enable_web_search_grounding,
+                    )
+                else:
+                    batch_transform = await uipath.context_grounding.start_batch_transform_async(
+                        name=value.name,
+                        index_name=value.index_name,
+                        index_id=value.index_id,
+                        prompt=value.prompt,
+                        output_columns=value.output_columns,
+                        storage_bucket_folder_path_prefix=value.storage_bucket_folder_path_prefix,
+                        enable_web_search_grounding=value.enable_web_search_grounding,
+                        folder_path=value.index_folder_path,
+                        folder_key=value.index_folder_key,
+                    )
+            except ContextGroundingIndexNotFoundError as e:
+                raise UiPathFaultedTriggerError(
+                    ErrorCategory.DEPLOYMENT,
+                    "Context grounding index not found. Check that the index is "
+                    "deployed and available in the configured folder.",
+                    str(e),
+                ) from e
             if not batch_transform:
                 raise Exception("Failed to start batch transform")
 

--- a/packages/uipath-platform/tests/services/test_hitl.py
+++ b/packages/uipath-platform/tests/services/test_hitl.py
@@ -67,6 +67,7 @@ from uipath.platform.documents import (
     StartExtractionValidationResponse,
     ValidateExtractionAction,
 )
+from uipath.platform.errors import ContextGroundingIndexNotFoundError
 from uipath.platform.orchestrator import Job, JobErrorInfo
 from uipath.platform.orchestrator.job import JobState
 from uipath.platform.resume_triggers import (
@@ -1706,6 +1707,38 @@ class TestHitlProcessor:
             )
 
     @pytest.mark.anyio
+    async def test_missing_deep_rag_index_is_deployment_error(
+        self,
+        setup_test_env: None,
+    ) -> None:
+        create_deep_rag = CreateDeepRag(
+            name="test-deep-rag",
+            index_name="Files",
+            prompt="test prompt",
+            glob_pattern="**/*.pdf",
+            citation_mode=CitationMode.INLINE,
+            index_folder_path="/test/path",
+        )
+        missing_index = ContextGroundingIndexNotFoundError("Files")
+        mock_start_deep_rag = AsyncMock(side_effect=missing_index)
+
+        with patch(
+            "uipath.platform.context_grounding._context_grounding_service.ContextGroundingService.start_deep_rag_async",
+            new=mock_start_deep_rag,
+        ):
+            with pytest.raises(UiPathFaultedTriggerError) as exc_info:
+                await UiPathResumeTriggerCreator().create_trigger(create_deep_rag)
+
+        error = exc_info.value
+        assert error.category == ErrorCategory.DEPLOYMENT
+        assert error.message == (
+            "Context grounding index not found. Check that the index is deployed and "
+            "available in the configured folder."
+        )
+        assert error.detail == "ContextGroundingIndex 'Files' not found"
+        assert error.__cause__ is missing_index
+
+    @pytest.mark.anyio
     async def test_create_resume_trigger_wait_deep_rag(
         self,
         setup_test_env: None,
@@ -1831,6 +1864,42 @@ class TestHitlProcessor:
                 folder_path=create_batch_transform.index_folder_path,
                 folder_key=create_batch_transform.index_folder_key,
             )
+
+    @pytest.mark.anyio
+    async def test_missing_batch_transform_index_is_deployment_error(
+        self,
+        setup_test_env: None,
+    ) -> None:
+        create_batch_transform = CreateBatchTransform(
+            name="test-batch-transform",
+            index_name="Files",
+            prompt="test prompt",
+            output_columns=[
+                BatchTransformOutputColumn(name="column1", description="desc1")
+            ],
+            destination_path="/output/path.xlsx",
+            index_folder_path="/test/path",
+        )
+        missing_index = ContextGroundingIndexNotFoundError("Files")
+        mock_start_batch_transform = AsyncMock(side_effect=missing_index)
+
+        with patch(
+            "uipath.platform.context_grounding._context_grounding_service.ContextGroundingService.start_batch_transform_async",
+            new=mock_start_batch_transform,
+        ):
+            with pytest.raises(UiPathFaultedTriggerError) as exc_info:
+                await UiPathResumeTriggerCreator().create_trigger(
+                    create_batch_transform
+                )
+
+        error = exc_info.value
+        assert error.category == ErrorCategory.DEPLOYMENT
+        assert error.message == (
+            "Context grounding index not found. Check that the index is deployed and "
+            "available in the configured folder."
+        )
+        assert error.detail == "ContextGroundingIndex 'Files' not found"
+        assert error.__cause__ is missing_index
 
     @pytest.mark.anyio
     async def test_create_resume_trigger_wait_batch_transform(

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.15"
+version = "0.2.16"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2760,7 +2760,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.15"
+version = "0.2.16"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- categorize missing Context Grounding indexes during DeepRAG and batch RAG trigger creation as deployment errors
- preserve already-classified trigger errors and the original missing-index detail
- guide users to check index deployment and folder configuration

## Why

Missing indexes were being caught by the generic HITL wrapper and reported as system errors. The Context Grounding handlers now own this classification.