### PR TITLE
docs(guardrails): note BYOG and LLM-as-judge are not enabled on every tenant yet

### DIFF
--- a/packages/uipath/docs/core/guardrails.md
+++ b/packages/uipath/docs/core/guardrails.md
@@ -210,6 +210,10 @@ def generate_code(spec: str) -> str:
 
 ### LLM-as-judge
 
+<!-- REMOVE WHEN: LLM-as-judge feature flag is enabled on all rings -->
+!!! info "Platform Availability"
+    `LLMAsJudgeValidator` ships in the `uipath` package on PyPI, but the LLM-as-judge guardrail it calls is still rolling out on the platform side and isn't enabled on every tenant yet — regardless of which judge models your governance policy permits. Watch the UiPath product release notes for when it lands.
+
 Evaluates content against a rule written in plain language, using a judge LLM to decide whether the payload complies. Use it for policy checks that are hard to express as fixed entities or rules — tone, topicality, disclaimers, domain-specific policies.
 
 ```python
@@ -243,6 +247,10 @@ def answer_question(question: str) -> str:
 - `positive_examples` / `negative_examples` — optional example payloads (not descriptions) that comply with / violate the rule, used to calibrate the judge. At most 2 entries per list, each at most 1000 characters.
 
 ### Bring Your Own Guardrail (BYOG)
+
+<!-- REMOVE WHEN: BYOG feature flag is enabled on all rings -->
+!!! info "Platform Availability"
+    `ByoValidator` ships in the `uipath` package on PyPI and works on any tenant where Bring Your Own Guardrail is enabled. The admin step it depends on — configuring a guardrail connection from a guardrail connection template under **Admin → AI Trust Layer → Guardrails Configurations** — is still rolling out and isn't enabled on every tenant yet. If that page isn't in your Admin panel, BYOG isn't enabled on yours — watch the UiPath product release notes for when it lands.
 
 Runs a customer-managed validator instead of a UiPath-managed one — your own Azure Content Safety subscription, a vendor connector, or a custom Integration Service connector. Supported at all stages: BYO validator capabilities are connector-defined and cannot be known statically, so no stage restriction is applied.
 


### PR DESCRIPTION
The [BYOG](https://uipath.github.io/uipath-python/core/guardrails/#bring-your-own-guardrail-byog) and [LLM-as-judge](https://uipath.github.io/uipath-python/core/guardrails/#llm-as-judge) sections read as if both features are live. Their SDK halves are — `ByoValidator` and `LLMAsJudgeValidator` ship on PyPI — but the platform side of each is still behind a feature flag and isn't enabled on every tenant. A customer already hit this on BYOG.

Adds a `Platform Availability` note to each section instead of removing the docs. The docs are correct for their audience (coded-agent developers consuming the PyPI package) — they just never said where the boundary is. Removing them would break the audience they serve; versioned docs were already ruled out as too costly to maintain.

**No release number, on review feedback.** A date published here is a date we then have to hit, and this repo is public. The notes say the feature isn't enabled everywhere yet and point at the product release notes instead. That reference is deliberately *not* a link to `core/release_notes.md` — that page tracks PyPI package releases (`uipath`, `uipath-langchain`, `uipath-runtime`) and will never say when a guardrail lands on a tenant; linking it would repeat the exact SDK-version/platform-rollout conflation these notes exist to prevent. For BYOG the note also gives a self-service check that needs no date at all: whether the Guardrails Configurations page is in your Admin panel.

**The two notes are worded differently on purpose.** BYOG's gate is one admin step — configuring a guardrail connection from a guardrail connection template under **Admin → AI Trust Layer → Guardrails Configurations** — with the rest of the feature live. For LLM-as-judge the whole guardrail is gated, so its note says it's unavailable regardless of which judge models the governance policy permits. Without that clause, the "must be a model your governance policy allows" line directly below reads as if a policy change fixes it.

**Title:** `Platform Availability`, not `Version Availability`. The latter is already taken and means a `uipath` PyPI version floor — all three existing uses say "available starting from **uipath** version **2.1.168** / **2.2.12** / **2.2.13**", and the package is on 2.14.7. This page renders both kinds of note, so they need to be tellable apart. See the [review thread](https://github.com/UiPath/uipath-python/pull/1868#discussion_r3843074842).

**Blast radius:** additive, docs only. Two markdown blocks. No SDK or behavior change.

**Cleanup:** the `<!-- REMOVE WHEN: ... -->` comments are the hook — `grep -rn "REMOVE WHEN" docs/` finds them. One per feature, since the two flags may not clear together. They carry no date either; HTML comments still ship in the published page source.

**Paired change:** UiPath/uipath-langchain-python#1045 carries the same notes, since `publish-docs.yml` symlinks that repo's `docs/` into this site as `docs/langchain`. Merging it fires a `repository_dispatch` that republishes the whole site, so land this PR first or alongside.

**Verified:** built the full site locally with the langchain docs symlinked exactly the way `publish-docs.yml` does. Confirmed in the rendered HTML that all notes come out as styled `admonition info` blocks titled `Platform Availability`, that no literal `!!!` leaks, that the `#llm-as-judge` and `#bring-your-own-guardrail-byog` anchors still resolve, and that no release number appears anywhere in the built page. `--strict` was not used — it aborts on a pre-existing `google_tag_manager_id` config warning unrelated to this change. Build produced no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)