### PR TITLE
feat(guardrails): resolve BYOG by validator name only [AL-510]

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.16"
+version = "0.2.17"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/_guardrails_service.py
@@ -127,8 +127,6 @@ class GuardrailsService(BaseService):
                     "BYO (Bring Your Own) guardrails require byo_validator_name."
                 )
             payload["byoValidatorName"] = guardrail.byo_validator_name
-            if guardrail.byo_connection_id:
-                payload["byoConnectionId"] = guardrail.byo_connection_id
         spec = RequestSpec(
             method="POST",
             endpoint=Endpoint("/agentsruntime_/api/execution/guardrails/validate"),

--- a/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/byo.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/decorators/validators/byo.py
@@ -19,13 +19,13 @@ class ByoValidator(BuiltInGuardrailValidator):
     Azure Content Safety subscription, a vendor connector, or a custom
     Integration Service connector) into UiPath guardrails. An admin first
     creates the configuration under ``Admin -> AI Trust Layer -> Guardrails
-    Configurations``; this validator references it by its validator name and
-    (recommended) Integration Service connection id.
+    Configurations``; this validator references it purely by its validator
+    name, which is unique per tenant. The Integration Service connection to
+    use is resolved server-side from the configuration, so an admin rebind is
+    always honored.
 
     Supported at all stages — BYO validator capabilities are connector-defined
     and cannot be known statically, so no stage restriction is applied here.
-    Configuring a scope or stage the connector does not support surfaces as a
-    ``PROVIDER_ERROR`` at evaluation time.
 
     Example::
 
@@ -35,10 +35,7 @@ class ByoValidator(BuiltInGuardrailValidator):
             guardrail,
         )
 
-        byog_harmful_content = ByoValidator(
-            "byog-harmful-content",
-            connection_id="24887687-6ed1-4fe2-9b87-087ffb232682",
-        )
+        byog_harmful_content = ByoValidator("my-harmful-content-guardrail")
 
         @guardrail(validator=byog_harmful_content, action=BlockAction())
         def summarize(text: str) -> str:
@@ -47,11 +44,7 @@ class ByoValidator(BuiltInGuardrailValidator):
     Args:
         validator_name: The BYOG configuration's validator name
             (``byoValidatorName``), as shown in Admin -> AI Trust Layer ->
-            Guardrails Configurations.
-        connection_id: Optional Integration Service connection id backing the
-            BYOG configuration. Strongly recommended: validator names are only
-            unique per connection, so omitting it lets the server pick the
-            first configuration matching the name.
+            Guardrails Configurations. Unique per tenant.
         parameters: Optional list of validator parameters. BYO parameter
             schemas are connector-defined, so values are passed through as-is.
 
@@ -63,14 +56,12 @@ class ByoValidator(BuiltInGuardrailValidator):
         self,
         validator_name: str,
         *,
-        connection_id: str | None = None,
         parameters: Sequence[ValidatorParameter] | None = None,
     ) -> None:
         """Initialize ByoValidator with a BYOG configuration reference."""
         if not validator_name or not validator_name.strip():
             raise ValueError("validator_name must be a non-empty string")
         self.validator_name = validator_name
-        self.connection_id = connection_id
         self.parameters = list(parameters or [])
 
     def get_built_in_guardrail(
@@ -88,7 +79,7 @@ class ByoValidator(BuiltInGuardrailValidator):
 
         Returns:
             Configured :class:`BuiltInValidatorGuardrail` referencing the BYOG
-            configuration via ``byoValidatorName``/``byoConnectionId``.
+            configuration via ``byoValidatorName``.
         """
         return BuiltInValidatorGuardrail(
             id=str(uuid4()),
@@ -100,5 +91,4 @@ class ByoValidator(BuiltInGuardrailValidator):
             validator_type=BYO_VALIDATOR_TYPE,
             validator_parameters=self.parameters,
             byo_validator_name=self.validator_name,
-            byo_connection_id=self.connection_id,
         )

--- a/packages/uipath-platform/src/uipath/platform/guardrails/guardrails.py
+++ b/packages/uipath-platform/src/uipath/platform/guardrails/guardrails.py
@@ -92,7 +92,6 @@ class BuiltInValidatorGuardrail(BaseGuardrail):
         default_factory=list, alias="validatorParameters"
     )
     byo_validator_name: str | None = Field(default=None, alias="byoValidatorName")
-    byo_connection_id: str | None = Field(default=None, alias="byoConnectionId")
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/packages/uipath-platform/tests/services/test_guardrails_decorators.py
+++ b/packages/uipath-platform/tests/services/test_guardrails_decorators.py
@@ -1253,29 +1253,22 @@ class TestByoValidator:
         with pytest.raises(ValueError, match="validator_name"):
             ByoValidator("   ")
 
-    def test_builds_byo_guardrail_with_name_and_connection(self):
-        v = ByoValidator(
-            "byog-harmful-content",
-            connection_id="24887687-6ed1-4fe2-9b87-087ffb232682",
-        )
+    def test_builds_byo_guardrail_from_name_alone(self):
+        v = ByoValidator("my-harmful-content-guardrail")
         g = v.get_built_in_guardrail("G", None, True)
         assert g.validator_type == "byo"
-        assert g.byo_validator_name == "byog-harmful-content"
-        assert g.byo_connection_id == "24887687-6ed1-4fe2-9b87-087ffb232682"
-
-    def test_connection_id_defaults_to_none(self):
-        v = ByoValidator("byog-harmful-content")
-        g = v.get_built_in_guardrail("G", None, True)
-        assert g.byo_connection_id is None
+        assert g.byo_validator_name == "my-harmful-content-guardrail"
 
     def test_aliases_serialize_for_the_wire(self):
-        v = ByoValidator("byog-pii", connection_id="conn-1")
+        v = ByoValidator("byog-pii")
         g = v.get_built_in_guardrail("G", None, True)
         dumped = g.model_dump(by_alias=True)
         assert dumped["validatorType"] == "byo"
         assert dumped["byoValidatorName"] == "byog-pii"
-        assert dumped["byoConnectionId"] == "conn-1"
         assert dumped["$guardrailType"] == "builtInValidator"
+        # BYOG resolves by validator name alone (unique per tenant); no
+        # connection id exists on the wire model.
+        assert "byoConnectionId" not in dumped
 
     def test_parameters_pass_through(self):
         from uipath.platform.guardrails.guardrails import NumberParameterValue
@@ -1308,7 +1301,7 @@ class TestByoValidator:
         assert g.selector is None
 
     def test_run_forwards_byo_guardrail_to_service(self):
-        v = ByoValidator("byog-harmful-content", connection_id="conn-1")
+        v = ByoValidator("my-harmful-content-guardrail")
         mock_uipath = MagicMock()
         mock_uipath.guardrails.evaluate_guardrail.return_value = (
             GuardrailValidationResult(
@@ -1323,5 +1316,4 @@ class TestByoValidator:
         data, g = mock_uipath.guardrails.evaluate_guardrail.call_args[0]
         assert data == "some input"
         assert g.validator_type == "byo"
-        assert g.byo_validator_name == "byog-harmful-content"
-        assert g.byo_connection_id == "conn-1"
+        assert g.byo_validator_name == "my-harmful-content-guardrail"

--- a/packages/uipath-platform/tests/services/test_guardrails_service.py
+++ b/packages/uipath-platform/tests/services/test_guardrails_service.py
@@ -350,7 +350,7 @@ class TestGuardrailsService:
             assert request_payload["byoValidatorName"] == "my_databricks_pii"
             assert result.result == GuardrailValidationResultType.PASSED
 
-        def test_evaluate_guardrail_byog_forwards_byo_connection_id(
+        def test_evaluate_guardrail_byog_never_forwards_legacy_connection_id(
             self,
             httpx_mock: HTTPXMock,
             service: GuardrailsService,
@@ -358,8 +358,10 @@ class TestGuardrailsService:
             org: str,
             tenant: str,
         ) -> None:
-            """A BYOG guardrail forwards byoConnectionId so the backend can narrow
-            configuration resolution to the specific connection."""
+            """A legacy byoConnectionId (from persisted json or an older caller)
+            is never forwarded: BYOG resolves by validator name alone, which is
+            unique per tenant; the connection comes from the configuration
+            server-side."""
             captured_request = None
 
             def capture_request(request):
@@ -376,16 +378,18 @@ class TestGuardrailsService:
                 callback=capture_request,
             )
 
-            byog_guardrail = BuiltInValidatorGuardrail(
-                id="byog-id",
-                name="Databricks PII (BYOG)",
-                enabled_for_evals=True,
-                selector=GuardrailSelector(scopes=[GuardrailScope.LLM]),
-                guardrail_type="builtInValidator",
-                validator_type="byo",
-                byo_validator_name="my_databricks_pii",
-                byo_connection_id="byog-conn-1",
-                validator_parameters=[],
+            byog_guardrail = BuiltInValidatorGuardrail.model_validate(
+                {
+                    "$guardrailType": "builtInValidator",
+                    "id": "byog-id",
+                    "name": "Databricks PII (BYOG)",
+                    "enabledForEvals": True,
+                    "selector": {"scopes": ["Llm"]},
+                    "validatorType": "byo",
+                    "byoValidatorName": "my_databricks_pii",
+                    "byoConnectionId": "byog-conn-1",
+                    "validatorParameters": [],
+                }
             )
 
             service.evaluate_guardrail("some input", byog_guardrail)
@@ -393,9 +397,9 @@ class TestGuardrailsService:
             assert captured_request is not None
             request_payload = json.loads(captured_request.content)
             assert request_payload["byoValidatorName"] == "my_databricks_pii"
-            assert request_payload["byoConnectionId"] == "byog-conn-1"
+            assert "byoConnectionId" not in request_payload
 
-        def test_evaluate_guardrail_byog_omits_connection_id_when_absent(
+        def test_evaluate_guardrail_byog_resolves_by_name_alone(
             self,
             httpx_mock: HTTPXMock,
             service: GuardrailsService,
@@ -403,8 +407,8 @@ class TestGuardrailsService:
             org: str,
             tenant: str,
         ) -> None:
-            """byoConnectionId is only forwarded when present; a BYOG guardrail without
-            one resolves by validator name alone."""
+            """A BYOG guardrail carries only byoValidatorName; no connection id
+            appears in the payload."""
             captured_request = None
 
             def capture_request(request):
@@ -438,8 +442,11 @@ class TestGuardrailsService:
             request_payload = json.loads(captured_request.content)
             assert "byoConnectionId" not in request_payload
 
-        def test_evaluate_guardrail_byo_connection_id_from_alias(self) -> None:
-            """byoConnectionId parses into the typed field via its camelCase alias."""
+        def test_evaluate_guardrail_legacy_byo_connection_id_still_parses(
+            self,
+        ) -> None:
+            """Legacy json carrying byoConnectionId still parses (extra="allow"),
+            but the value is not a typed field anymore."""
             guardrail = BuiltInValidatorGuardrail.model_validate(
                 {
                     "$guardrailType": "builtInValidator",
@@ -451,7 +458,8 @@ class TestGuardrailsService:
                     "validatorParameters": [],
                 }
             )
-            assert guardrail.byo_connection_id == "byog-conn-1"
+            assert guardrail.byo_validator_name == "my_databricks_pii"
+            assert "byo_connection_id" not in type(guardrail).model_fields
 
         def test_evaluate_guardrail_byo_without_name_raises(
             self,
@@ -529,7 +537,7 @@ class TestGuardrailsService:
             request_payload = json.loads(captured_request.content)
             assert "byoValidatorName" not in request_payload
 
-        def test_evaluate_guardrail_non_byo_type_does_not_forward_connection_id(
+        def test_evaluate_guardrail_non_byo_type_never_forwards_byo_fields(
             self,
             httpx_mock: HTTPXMock,
             service: GuardrailsService,
@@ -537,8 +545,8 @@ class TestGuardrailsService:
             org: str,
             tenant: str,
         ) -> None:
-            """byoConnectionId is only forwarded for the "byo" sentinel, never leaked
-            into a non-BYOG validator payload even if the field happens to be set."""
+            """BYO fields are only forwarded for the "byo" sentinel, never leaked
+            into a non-BYOG validator payload even if a name happens to be set."""
             captured_request = None
 
             def capture_request(request):
@@ -562,7 +570,7 @@ class TestGuardrailsService:
                 selector=GuardrailSelector(scopes=[GuardrailScope.LLM]),
                 guardrail_type="builtInValidator",
                 validator_type="pii_detection",
-                byo_connection_id="stray-conn",
+                byo_validator_name="stray-name",
                 validator_parameters=[],
             )
 
@@ -570,6 +578,7 @@ class TestGuardrailsService:
 
             assert captured_request is not None
             request_payload = json.loads(captured_request.content)
+            assert "byoValidatorName" not in request_payload
             assert "byoConnectionId" not in request_payload
 
         def test_evaluate_guardrail_ootb_omits_byo_validator_name(

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.16"
+version = "0.2.17"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2760,7 +2760,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.16"
+version = "0.2.17"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## What changed?

The Agents backend now enforces BYOG validator-name uniqueness **per tenant** and no longer accepts a connection id at validation nor persists one in the agent (UiPath/Agents#5959, AL-510): the name alone resolves the configuration, and the Integration Service connection is taken from it server-side — an admin rebind is always honored. This PR removes the now-dead connection id from the coded-agents surface.

- **`BuiltInValidatorGuardrail`** — the `byo_connection_id` field is removed. Legacy json carrying `byoConnectionId` still parses (`extra="allow"`) but the value is inert; a compat test pins that it is **never forwarded** to the service.
- **`GuardrailsService.evaluate_guardrail`** — stops forwarding `byoConnectionId`; the `byo` payload carries `byoValidatorName` only.
- **`ByoValidator`** — the `connection_id` kwarg is removed; the docstring now states names are unique per tenant, and the example loses the (real, tenant-specific) connection id it still embedded.
- **Version** — `uipath-platform` 0.2.17, both lockfiles synced.

**Version-skew safety:** published `uipath-langchain` releases (0.14.18–0.14.20) still pass `byo_connection_id=` when constructing the model — with `extra="allow"` that lands as an inert extra attribute the service never reads, and the server ignores the JSON field anyway. All old/new combinations are safe; no coordinated release needed.

## How has this been tested?

- `test_guardrails_service.py`: the BYOG payload contains `byoValidatorName` and **no** `byoConnectionId` — including when a legacy `byoConnectionId` is present on the parsed model, and for non-byo validator types; legacy-json parse compat pinned.
- `test_guardrails_decorators.py`: `ByoValidator` name-only construction, wire serialization (asserts `byoConnectionId` absent from the dump), parameter passthrough, run-forwarding.
- Full `uipath-platform` package suite green; `ruff check`, `ruff format --check`, `mypy src tests` clean; `uv lock --check` clean in both affected packages.

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] API removals
- [ ] None
- [ ] DB migrations

`ByoValidator(connection_id=...)` from 0.2.14–0.2.16 now raises `TypeError`, and `BuiltInValidatorGuardrail.byo_connection_id` is no longer a typed field. Both shipped days ago (July 29), and the server already ignores the field they fed — deliberate hard removal in agreement with the backend change rather than a deprecation shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
