### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
         with:
           configuration-path: '.github/labeler.yml'
           sync-labels: true

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -23,21 +23,21 @@ permissions:
 jobs:
   build:
     name: Build ${{ inputs.package }}
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     defaults:
       run:
         working-directory: packages/${{ inputs.package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: "packages/${{ inputs.package }}/.python-version"
 
@@ -72,7 +72,7 @@ jobs:
         run: uv build --no-sources --package ${{ inputs.package }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-dists-${{ inputs.package }}
           path: packages/${{ inputs.package }}/dist/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,16 +18,16 @@ permissions:
 
 jobs:
   detect-publishable-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
       count: ${{ steps.detect.outputs.count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -48,20 +48,20 @@ jobs:
     name: Publish uipath-core
     needs: [detect-publishable-packages, build-uipath-core]
     if: contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-core')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-dists-uipath-core
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:
           verbose: true
           skip-existing: true
@@ -73,15 +73,15 @@ jobs:
       always() &&
       (contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-platform') ||
        contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath'))
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
         if: contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-core')
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Python
         if: contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-core')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -110,20 +110,20 @@ jobs:
     if: |
       always() &&
       contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-platform')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-dists-uipath-platform
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:
           verbose: true
           skip-existing: true
@@ -134,15 +134,15 @@ jobs:
     if: |
       always() &&
       contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
         if: contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-platform')
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Python
         if: contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath-platform')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -173,20 +173,20 @@ jobs:
     if: |
       always() &&
       contains(fromJson(needs.detect-publishable-packages.outputs.packages), 'uipath')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-dists-uipath
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:
           verbose: true
           skip-existing: true

--- a/.github/workflows/check-dependency-bumps.yml
+++ b/.github/workflows/check-dependency-bumps.yml
@@ -8,15 +8,15 @@ permissions:
 
 jobs:
   check-dependency-bumps:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/check-version-availability.yml
+++ b/.github/workflows/check-version-availability.yml
@@ -8,15 +8,15 @@ permissions:
 
 jobs:
   check-version-availability:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,18 +6,18 @@ on:
 jobs:
   commitlint:
     name: Commit Lint
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3.9.1
         with:
           node-version: 22
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,18 +11,18 @@ permissions:
 
 jobs:
   detect-changed-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
       count: ${{ steps.detect.outputs.count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -37,13 +37,13 @@ jobs:
   discover-testcases:
     needs: [detect-changed-packages]
     if: needs.detect-changed-packages.outputs.count > 0
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       testcases: ${{ steps.discover.outputs.testcases }}
       count: ${{ steps.discover.outputs.count }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
     - name: Discover testcases
       id: discover
@@ -75,7 +75,7 @@ jobs:
   integration-tests:
     needs: [discover-testcases]
     if: needs.discover-testcases.outputs.count > 0
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
       env:
@@ -91,7 +91,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
     - name: Install dependencies
       working-directory: packages/${{ matrix.testcase.package }}
@@ -125,7 +125,7 @@ jobs:
 
   summarize-results:
     needs: [detect-changed-packages, discover-testcases, integration-tests]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: always()
     steps:
       - name: Check integration tests status

--- a/.github/workflows/lint-packages.yml
+++ b/.github/workflows/lint-packages.yml
@@ -8,18 +8,18 @@ permissions:
 
 jobs:
   detect-changed-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
       count: ${{ steps.detect.outputs.count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -34,7 +34,7 @@ jobs:
   lint-uipath-core:
     name: Lint uipath-core
     needs: detect-changed-packages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Check if package changed
         id: check
@@ -51,17 +51,17 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: "packages/uipath-core/.python-version"
 
@@ -88,7 +88,7 @@ jobs:
   lint-uipath-platform:
     name: Lint uipath-platform
     needs: detect-changed-packages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Check if package changed
         id: check
@@ -105,17 +105,17 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: "packages/uipath-platform/.python-version"
 
@@ -142,7 +142,7 @@ jobs:
   lint-uipath:
     name: Lint uipath
     needs: detect-changed-packages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Check if package changed
         id: check
@@ -159,17 +159,17 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: "packages/uipath/.python-version"
 
@@ -201,7 +201,7 @@ jobs:
   lint-gate:
     name: Lint
     needs: [lint-uipath-core, lint-uipath-platform, lint-uipath]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: always()
     steps:
       - name: Check lint results

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -15,18 +15,18 @@ permissions:
 jobs:
   detect-changed-packages:
     if: contains(github.event.pull_request.labels.*.name, 'build:dev')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
       count: ${{ steps.detect.outputs.count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -42,7 +42,7 @@ jobs:
     name: Publish Dev Build - ${{ matrix.package }}
     needs: detect-changed-packages
     if: contains(github.event.pull_request.labels.*.name, 'build:dev') && needs.detect-changed-packages.outputs.count > 0
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     defaults:
       run:
         working-directory: packages/${{ matrix.package }}
@@ -53,15 +53,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: "packages/${{ matrix.package }}/.python-version"
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,22 +18,22 @@ on:
 
 jobs:
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: ${{ github.repository == 'UiPath/uipath-python' }}
     permissions:
       contents: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: "packages/uipath/.python-version"
 

--- a/.github/workflows/test-cd-scripts.yml
+++ b/.github/workflows/test-cd-scripts.yml
@@ -20,13 +20,13 @@ permissions:
 
 jobs:
   test-cd-scripts:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -11,19 +11,19 @@ permissions:
 
 jobs:
   detect-changed-packages:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
       count: ${{ steps.detect.outputs.count }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
     steps:
       - name: Check if package changed
         id: check
@@ -62,15 +62,15 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload coverage HTML report
         if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-uipath-core
           path: packages/uipath-core/htmlcov/
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload coverage XML report
         if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-uipath-core
           path: packages/uipath-core/coverage.xml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
     steps:
       - name: Check if package changed
         id: check
@@ -132,15 +132,15 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload coverage HTML report
         if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-uipath-platform
           path: packages/uipath-platform/htmlcov/
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload coverage XML report
         if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-uipath-platform
           path: packages/uipath-platform/coverage.xml
@@ -178,7 +178,7 @@ jobs:
   e2e-uipath-platform:
     name: E2E (uipath-platform, memory)
     needs: detect-changed-packages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Check if package changed
         id: check
@@ -197,15 +197,15 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -233,7 +233,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest]
+        os: [uipath-ubuntu-latest, uipath-windows-latest]
     steps:
       - name: Check if package changed
         id: check
@@ -252,15 +252,15 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
         if: steps.check.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -281,7 +281,7 @@ jobs:
 
       - name: Upload coverage HTML report
         if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-uipath
           path: packages/uipath/htmlcov/
@@ -289,7 +289,7 @@ jobs:
 
       - name: Upload coverage XML report
         if: steps.check.outputs.skip != 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-uipath
           path: packages/uipath/coverage.xml
@@ -300,32 +300,32 @@ jobs:
   sonarcloud:
     name: SonarCloud
     needs: [test-uipath-core, test-uipath-platform, test-uipath]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: always() && needs.test-uipath-core.result != 'failure' && needs.test-uipath-platform.result != 'failure' && needs.test-uipath.result != 'failure'
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Download uipath-core coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
           name: coverage-xml-uipath-core
           path: packages/uipath-core
 
       - name: Download uipath-platform coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
           name: coverage-xml-uipath-platform
           path: packages/uipath-platform
 
       - name: Download uipath coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
           name: coverage-xml-uipath
@@ -338,14 +338,14 @@ jobs:
           sed -i 's|<source>src</source>|<source>packages/uipath/src</source>|g' packages/uipath/coverage.xml || true
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   test-gate:
     name: Test
     needs: [test-uipath-core, test-uipath-platform, test-uipath, e2e-uipath-platform]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: always()
     steps:
       - name: Check test results

--- a/.github/workflows/test-uipath-integrations.yml
+++ b/.github/workflows/test-uipath-integrations.yml
@@ -6,19 +6,19 @@ on:
 
 jobs:
   build-wheels:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     if: contains(github.event.pull_request.labels.*.name, 'test:uipath-integrations')
     steps:
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
 
@@ -35,21 +35,21 @@ jobs:
         run: uv build
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: uipath-wheels
           path: packages/*/dist/*.whl
 
   discover-packages:
     needs: [build-wheels]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     outputs:
       packages: ${{ steps.discover.outputs.packages }}
     steps:
       - name: Checkout uipath-integrations-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
@@ -83,27 +83,27 @@ jobs:
 
     steps:
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: uipath-wheels
           path: wheels
 
       - name: Checkout uipath-integrations-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
 
       - name: Checkout uipath-python scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: _scripts
           sparse-checkout: .github/scripts
@@ -127,7 +127,7 @@ jobs:
 
   discover-testcases:
     needs: [test-package, discover-packages]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -135,7 +135,7 @@ jobs:
       has_testcases: ${{ steps.discover.outputs.has_testcases }}
     steps:
       - name: Checkout uipath-integrations-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
@@ -177,7 +177,7 @@ jobs:
   run-integration-tests:
     needs: [build-wheels, discover-testcases]
     if: needs.discover-testcases.outputs.has_testcases == 'true'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
       env:
@@ -195,19 +195,19 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: uipath-wheels
           path: wheels
 
       - name: Checkout uipath-integrations-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-integrations-python'
           path: 'uipath-integrations-python'
 
       - name: Checkout uipath-python scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: _scripts
           sparse-checkout: .github/scripts
@@ -240,12 +240,12 @@ jobs:
   notify-on-failure:
     needs: [test-package, run-integration-tests]
     if: always() && contains(github.event.pull_request.labels.*.name, 'test:uipath-integrations') && (needs.test-package.result == 'failure' || needs.run-integration-tests.result == 'failure')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const marker = '<!-- cross-test-failure:uipath-integrations -->';

--- a/.github/workflows/test-uipath-langchain.yml
+++ b/.github/workflows/test-uipath-langchain.yml
@@ -6,19 +6,19 @@ on:
 
 jobs:
   build-wheels:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     if: contains(github.event.pull_request.labels.*.name, 'test:uipath-langchain')
     steps:
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
 
@@ -35,7 +35,7 @@ jobs:
         run: uv build
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: uipath-wheels
           path: packages/*/dist/*.whl
@@ -53,27 +53,27 @@ jobs:
 
     steps:
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: uipath-wheels
           path: wheels
 
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
 
       - name: Checkout uipath-python scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: _scripts
           sparse-checkout: .github/scripts
@@ -91,7 +91,7 @@ jobs:
           uv run pytest
 
   discover-testcases:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     needs: [test-uipath-langchain]
@@ -99,7 +99,7 @@ jobs:
       testcases: ${{ steps.discover.outputs.testcases }}
     steps:
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
@@ -119,7 +119,7 @@ jobs:
           echo "testcases=$testcases_json" >> $GITHUB_OUTPUT
 
   run-uipath-langchain-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     needs: [build-wheels, discover-testcases]
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -139,19 +139,19 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: uipath-wheels
           path: wheels
 
       - name: Checkout uipath-langchain-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-langchain-python'
           path: 'uipath-langchain-python'
 
       - name: Checkout uipath-python scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: _scripts
           sparse-checkout: .github/scripts
@@ -187,12 +187,12 @@ jobs:
   notify-on-failure:
     needs: [test-uipath-langchain, run-uipath-langchain-integration-tests]
     if: always() && contains(github.event.pull_request.labels.*.name, 'test:uipath-langchain') && (needs.test-uipath-langchain.result == 'failure' || needs.run-uipath-langchain-integration-tests.result == 'failure')
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const marker = '<!-- cross-test-failure:uipath-langchain -->';

--- a/.github/workflows/test-uipath-runtime.yml
+++ b/.github/workflows/test-uipath-runtime.yml
@@ -6,19 +6,19 @@ on:
 
 jobs:
   build-wheels:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     if: contains(github.event.pull_request.labels.*.name, 'test:uipath-runtime')
     steps:
       - name: Checkout uipath-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
 
@@ -27,7 +27,7 @@ jobs:
         run: uv build
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: uipath-core-wheel
           path: packages/uipath-core/dist/*.whl
@@ -45,27 +45,27 @@ jobs:
 
     steps:
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: uipath-core-wheel
           path: wheels
 
       - name: Checkout uipath-runtime-python
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           repository: 'UiPath/uipath-runtime-python'
           path: 'uipath-runtime-python'
 
       - name: Checkout uipath-python scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           path: _scripts
           sparse-checkout: .github/scripts


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.