### PR TITLE
fix(cli): allow push to a Studio Web function project

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.20"
+version = "0.2.21"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/constants/__init__.py
+++ b/packages/uipath-platform/src/uipath/platform/constants/__init__.py
@@ -93,6 +93,7 @@ COMMUNITY_agents_SUFFIX = "-community-agents"
 
 # File names
 PYTHON_CONFIGURATION_FILE = "pyproject.toml"
+NODE_CONFIGURATION_FILE = "package.json"
 UIPATH_CONFIG_FILE = "uipath.json"
 UIPATH_BINDINGS_FILE = "bindings.json"
 ENTRY_POINTS_FILE = "entry-points.json"

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.20"
+version = "0.2.21"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath"
-version = "2.14.7"
+version = "2.14.8"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
   "uipath-runtime>=0.13.1, <0.14.0",
-  "uipath-platform>=0.2.20, <0.3.0",
+  "uipath-platform>=0.2.21, <0.3.0",
   "click>=8.3.1",
   "httpx>=0.28.1",
   "pyjwt>=2.10.1",

--- a/packages/uipath/src/uipath/_cli/_utils/_common.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_common.py
@@ -20,6 +20,7 @@ from ..spinner import Spinner
 from ._console import ConsoleLogger
 from ._studio_project import (
     NonCodedAgentProjectException,
+    NonPythonFunctionProjectException,
     StudioClient,
     StudioProjectMetadata,
 )
@@ -137,13 +138,17 @@ def determine_project_type(entrypoints: list[EntryPoint]) -> str:
     return chosen_type
 
 
-async def ensure_coded_agent_project(studio_client: StudioClient):
+async def ensure_coded_project(studio_client: StudioClient):
+    console = ConsoleLogger()
     try:
-        await studio_client.ensure_coded_agent_project_async()
+        await studio_client.ensure_coded_project_async()
     except NonCodedAgentProjectException:
-        console = ConsoleLogger()
         console.error(
             "The targeted Studio Web project is not of type coded agent. Please check the UIPATH_PROJECT_ID environment variable."
+        )
+    except NonPythonFunctionProjectException:
+        console.error(
+            "The targeted Studio Web function project already contains TypeScript/JavaScript sources. Please check the UIPATH_PROJECT_ID environment variable."
         )
 
 

--- a/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
+++ b/packages/uipath/src/uipath/_cli/_utils/_studio_project.py
@@ -18,6 +18,7 @@ from uipath.platform.constants import (
     ENV_TENANT_ID,
     HEADER_SW_LOCK_KEY,
     HEADER_TENANT_ID,
+    NODE_CONFIGURATION_FILE,
     PYTHON_CONFIGURATION_FILE,
     STUDIO_METADATA_FILE,
 )
@@ -31,6 +32,19 @@ class NonCodedAgentProjectException(Exception):
     """Raised when the targeted project is not a coded agent one."""
 
     pass
+
+
+class NonPythonFunctionProjectException(Exception):
+    """Raised when the targeted function project holds sources of another runtime."""
+
+    pass
+
+
+class StudioProjectType(str, Enum):
+    """Project types reported by the Studio Web backend."""
+
+    AGENT = "Agent"
+    FUNCTION = "Function"
 
 
 class ProjectFile(BaseModel):
@@ -498,26 +512,52 @@ class StudioClient:
         self._project_id = project_id
         self._resources_cache: Optional[List[dict[str, Any]]] = None
         self._project_structure_cache: Optional[ProjectStructure] = None
+        self._project_details_cache: Optional[dict[str, Any]] = None
+
+    async def _get_project_details(self) -> dict[str, Any]:
+        if self._project_details_cache is None:
+            response = await self.uipath.api_client.request_async(
+                "GET",
+                url=f"/studio_/backend/api/Project/{self._project_id}",
+                scoped="org",
+            )
+            self._project_details_cache = response.json()
+        return self._project_details_cache
 
     async def _get_solution_id(self) -> str:
         # implement property cache logic as coroutines are not supported
         if (solution_id := UiPathConfig.studio_solution_id) is not None:
             return solution_id
-        response = await self.uipath.api_client.request_async(
-            "GET",
-            url=f"/studio_/backend/api/Project/{self._project_id}",
-            scoped="org",
-        )
-        UiPathConfig.studio_solution_id = response.json()["solutionId"]
+        details = await self._get_project_details()
+        UiPathConfig.studio_solution_id = details["solutionId"]
         return UiPathConfig.studio_solution_id
 
-    async def ensure_coded_agent_project_async(self):
+    async def get_project_type_async(self) -> Optional[str]:
+        return (await self._get_project_details()).get("projectType")
+
+    async def ensure_coded_project_async(self):
+        """Validate that the targeted Studio Web project accepts a Python code push.
+
+        Function projects are created without a configuration file because they
+        may hold either Python or TypeScript/JavaScript sources, so they are
+        identified by their project type and only rejected once they already
+        hold sources of another runtime.
+        """
         structure = await self.get_project_structure_async()
         # An empty structure means a never-pushed project: allow the first push.
         if not structure.files and not structure.folders:
             return
-        if not any(file.name == PYTHON_CONFIGURATION_FILE for file in structure.files):
-            raise NonCodedAgentProjectException()
+
+        root_file_names = {file.name for file in structure.files}
+        if PYTHON_CONFIGURATION_FILE in root_file_names:
+            return
+
+        if await self.get_project_type_async() == StudioProjectType.FUNCTION:
+            if NODE_CONFIGURATION_FILE in root_file_names:
+                raise NonPythonFunctionProjectException()
+            return
+
+        raise NonCodedAgentProjectException()
 
     async def get_project_metadata_async(self) -> Optional[StudioProjectMetadata]:
         structure = await self.get_project_structure_async()

--- a/packages/uipath/src/uipath/_cli/cli_pull.py
+++ b/packages/uipath/src/uipath/_cli/cli_pull.py
@@ -8,7 +8,7 @@ import click
 from uipath.platform.common import UiPathConfig
 
 from ._telemetry import track_command
-from ._utils._common import ensure_coded_agent_project, may_override_files
+from ._utils._common import ensure_coded_project, may_override_files
 from ._utils._console import ConsoleLogger
 from ._utils._project_files import (
     ProjectPullError,
@@ -61,7 +61,7 @@ def pull(root: Path, overwrite: bool) -> None:
     if not result.should_continue:
         return
 
-    asyncio.run(ensure_coded_agent_project(studio_client))
+    asyncio.run(ensure_coded_project(studio_client))
 
     if not overwrite:
         may_override = asyncio.run(may_override_files(studio_client, "local"))

--- a/packages/uipath/src/uipath/_cli/cli_push.py
+++ b/packages/uipath/src/uipath/_cli/cli_push.py
@@ -18,7 +18,7 @@ from ._push._summary import ResourceImportSummary
 from ._push._virtual_kinds import fetch_supported_virtual_kinds
 from ._push.sw_file_handler import SwFileHandler
 from ._telemetry import track_command
-from ._utils._common import ensure_coded_agent_project, may_override_files
+from ._utils._common import ensure_coded_project, may_override_files
 from ._utils._console import ConsoleLogger
 from ._utils._project_files import (
     Severity,
@@ -243,7 +243,7 @@ def push(root: str, ignore_resources: bool, nolock: bool, overwrite: bool) -> No
 
     studio_client = StudioClient(project_id=project_id)
 
-    asyncio.run(ensure_coded_agent_project(studio_client))
+    asyncio.run(ensure_coded_project(studio_client))
 
     if not overwrite:
         may_override = asyncio.run(may_override_files(studio_client, "remote"))

--- a/packages/uipath/tests/cli/test_pull.py
+++ b/packages/uipath/tests/cli/test_pull.py
@@ -377,6 +377,11 @@ class TestPull:
             json=mock_structure,
         )
 
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}",
+            json={"id": project_id, "projectType": "Agent"},
+        )
+
         with runner.isolated_filesystem(temp_dir=temp_dir):
             configure_env_vars(mock_env_vars)
             os.environ["UIPATH_PROJECT_ID"] = project_id

--- a/packages/uipath/tests/cli/test_push.py
+++ b/packages/uipath/tests/cli/test_push.py
@@ -692,6 +692,11 @@ class TestPush:
             json=mock_structure,
         )
 
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}",
+            json={"id": project_id, "projectType": "Agent"},
+        )
+
         with runner.isolated_filesystem(temp_dir=temp_dir):
             self._create_required_files()
 
@@ -785,6 +790,137 @@ class TestPush:
             assert "Uploading 'uipath.json'" in result.output
             assert "Uploading 'uv.lock'" in result.output
             assert "Uploading '.uipath/studio_metadata.json'" in result.output
+
+    def test_push_to_scaffolded_function_project(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        mock_env_vars: dict[str, str],
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test push to a Function project that only holds the scaffolded files.
+
+        Studio Web creates Function projects without a pyproject.toml because
+        they may hold TypeScript/JavaScript sources instead, so the coded
+        validation must fall back to the project type.
+        """
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        mock_structure = {
+            "id": "root",
+            "name": "root",
+            "folders": [],
+            "files": [
+                {
+                    "id": "123",
+                    "name": "project.uiproj",
+                    "isMain": False,
+                    "fileType": "0",
+                    "isEntryPoint": False,
+                    "ignoredFromPublish": False,
+                },
+            ],
+            "folderType": "0",
+        }
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}",
+            json={"id": project_id, "projectType": "Function"},
+        )
+
+        self._mock_lock_retrieval(httpx_mock, base_url, project_id, times=1)
+
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/StructuralMigration",
+            status_code=200,
+            json={"success": True},
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._create_required_files()
+
+            with open("pyproject.toml", "w") as f:
+                f.write(project_details.to_toml())
+
+            with open("main.py", "w") as f:
+                f.write("print('Hello World')")
+
+            with open("uv.lock", "w") as f:
+                f.write('version = 1 \n requires-python = ">=3.11"')
+
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            result = runner.invoke(cli, ["push", "./", "--ignore-resources"])
+            assert result.exit_code == 0
+            assert "not of type coded agent" not in result.output
+            assert "Uploading 'main.py'" in result.output
+            assert "Uploading 'pyproject.toml'" in result.output
+
+    def test_push_to_typescript_function_project(
+        self,
+        runner: CliRunner,
+        temp_dir: str,
+        project_details: ProjectDetails,
+        mock_env_vars: dict[str, str],
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test push to a Function project that already holds a package.json."""
+        base_url = "https://cloud.uipath.com/organization"
+        project_id = "test-project-id"
+
+        mock_structure = {
+            "id": "root",
+            "name": "root",
+            "folders": [],
+            "files": [
+                {
+                    "id": "123",
+                    "name": "package.json",
+                    "isMain": False,
+                    "fileType": "0",
+                    "isEntryPoint": False,
+                    "ignoredFromPublish": False,
+                },
+            ],
+            "folderType": "0",
+        }
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}/FileOperations/Structure",
+            json=mock_structure,
+        )
+
+        httpx_mock.add_response(
+            url=f"{base_url}/studio_/backend/api/Project/{project_id}",
+            json={"id": project_id, "projectType": "Function"},
+        )
+
+        with runner.isolated_filesystem(temp_dir=temp_dir):
+            self._create_required_files()
+
+            with open("pyproject.toml", "w") as f:
+                f.write(project_details.to_toml())
+
+            configure_env_vars(mock_env_vars)
+            os.environ["UIPATH_PROJECT_ID"] = project_id
+
+            result = runner.invoke(cli, ["push", "./", "--ignore-resources"])
+            assert result.exit_code == 1
+            assert "already contains TypeScript/JavaScript sources" in result.output
 
     def test_push_with_nolock_flag(
         self,

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.7"
+version = "2.14.8"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2760,7 +2760,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.20"
+version = "0.2.21"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Problem

Creating a project of type **Function** in Studio Web and pushing it with the project key from the UI fails:

```
❌ The targeted Studio Web project is not of type coded agent. Please check the UIPATH_PROJECT_ID environment variable.
```

`ensure_coded_agent_project_async` decided whether a remote project accepts a Python push by looking for `pyproject.toml` in the remote root. A freshly created Function project has no configuration file (it may hold Python or TypeScript/JavaScript sources, so Studio Web cannot pick one), but it is not empty either: it ships `project.uiproj` and `.project/JitCustomTypes.json`. The structure is non-empty and has no `pyproject.toml`, so the check rejected the very first push.

## Change

The check now falls back to the project type reported by `GET /studio_/backend/api/Project/{id}` when the configuration file is missing:

- `pyproject.toml` present, or the remote is empty: allowed, as before.
- `projectType == "Function"`: allowed, unless the remote already holds a `package.json` (a TypeScript/JavaScript function), which gets its own message.
- any other project type: still requires `pyproject.toml`, so a low-code agent project is still rejected.

The project details call is lazy (only made when `pyproject.toml` is absent) and cached, and it now also backs `_get_solution_id`, which was making the same request. `ensure_coded_agent_project` is renamed to `ensure_coded_project` since it no longer covers agents only.