### PR TITLE
feat(cli)!: align the uipath-ipc contract with the .NET handler [ROBO-5904]

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.14.6"
+version = "2.14.7"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_server.py
+++ b/packages/uipath/src/uipath/_cli/cli_server.py
@@ -23,9 +23,9 @@ from ._utils._console import ConsoleLogger
 from .cli_server_ipc import (
     IPythonRuntimeServer,
     PythonRuntimeService,
-    RunJobRequest,
-    RunJobResult,
-    StopJobRequest,
+    PythonServerRunJobResult,
+    PythonServerRunRequest,
+    PythonServerStopJobRequest,
     start_ipc_server,
 )
 
@@ -33,9 +33,9 @@ __all__ = [
     "server",
     "IPythonRuntimeServer",
     "PythonRuntimeService",
-    "RunJobRequest",
-    "RunJobResult",
-    "StopJobRequest",
+    "PythonServerRunJobResult",
+    "PythonServerRunRequest",
+    "PythonServerStopJobRequest",
     "start_ipc_server",
 ]
 

--- a/packages/uipath/src/uipath/_cli/cli_server_ipc.py
+++ b/packages/uipath/src/uipath/_cli/cli_server_ipc.py
@@ -12,7 +12,7 @@ def _run_id(job_key: str, resume_version: int | None) -> str:
 
 
 @dataclass
-class RunJobRequest:
+class PythonServerRunRequest:
     """PascalCase fields match the wire keys."""
 
     JobKey: str = ""
@@ -26,14 +26,14 @@ class RunJobRequest:
 
 
 @dataclass
-class StopJobRequest:
+class PythonServerStopJobRequest:
     JobKey: str = ""
     ResumeVersion: int | None = None
     ForceStop: bool = False
 
 
 @dataclass
-class RunJobResult:
+class PythonServerRunJobResult:
     ExitCode: int = 0
     Error: str | None = None
 
@@ -42,25 +42,37 @@ class IPythonRuntimeServer(ABC):
     """Contract the job executor calls over uipath-ipc."""
 
     @abstractmethod
-    async def RunJob(self, request: RunJobRequest) -> RunJobResult:
-        """Run a job → RunJobResult(ExitCode, Error)."""
+    async def Register(self) -> bool:
+        """Prove the connection is up. No-op until there is something to register."""
 
     @abstractmethod
-    async def StopJob(self, request: StopJobRequest) -> bool:
+    async def RunJob(self, request: PythonServerRunRequest) -> PythonServerRunJobResult:
+        """Run a job → PythonServerRunJobResult(ExitCode, Error)."""
+
+    @abstractmethod
+    async def StopJob(self, request: PythonServerStopJobRequest) -> bool:
         """Cancel a running job by key (bool return avoids fire-and-forget)."""
 
 
 class PythonRuntimeService(IPythonRuntimeServer):
     """``IPythonRuntimeServer`` implementation backed by run/debug/eval."""
 
-    async def RunJob(self, request: RunJobRequest) -> RunJobResult:
+    async def Register(self) -> bool:
+        console.info("Runtime client registered.")
+        return True
+
+    async def RunJob(self, request: PythonServerRunRequest) -> PythonServerRunJobResult:
         command_name = request.Command
         if not isinstance(command_name, str) or not command_name:
-            return RunJobResult(ExitCode=1, Error="Missing or invalid field: 'Command'")
+            return PythonServerRunJobResult(
+                ExitCode=1, Error="Missing or invalid field: 'Command'"
+            )
 
         cmd = COMMANDS.get(command_name)
         if cmd is None:
-            return RunJobResult(ExitCode=1, Error=f"Unknown command: {command_name}")
+            return PythonServerRunJobResult(
+                ExitCode=1, Error=f"Unknown command: {command_name}"
+            )
 
         args = parse_args(request.Args)
 
@@ -71,10 +83,12 @@ class PythonRuntimeService(IPythonRuntimeServer):
         result = await _run_command_isolated(
             cmd, args, request.EnvironmentVariables, request.WorkingDirectory
         )
-        # IPC contract (RunJobResult) carries only ExitCode + Error.
-        return RunJobResult(ExitCode=result["ExitCode"], Error=result["Error"])
+        # IPC contract (PythonServerRunJobResult) carries only ExitCode + Error.
+        return PythonServerRunJobResult(
+            ExitCode=result["ExitCode"], Error=result["Error"]
+        )
 
-    async def StopJob(self, request: StopJobRequest) -> bool:
+    async def StopJob(self, request: PythonServerStopJobRequest) -> bool:
         console.info(
             f"StopJob requested for {_run_id(request.JobKey, request.ResumeVersion)} "
             f"(force={request.ForceStop}) (no-op)"

--- a/packages/uipath/tests/cli/test_server_ipc.py
+++ b/packages/uipath/tests/cli/test_server_ipc.py
@@ -31,7 +31,7 @@ from uipath_ipc import (
 from uipath._cli import _server_core
 from uipath._cli.cli_server import (
     IPythonRuntimeServer,
-    RunJobResult,
+    PythonServerRunJobResult,
     start_ipc_server,
 )
 
@@ -81,20 +81,13 @@ def _wait_until_ready(pipe_name: str, timeout: float = 10.0) -> None:
     """Poll the pipe until the IPC server answers, instead of a fixed sleep.
 
     A fixed ``sleep`` races the server's startup under load; this connects a real
-    client and calls the no-op ``StopJob`` until it succeeds (or times out).
+    client and calls ``Register`` until it succeeds (or times out).
     """
     deadline = time.monotonic() + timeout
     last_err: Exception | None = None
     while time.monotonic() < deadline:
         try:
-            asyncio.run(
-                _with_proxy(
-                    pipe_name,
-                    lambda p: p.StopJob(
-                        {"JobKey": "00000000-0000-0000-0000-000000000000"}
-                    ),
-                )
-            )
+            asyncio.run(_with_proxy(pipe_name, lambda p: p.Register()))
             return
         except Exception as e:  # server not accepting connections yet
             last_err = e
@@ -291,9 +284,12 @@ class TestIpcContractFieldTransit:
         received: list[Any] = []
 
         class SpyService(IPythonRuntimeServer):
-            async def RunJob(self, request: Any) -> RunJobResult:
+            async def Register(self) -> bool:
+                return True
+
+            async def RunJob(self, request: Any) -> PythonServerRunJobResult:
                 received.append(request)
-                return RunJobResult(ExitCode=0)
+                return PythonServerRunJobResult(ExitCode=0)
 
             async def StopJob(self, request: Any) -> bool:
                 received.append(request)

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.6"
+version = "2.14.7"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
The .NET handler and this SDK define the same uipath-ipc service (`IPythonRuntimeServer`) but had drifted: the payload type names differed, and the handler had no way to prove the pipe was alive.

### Changes

- Rename the IPC payload types to the .NET names: `PythonServerRunRequest`, `PythonServerStopJobRequest`, `PythonServerRunJobResult`.
- Add `Register()` — no parameters, server-side no-op. Modelled on `ServerlessController.Register` in the Robot. The `Task<bool>` return only exists to escape UiPath.Ipc's fire-and-forget semantics; it is always true and carries no meaning. Failure is an exception, the way `ServerlessClient.Initialize` behaves.
- The test's readiness poll now calls `Register` instead of a `StopJob` with a zero GUID — the same probe the handler is dropping.
- Bump `uipath` to 2.14.5.

### Why Register

Today the handler proves readiness by calling `StopJob` for a job that cannot exist, and discards the answer. That means a pod whose pipe never came up is still released for work and fails every IPC-preferring job. With a real method the handler can deny readiness instead of only delaying it.

`Register()` deliberately takes no arguments: once coreipc #148 (ROBO-5858) lands, the caller handle comes from the ambient `IpcContext`, so the signature never has to change.

### Sequencing

This must be released before an image can answer `Register` — an older `uipath` in a prebaked venv responds method-not-found. `uipath-agents` also pins `uipath[ipc]>=2.13.22,<2.14.0`, so that ceiling has to be widened before 2.14.5 can reach a venv. The hdens side lands after both, and gates the call on the venv's `uipath` version so older venvs keep working.

BREAKING CHANGE: payload type names changed and `Register()` was added to `IPythonRuntimeServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)