### PR TITLE
ci: exempt uipath-runtime from the Safe Chain age gate when building, publish uipath 2.14.4

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -16,6 +16,9 @@ on:
       APPLICATIONINSIGHTS_CONNECTION_STRING:
         required: false
 
+env:
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: uipath-runtime
+
 permissions:
   contents: read
   actions: write

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.14.3"
+version = "2.14.4"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.3"
+version = "2.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## What

- `797e03ab` — the same three-line `env:` block [#1858](https://github.com/UiPath/uipath-python/pull/1858) added to the lint and test workflows, in the remaining workflow on the publish path
- `47995835` — `uipath` 2.14.3 → 2.14.4 (`pyproject.toml` + `uv.lock`)

2.14.3 was built but never uploaded, so it is retired rather than reused. The bump also means this PR touches `packages/uipath/pyproject.toml`, which is what CD's `paths:` filter triggers on — without it the merge would not start CD at all.

The exemption applies to the age check only; malware scanning and every other Safe Chain check are unaffected, and it cannot narrow the checks for any other package.
