### PR TITLE
fix(cli): bound how much log a single drain reads into memory [PC-4873]

### DIFF
--- a/packages/uipath/src/uipath/_cli/_server_jobs.py
+++ b/packages/uipath/src/uipath/_cli/_server_jobs.py
@@ -189,6 +189,10 @@ def build_result_payload(job_key: str, outcome: dict[str, Any]) -> dict[str, Any
 
 LOG_POLL_SECONDS = 0.25
 LOG_BATCH_MAX_LINES = 200
+# Cap on how much log a single drain pulls into memory. Without it a job that logs
+# heavily between polls -- or the final drain after a long run -- reads the whole
+# remainder at once, and the decoded str costs more again.
+LOG_READ_CHUNK_BYTES = 256 * 1024
 LOG_FLUSH_TIMEOUT_SECONDS = 10
 
 # How long a cancelled job gets to unwind before we admit the stop did not take.
@@ -249,31 +253,48 @@ class JobLogTailer:
         self._stop.set()
 
     async def _drain(self, final: bool = False) -> None:
-        try:
-            if not os.path.exists(self.path):
+        """Forward whatever is new, a bounded window at a time until caught up."""
+        while True:
+            try:
+                if not os.path.exists(self.path):
+                    return
+                # Binary with explicit offsets: a text-mode tell() cookie is opaque, and
+                # we need to rewind past an unterminated tail.
+                with open(self.path, "rb") as f:
+                    f.seek(self._offset)
+                    chunk = f.read(LOG_READ_CHUNK_BYTES)
+            except OSError:
                 return
-            # Binary with explicit offsets: a text-mode tell() cookie is opaque, and we
-            # need to rewind past an unterminated tail.
-            with open(self.path, "rb") as f:
-                f.seek(self._offset)
-                chunk = f.read()
-        except OSError:
-            return
 
-        if not chunk:
-            return
-
-        # A logging handler writes the record and only then flushes, so the tail can be
-        # half a line. Leave it for the next poll rather than reporting a fragment as a
-        # complete entry — except on the final drain, where nothing more is coming.
-        if not final and not chunk.endswith(b"\n"):
-            cut = chunk.rfind(b"\n")
-            if cut == -1:
+            if not chunk:
                 return
-            chunk = chunk[: cut + 1]
 
-        self._offset += len(chunk)
+            # A short read means we reached the end of the file; a full one means there
+            # is more waiting and we should come back round.
+            more_pending = len(chunk) == LOG_READ_CHUNK_BYTES
 
+            if not chunk.endswith(b"\n"):
+                # A logging handler writes the record and only then flushes, so the tail
+                # can be half a line.
+                cut = chunk.rfind(b"\n")
+                if cut != -1:
+                    # Trim to the last complete line. Safe to decode: \n never appears
+                    # inside a multi-byte UTF-8 sequence.
+                    chunk = chunk[: cut + 1]
+                elif not (more_pending or final):
+                    # Partial line still being written — wait for its newline.
+                    return
+                # Otherwise: a single line longer than the read window, or the last drain
+                # with nothing more coming. Emit the fragment rather than buffering
+                # without bound.
+
+            self._offset += len(chunk)
+            await self._emit(chunk)
+
+            if not more_pending:
+                return
+
+    async def _emit(self, chunk: bytes) -> None:
         batch: list[dict[str, Any]] = []
         for raw in chunk.decode("utf-8", errors="replace").splitlines():
             line = raw.rstrip("\r")

--- a/packages/uipath/tests/cli/test_server_logs.py
+++ b/packages/uipath/tests/cli/test_server_logs.py
@@ -294,3 +294,52 @@ async def test_tailer_tolerates_a_missing_file(tmp_path):
     await asyncio.wait_for(tailer.run(), timeout=5)
 
     assert callback.batches == []
+
+
+# --------------------------------------------------------------------------- #
+# bounded reads                                                               #
+# --------------------------------------------------------------------------- #
+
+
+async def test_tailer_catches_up_across_multiple_read_windows(tmp_path, monkeypatch):
+    """A job that logs more than one window between polls must still be forwarded in
+    full — bounding the read must not mean dropping the remainder."""
+    import uipath._cli._server_jobs as jobs
+
+    monkeypatch.setattr(jobs, "LOG_READ_CHUNK_BYTES", 512)
+
+    log_file = tmp_path / "execution.log"
+    total = 200  # ~40 bytes each, comfortably several windows
+    log_file.write_bytes(
+        b"".join(b"[2026-07-29 17:00:00,000][INFO] line-%d\n" % i for i in range(total))
+    )
+
+    callback = RecordingCallback()
+    tailer = JobLogTailer("job-1", str(log_file), callback)
+    tailer.stop()
+    await asyncio.wait_for(tailer.run(), timeout=10)
+
+    messages = [line["message"] for line in callback.lines]
+    assert len(messages) == total
+    assert messages[0] == "line-0"
+    assert messages[-1] == f"line-{total - 1}"
+
+
+async def test_tailer_emits_a_line_longer_than_the_read_window(tmp_path, monkeypatch):
+    """A single pathologically long line must not stall the tailer forever: bounded
+    memory beats perfect line integrity here."""
+    import uipath._cli._server_jobs as jobs
+
+    monkeypatch.setattr(jobs, "LOG_READ_CHUNK_BYTES", 64)
+
+    log_file = tmp_path / "execution.log"
+    log_file.write_bytes(b"x" * 500 + b"\n[2026-07-29 17:00:00,000][INFO] after\n")
+
+    callback = RecordingCallback()
+    tailer = JobLogTailer("job-1", str(log_file), callback)
+    tailer.stop()
+    await asyncio.wait_for(tailer.run(), timeout=10)
+
+    joined = "".join(line["message"] for line in callback.lines)
+    assert "x" * 500 in joined, "the long line must be forwarded, even if fragmented"
+    assert any(line["message"] == "after" for line in callback.lines)


### PR DESCRIPTION
> ## 🅿️ Parked with #1835 — by dependency only
>
> Nothing here is affected by the transport direction: this bounds how much `JobLogTailer._drain` reads into memory, which stands whether logs are pushed over HTTP or streamed over uipath-ipc. It is parked purely because `JobLogTailer` is introduced by #1835, so there is nothing on `main` for it to bound.
>
> If the log push is re-cut over IPC, this bounding logic carries over essentially unchanged.
>
> Last rebased 2026-08-19 and green at that point: 1457 passed, ruff/mypy clean.

---

> **Draft — third in the stack.** Base is `feat/python-job-cancellation` (#1842). It stays stacked rather than targeting `main` directly: `JobLogTailer` is introduced by #1835, so there is nothing on `main` for this to bound.
>
> Paired with UiPath/hdens#7711. Rebased onto `main`; replayed with no conflicts.

## Summary

`JobLogTailer._drain` called `f.read()` with no limit, so a single pass pulled everything written since the last poll into memory — and the decoded `str` costs more again.

The 250 ms poll normally keeps that tiny. It does not when:
- a job logs heavily between polls,
- the tailer is starved (a stop can hold the loop for up to `STOP_GRACE_SECONDS`),
- or the **final drain** runs after a long job.

Same read-it-all-only-to-forward-it shape that has OOMed pods on the handler side (UiPath/hdens#7711).

Each pass now reads at most `LOG_READ_CHUNK_BYTES` (256 KiB) and loops until caught up, so peak memory is the **window**, not the backlog.

## Two cases only reachable once the read is bounded

- **A chunk boundary landing mid-line** — trimmed back to the last newline. That is also what keeps the decode correct: `\n` never appears inside a multi-byte UTF-8 sequence, so cutting there can't split a character.
- **A single line longer than the window** — emitted as a fragment rather than held. Buffering it defeats the point, and stalling on it would wedge the tailer permanently (the old code's `cut == -1 → return` becomes an infinite stall once reads are bounded).

## Caveats

- A line longer than 256 KiB is delivered in pieces; nothing downstream rejoins them.

## Testing

- `uv run pytest tests/cli` — **1457 passed**, 0 failures. Two new tests for exactly the cases above: catch-up across multiple windows with a shrunk `LOG_READ_CHUNK_BYTES`, and a 500-byte line through a 64-byte window. The existing 14 tailer tests are unchanged and still pass — ordering, no-replay, partial-line hold-back, and final-drain behaviour are all preserved.
- `ruff check` and `ruff format --check` clean; `mypy --config-file pyproject.toml .` — no issues in 336 source files.

## Jira

[PC-4873](https://uipath.atlassian.net/browse/PC-4873)


[PC-4873]: https://uipath.atlassian.net/browse/PC-4873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
