### PR TITLE
chore: require uipath-runtime>=0.13.1 for the output-arguments split

### DIFF
--- a/.github/workflows/lint-packages.yml
+++ b/.github/workflows/lint-packages.yml
@@ -3,6 +3,9 @@ name: Lint Packages
 on:
   workflow_call:
 
+env:
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: uipath-runtime
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -6,6 +6,9 @@ on:
       SONAR_TOKEN:
         required: false
 
+env:
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: uipath-runtime
+
 permissions:
   contents: read
 

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.14.2"
+version = "2.14.3"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
-  "uipath-runtime>=0.13.0, <0.14.0",
+  "uipath-runtime>=0.13.1, <0.14.0",
   "uipath-platform>=0.2.14, <0.3.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.2"
+version = "2.14.3"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ requires-dist = [
     { name = "uipath-core", editable = "../uipath-core" },
     { name = "uipath-ipc", marker = "extra == 'ipc'", specifier = ">=2.5.1,<2.6.0" },
     { name = "uipath-platform", editable = "../uipath-platform" },
-    { name = "uipath-runtime", specifier = ">=0.13.0,<0.14.0" },
+    { name = "uipath-runtime", specifier = ">=0.13.1,<0.14.0" },
 ]
 provides-extras = ["ipc"]
 
@@ -2800,16 +2800,16 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.13.0"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/c0/d55cf48ee43758c2c1c65f52fd0596fd75f5bd5067a5016e6553b4d2c5fe/uipath_runtime-0.13.0.tar.gz", hash = "sha256:8ae3150df5fb0043210faacf39148789c1fb252c6a8d6bc27174c0d9ce7304f5", size = 243594, upload-time = "2026-08-04T11:19:04.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/42/837240fd4cb2824ee5899cd2e06352c617645077efcecff7081a7292464a/uipath_runtime-0.13.1.tar.gz", hash = "sha256:4fd51d95e8b3c8554de8148239425499bbb7ec8687ad93a38f5107c6cdc0d7dd", size = 246257, upload-time = "2026-08-12T12:48:20.386Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/88/9518dcbeedaa8117e5fd3d0424c4a7354bae1f3ede1b2e3f48524e4b7efc/uipath_runtime-0.13.0-py3-none-any.whl", hash = "sha256:2a7c128cf14fdbef899b272ee5995da63baeb882acc904f39ef8f8f52bcb019f", size = 96349, upload-time = "2026-08-04T11:19:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/84/de/94e1ebcd7f25ee7620cb712f376cd84349d5d4b599bdbc6298556310598f/uipath_runtime-0.13.1-py3-none-any.whl", hash = "sha256:365134dfdc87050636b9027b839bbd93636ee56bd463bb38c1e48b7e19e848dd", size = 96876, upload-time = "2026-08-12T12:48:19.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`uipath-runtime` 0.13.1 added `runtime.splitOutputArguments` ([uipath-runtime-python#159](https://github.com/UiPath/uipath-runtime-python/pull/159)): when set, a job's output arguments are written to their own file and the result envelope carries an `outputArgumentsFilePath` pointer instead of the inline `output` value, so a consumer can stream the payload instead of materializing it. In Serverless that is the difference between an ~80 MB job completing and OOMing the handler.

An older runtime does not recognise the key and silently ignores it — the payload stays inline and the consumer gets exactly the blowup the split exists to avoid, with no error to explain it. Raising the floor turns that silent no-op into a resolution failure.

## What

- `uipath-runtime>=0.13.0` → `>=0.13.1`
- `uipath` 2.14.2 → 2.14.3
- `uv.lock` regenerated (resolves `uipath-runtime` 0.13.1)

No source changes.

## Also here: a Safe Chain exemption (`3665a522`)

Safe Chain 403'd the eight jobs that install `uipath` — the six `Test (uipath, …)` plus `Lint uipath` and the `Lint` gate — because 0.13.1 is under 48h old. `pyproject.toml` already exempts `uipath-runtime` from uv's own `exclude-newer` window, but Safe Chain runs outside the project and cannot see that. The two workflows now set `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: uipath-runtime`, as `uipath-agents-python` and [cli#2195](https://github.com/UiPath/cli/pull/2195) already do.

Scope, read from the upstream source and confirmed by running it:

- it skips **only** the age gate — malware blocking runs earlier and independently, verified by installing Safe Chain's malware test package with that package itself excluded and still getting blocked
- env exclusions are **unioned** with the config file, so this can add `uipath-runtime` but never remove anyone else's protection
- the match is exact plus PEP 503 variants, so it covers `uipath_runtime` and nothing beyond

`84d5d0d9` (bump only) failed on `403 … minimum package age (uipath_runtime@0.13.1)`; `3665a522` adds nothing but the two `env:` blocks and CI is green. Kept as its own commit so it can be dropped if you would rather wait the window out.

Keeping it in `pyproject.toml` instead was tried on this branch and does not work — [same eight jobs, same 403](https://github.com/UiPath/uipath-python/actions/runs/31686979830). Safe Chain shims `uv` and blocks on the wheel download, so it never reads `[tool.uv.exclude-newer-package]`; its own error message names the env var as the remedy. That is why `uipath-agents-python` carries both: pyproject for uv's window, yml for Safe Chain's.

## Testing

`2375 passed, 1 skipped`; `uv lock --check`, ruff and full mypy (324 files, src + tests) all clean.

## Chain

This is 2 of 4. Each link can only open once the previous one publishes.

1. ✅ `uipath-runtime-python` — the split itself (published as 0.13.1)
2. **this PR** — raise the floor so the key is guaranteed present
3. `uipath-agents-python` — three ceilings currently exclude both new versions
4. `hdens` — consume the pointer and stream the file into the blob upload
