### PR TITLE
refactor(cli): simplify scaffold uipath pin to a guarded constant

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.14.9"
+version = "2.14.10"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/_cli/cli_new.py
+++ b/packages/uipath/src/uipath/_cli/cli_new.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import shutil
 import uuid
 
@@ -15,33 +14,11 @@ from .middlewares import Middlewares
 
 console = ConsoleLogger()
 
-FALLBACK_UIPATH_MINOR = "2.14"
-
-
-def _minor_range_spec(major: int, minor: int) -> str:
-    return f"uipath>={major}.{minor}.0, <{major}.{minor + 1}.0"
-
-
-def _fallback_uipath_dependency_spec() -> str:
-    major, minor = (int(part) for part in FALLBACK_UIPATH_MINOR.split("."))
-    return _minor_range_spec(major, minor)
-
-
-def _uipath_dependency_spec() -> str:
-    from . import _get_safe_version
-
-    installed = _get_safe_version()
-    # Strip pre-release/dev/local suffixes: only the leading "major.minor" matters.
-    match = re.match(r"^(\d+)\.(\d+)", installed)
-    if match is None:
-        fallback = _fallback_uipath_dependency_spec()
-        console.warning(
-            f"Could not determine the installed 'uipath' version ('{installed}'); "
-            f"falling back to '{fallback}'. Pin it manually if needed."
-        )
-        return fallback
-
-    return _minor_range_spec(int(match.group(1)), int(match.group(2)))
+# The `uipath` minor release that scaffolded projects are pinned to.
+# Deliberately a constant: the guard test in tests/cli/test_new.py fails on
+# every minor bump so the scaffold (pin, template, hints) gets reviewed
+# alongside the release rather than drifting silently.
+UIPATH_SCAFFOLD_MINOR = "2.14"
 
 
 def generate_script(target_directory):
@@ -55,13 +32,14 @@ def generate_script(target_directory):
 
 def generate_pyproject(target_directory, project_name):
     project_toml_path = os.path.join(target_directory, PYTHON_CONFIGURATION_FILE)
+    major, minor = (int(part) for part in UIPATH_SCAFFOLD_MINOR.split("."))
     toml_content = f"""[project]
 name = "{project_name}"
 version = "0.0.1"
 description = "{project_name}"
 authors = [{{ name = "John Doe", email = "john.doe@myemail.com" }}]
 dependencies = [
-    "{_uipath_dependency_spec()}"
+    "uipath>={major}.{minor}.0, <{major}.{minor + 1}.0"
 ]
 requires-python = ">=3.11"
 """

--- a/packages/uipath/tests/cli/test_new.py
+++ b/packages/uipath/tests/cli/test_new.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from uipath._cli import cli
 from uipath._cli.middlewares import MiddlewareResult
@@ -98,51 +99,24 @@ class TestNew:
                     assert "Created 'main.py' file." not in result.output
 
 
-class TestUipathDependencySpec:
-    """The scaffolded pin must follow the installed uipath version."""
+class TestUipathScaffoldPin:
+    """The scaffolded pin must admit the uipath release it ships with."""
 
-    def _written_pin(self, temp_dir: str) -> str:
-        from uipath._cli.cli_new import generate_pyproject
+    def test_scaffold_pin_admits_installed_uipath(self) -> None:
+        """Guard: fails on every minor bump so the scaffold gets reviewed.
 
-        generate_pyproject(temp_dir, "demo")
-        with open(os.path.join(temp_dir, "pyproject.toml")) as f:
-            content = f.read()
-        match = re.search(r'"(uipath[^"]*)"', content)
-        assert match is not None, content
-        return match.group(1)
+        When this fails, review the scaffold in ``cli_new.py`` (pin constant,
+        ``main.py`` template, post-scaffold hints) for the new minor, then bump
+        ``UIPATH_SCAFFOLD_MINOR``.
+        """
+        from uipath._cli.cli_new import UIPATH_SCAFFOLD_MINOR
 
-    def test_pin_derived_from_installed_version(self, temp_dir: str) -> None:
-        with patch("uipath._cli._get_safe_version", return_value="2.14.7"):
-            assert self._written_pin(temp_dir) == "uipath>=2.14.0, <2.15.0"
-
-    def test_pin_strips_prerelease_suffix(self, temp_dir: str) -> None:
-        with patch("uipath._cli._get_safe_version", return_value="2.15.0rc1"):
-            assert self._written_pin(temp_dir) == "uipath>=2.15.0, <2.16.0"
-
-    def test_pin_falls_back_when_version_unknown(self, temp_dir: str) -> None:
-        from uipath._cli.cli_new import _fallback_uipath_dependency_spec, console
-
-        # _get_safe_version() returns "unknown" on PackageNotFoundError.
-        with (
-            patch("uipath._cli._get_safe_version", return_value="unknown"),
-            patch.object(console, "warning") as mock_warning,
-        ):
-            assert self._written_pin(temp_dir) == _fallback_uipath_dependency_spec()
-        mock_warning.assert_called_once()
-        assert (
-            "Could not determine the installed 'uipath' version"
-            in (mock_warning.call_args.args[0])
-        )
-
-    def test_fallback_pin_admits_installed_uipath(self) -> None:
-        """Guard: a release PR that forgets to bump FALLBACK_UIPATH_MINOR fails CI."""
-        from uipath._cli.cli_new import _fallback_uipath_dependency_spec
-
-        spec = _fallback_uipath_dependency_spec().removeprefix("uipath")
-        installed = version("uipath")
-        assert SpecifierSet(spec).contains(installed, prereleases=True), (
-            f"fallback pin '{spec}' does not admit installed uipath {installed}; "
-            "bump FALLBACK_UIPATH_MINOR in cli_new.py"
+        installed = Version(version("uipath"))
+        installed_minor = f"{installed.major}.{installed.minor}"
+        assert UIPATH_SCAFFOLD_MINOR == installed_minor, (
+            f"uipath minor changed to {installed_minor} but UIPATH_SCAFFOLD_MINOR is "
+            f"{UIPATH_SCAFFOLD_MINOR}; review the scaffold in cli_new.py (pin, "
+            f"template, hints) and bump the constant"
         )
 
     def test_scaffolded_pin_contains_installed_uipath(
@@ -150,8 +124,8 @@ class TestUipathDependencySpec:
     ) -> None:
         """Regression guard: runs against the real installed package, not a mock.
 
-        A stale hard-coded range would make ``uv sync`` downgrade the project's
-        venv right after ``uipath new``.
+        A stale range would make ``uv sync`` downgrade the project's venv right
+        after ``uipath new``.
         """
         with runner.isolated_filesystem(temp_dir=temp_dir):
             result = runner.invoke(cli, ["new", "demo"])

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.9"
+version = "2.14.10"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## Summary

Follow-up to #1869 ([UV-16117](https://uipath.atlassian.net/browse/UV-16117)). That PR made `uipath new` derive the scaffolded `uipath>=X.Y.0, <X.(Y+1).0` pin from the installed distribution at runtime, with a constant fallback (`FALLBACK_UIPATH_MINOR`) and a CI guard test that fails when the fallback lags the release.

With the guard in place the runtime detection is redundant: the guard forces the constant to match the minor of every release that ships, so in any installed wheel the constant already equals what `importlib.metadata` would report. The two mechanisms only diverge when package metadata is missing — i.e. when `uipath` isn't installed, which is also when the `uipath` entry point doesn't exist.

This PR keeps the simpler of the two. A deliberate constant also has an advantage detection can't offer: a minor bump turns CI red, which is the natural moment to review whether the rest of the scaffold (template, hints) needs updating for the new release.

## Changes

- **`cli_new.py`**: remove `_uipath_dependency_spec` / `_fallback_uipath_dependency_spec` / `_minor_range_spec`, the `re` import and the `_get_safe_version` lookup. The pin is formatted inline from a single documented constant, renamed `UIPATH_SCAFFOLD_MINOR` (it is no longer a fallback).
- **`tests/cli/test_new.py`**: the three mocked-version tests go away with the code they tested. The guard now asserts **strict equality** between `UIPATH_SCAFFOLD_MINOR` and the installed minor, so a constant that is *ahead* of the release fails too, and its failure message reads as a review prompt: *"review the scaffold in cli_new.py (pin, template, hints) and bump the constant"*. The real-`uipath new` regression check for UV-16117 is unchanged.
- Version bump `2.14.9` → `2.14.10`.

Scaffold output is byte-for-byte unchanged (`"uipath>=2.14.0, <2.15.0"`). Everything else from #1869 (GUID `id` in `uipath.json`, hint whitespace fix, docs) is retained. Net vs `main`: +27 / −76.

## Testing

- `pytest tests/cli/test_new.py` — 8 passed; `ruff check`, `ruff format --check`, mypy clean.
- Earlier iteration of this branch was verified end-to-end with a built 2.14.10 wheel in a fresh venv (`uipath new` → `uv sync` with no downgrade → `uipath init` → `uipath run` exit 0); the scaffold output is identical in this iteration.

## Follow-up for plugin CLIs

UiPath/uipath-langchain-python#1052 (and later `uipath-llamaindex`, `uipath-openai-agents`) should follow the same pattern: one `*_SCAFFOLD_MINOR` constant, the pin formatted inline, and a guard test asserting the constant equals the installed minor. No shared helper is needed and no `uipath` floor bump is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[UV-16117]: https://uipath.atlassian.net/browse/UV-16117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ