### PR TITLE
fix(cli): honor packOptions.filesIncluded for dot-prefixed paths

### DIFF
--- a/packages/uipath/src/uipath/_cli/_utils/_project_files.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_project_files.py
@@ -465,16 +465,25 @@ def files_to_include(
         normalized_root_rel_path = root_rel_path.replace(os.sep, "/")
         is_root_evals_folder = normalized_root_rel_path == LEGACY_EVAL_FOLDER
 
-        # Skip all directories that start with . or are a venv or are excluded
+        # Skip directories that start with . or are a venv or are excluded,
+        # unless an explicit `files_included` entry lives under them.
         included_dirs = []
         for d in dirs:
-            if d.startswith(".") or is_venv_dir(os.path.join(root, d)):
-                continue
-
-            # Check if directory should be excluded
             dir_path = os.path.join(root, d)
             dir_rel_path = os.path.relpath(dir_path, directory)
             normalized_dir_rel_path = dir_rel_path.replace(os.sep, "/")
+
+            if d.startswith(".") or is_venv_dir(dir_path):
+                # Dot/venv directories are pruned by default, but still descend
+                # when an always-include path lives under them so that
+                # `packOptions.filesIncluded` entries are honored.
+                has_included_descendant = any(
+                    included == normalized_dir_rel_path
+                    or included.startswith(normalized_dir_rel_path + "/")
+                    for included in files_included
+                )
+                if not has_included_descendant:
+                    continue
 
             # Check exclusion: by dirname (for root level) or by relative path
             should_exclude_dir = (
@@ -494,9 +503,6 @@ def files_to_include(
 
         dirs[:] = included_dirs
         for file in files:
-            if file.startswith("."):
-                continue
-
             file_extension = os.path.splitext(file)[1].lower()
             file_path = os.path.join(root, file)
             file_name = os.path.basename(file_path)
@@ -505,20 +511,27 @@ def files_to_include(
             # Normalize the path
             normalized_rel_path = rel_path.replace(os.sep, "/")
 
+            # A file is explicitly requested when it matches a `files_included`
+            # entry by filename (base directory only) or by relative path.
+            explicitly_included = (
+                file in files_included and normalized_rel_path == file
+            ) or normalized_rel_path in files_included
+
+            # Hidden files are excluded by default, but an explicit
+            # `packOptions.filesIncluded` entry must still be honored.
+            if file.startswith(".") and not explicitly_included:
+                continue
+
             # Skip files in the root evals folder (but allow eval-set and evaluators subdirectories)
             if is_root_evals_folder:
                 skipped_files.append(normalized_rel_path)
                 continue
 
-            # Check inclusion: by extension, by filename (for base directory), or by relative path
+            # Check inclusion: by extension (visible files only), or when the
+            # file is explicitly listed by filename / relative path.
             should_include = (
-                file_extension in file_extensions_included
-                or (
-                    file in files_included and normalized_rel_path == file
-                )  # filename match for base directory only
-                or normalized_rel_path
-                in files_included  # path match for subdirectories
-            )
+                not file.startswith(".") and file_extension in file_extensions_included
+            ) or explicitly_included
 
             # Check exclusion: by filename (for base directory only) or by relative path
             should_exclude = (

--- a/packages/uipath/src/uipath/_cli/_utils/_project_files.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_project_files.py
@@ -465,6 +465,19 @@ def files_to_include(
         normalized_root_rel_path = root_rel_path.replace(os.sep, "/")
         is_root_evals_folder = normalized_root_rel_path == LEGACY_EVAL_FOLDER
 
+        # Whether this directory is only being walked because an explicit
+        # `files_included` entry lives under a dot/venv ancestor. In that case
+        # files here must NOT be picked up merely because their extension is on
+        # the allowlist -- that would leak unrelated hidden/venv contents (e.g.
+        # `.config/secrets.json`). Only explicitly-listed files are packed here.
+        root_under_pruned_dir = False
+        ancestor = root
+        while os.path.normpath(ancestor) != os.path.normpath(directory):
+            if os.path.basename(ancestor).startswith(".") or is_venv_dir(ancestor):
+                root_under_pruned_dir = True
+                break
+            ancestor = os.path.dirname(ancestor)
+
         # Skip directories that start with . or are a venv or are excluded,
         # unless an explicit `files_included` entry lives under them.
         included_dirs = []
@@ -527,10 +540,13 @@ def files_to_include(
                 skipped_files.append(normalized_rel_path)
                 continue
 
-            # Check inclusion: by extension (visible files only), or when the
-            # file is explicitly listed by filename / relative path.
+            # Check inclusion: by extension (only for visible files that are not
+            # under a pruned dot/venv directory), or when the file is explicitly
+            # listed by filename / relative path.
             should_include = (
-                not file.startswith(".") and file_extension in file_extensions_included
+                not file.startswith(".")
+                and not root_under_pruned_dir
+                and file_extension in file_extensions_included
             ) or explicitly_included
 
             # Check exclusion: by filename (for base directory only) or by relative path

--- a/packages/uipath/src/uipath/_cli/_utils/_project_files.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_project_files.py
@@ -524,11 +524,12 @@ def files_to_include(
             # Normalize the path
             normalized_rel_path = rel_path.replace(os.sep, "/")
 
-            # A file is explicitly requested when it matches a `files_included`
-            # entry by filename (base directory only) or by relative path.
-            explicitly_included = (
-                file in files_included and normalized_rel_path == file
-            ) or normalized_rel_path in files_included
+            # A file is explicitly requested when its project-relative path
+            # matches a `files_included` entry. Root-level entries are bare
+            # filenames, which already equal `normalized_rel_path` there, so a
+            # single membership check covers both the base-directory filename
+            # case and the nested relative-path case.
+            explicitly_included = normalized_rel_path in files_included
 
             # Hidden files are excluded by default, but an explicit
             # `packOptions.filesIncluded` entry must still be honored.

--- a/packages/uipath/tests/cli/test_files_to_include.py
+++ b/packages/uipath/tests/cli/test_files_to_include.py
@@ -56,6 +56,9 @@ class TestFilesToIncludeExplicitHiddenPaths:
         os.makedirs(os.path.join(project_dir, ".git"))
         open(os.path.join(project_dir, ".git", "config.md"), "w").close()
         open(os.path.join(project_dir, ".secret.md"), "w").close()
+        # A *visible* file that shares the descended-into dot directory but is
+        # NOT explicitly listed must not be pulled in by its extension.
+        open(os.path.join(project_dir, ".config", "assets", "other.md"), "w").close()
 
         pack_options = PackOptions(
             filesIncluded=[".config/assets/asset.md", ".python-version"]
@@ -69,3 +72,6 @@ class TestFilesToIncludeExplicitHiddenPaths:
         # Hidden paths that were not explicitly included stay excluded.
         assert ".secret.md" not in rel_paths
         assert ".git/config.md" not in rel_paths
+        # A visible, non-listed file under the descended-into dot directory must
+        # not be included by extension (would leak hidden-dir contents).
+        assert ".config/assets/other.md" not in rel_paths

--- a/packages/uipath/tests/cli/test_files_to_include.py
+++ b/packages/uipath/tests/cli/test_files_to_include.py
@@ -29,3 +29,43 @@ class TestFilesToIncludeHiddenFiles:
 
         assert "app.py" in included_names
         assert ".secret.json" not in included_names
+
+
+class TestFilesToIncludeExplicitHiddenPaths:
+    """`packOptions.filesIncluded` must be honored even for dot-prefixed paths.
+
+    Regression for the case where an explicit include living under a dot-prefixed
+    directory (e.g. `.config/assets/x.md`) or a named dotfile (e.g.
+    `.python-version`) was silently dropped: the dot-directory was pruned from
+    `os.walk` and dotfiles were skipped before the inclusion logic ran, so
+    `uipath pack` exited 0 with those always-include files missing.
+    """
+
+    def test_explicit_includes_under_dot_paths_are_packed(self, tmp_path):
+        from uipath._cli.models.uipath_json_schema import PackOptions
+
+        project_dir = str(tmp_path)
+
+        # Explicit include inside a dot-prefixed directory.
+        os.makedirs(os.path.join(project_dir, ".config", "assets"))
+        open(os.path.join(project_dir, ".config", "assets", "asset.md"), "w").close()
+        # Explicit dotfile include at the project root.
+        open(os.path.join(project_dir, ".python-version"), "w").close()
+
+        # Controls that must stay excluded (not listed in filesIncluded).
+        os.makedirs(os.path.join(project_dir, ".git"))
+        open(os.path.join(project_dir, ".git", "config.md"), "w").close()
+        open(os.path.join(project_dir, ".secret.md"), "w").close()
+
+        pack_options = PackOptions(
+            filesIncluded=[".config/assets/asset.md", ".python-version"]
+        )
+
+        included, _ = files_to_include(pack_options, project_dir, include_uv_lock=False)
+        rel_paths = {f.relative_path.replace(os.sep, "/") for f in included}
+
+        assert ".config/assets/asset.md" in rel_paths
+        assert ".python-version" in rel_paths
+        # Hidden paths that were not explicitly included stay excluded.
+        assert ".secret.md" not in rel_paths
+        assert ".git/config.md" not in rel_paths


### PR DESCRIPTION
## Description

Fixes #1855.

`files_to_include` (`_cli/_utils/_project_files.py`) is meant to honor `packOptions.filesIncluded` — documented as *"Specific files to always include."* But it prunes and skips dot-prefixed paths **before** the inclusion logic runs:

- the directory loop does `if d.startswith(".") or is_venv_dir(...): continue`, so `os.walk` never descends into e.g. `.config/`;
- the file loop does `if file.startswith("."): continue`, so dotfiles never reach the inclusion check.

As a result, an explicit include living under a dot-directory (e.g. `.config/assets/x.md`) or a named dotfile (e.g. `.python-version`) is **silently dropped** — `uipath pack` exits `0` with those always-include files missing and an empty `skipped` list (unreportable data loss in the package).

Repro on `main` (the issue's script): `included: ['plain/ASSET.md', 'pyproject.toml']`, `skipped: []` — `.config/assets/demo/ASSET.md` and `.python-version` are gone.

## Fix

- The walk now descends into a dot/venv directory **only when** a `files_included` entry lives under it (so `.git`/`.venv` stay pruned, but an explicitly-included subtree is reachable).
- A hidden file is packed **only when** it's explicitly listed by name or relative path — never merely because its extension matches `fileExtensionsIncluded`.

Default behavior is unchanged: dot/venv directories are still pruned and hidden files are still excluded unless explicitly requested. I deliberately kept the diff focused — honoring explicit includes closes the silent-data-loss path without flooding `skipped` with every `.git` entry (an independent idea floated in the issue).

## Tests

Added `TestFilesToIncludeExplicitHiddenPaths`: packs an explicit include inside `.config/assets/` and a `.python-version` dotfile, and asserts non-listed hidden paths (`.secret.md`, `.git/config.md`) stay excluded. It **fails on current `main`** (`assert '.config/assets/asset.md' in set()`) and passes with this change. The two existing hidden-file-exclusion tests still pass — no regression to the default.


I used a coding agent to help write and verify this change.
