### PR TITLE
fix(deps): allow uipath-runtime 0.13.x on the 2.13 line

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uipath"
-version = "2.13.22"
+version = "2.13.23"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
   "uipath-core>=0.5.30, <0.6.0",
-  "uipath-runtime>=0.12.2, <0.13.0",
+  "uipath-runtime>=0.12.2, <0.14.0",
   "uipath-platform>=0.2.14, <0.3.0",
   "click>=8.3.1",
   "httpx>=0.28.1",

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.13.22"
+version = "2.13.23"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },
@@ -2682,7 +2682,7 @@ requires-dist = [
     { name = "uipath-core", editable = "../uipath-core" },
     { name = "uipath-ipc", marker = "extra == 'ipc'", specifier = ">=2.5.1,<2.6.0" },
     { name = "uipath-platform", editable = "../uipath-platform" },
-    { name = "uipath-runtime", specifier = ">=0.12.2,<0.13.0" },
+    { name = "uipath-runtime", specifier = ">=0.12.2,<0.14.0" },
 ]
 provides-extras = ["ipc"]
 
@@ -2800,16 +2800,16 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.12.2"
+version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "uipath-core" },
     { name = "vadersentiment" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/eb/1638b8307c9305527a449664c95a03a2af1bfaf1bd150819fb882ef71415/uipath_runtime-0.12.2.tar.gz", hash = "sha256:0d1f56f41add0d932bbe0c975d473ec27a86c58e14e9aa745d6501356c51284a", size = 235789, upload-time = "2026-07-07T11:02:12.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/4d/86409493366ee75b5548dd992e5d256ddf304f2b398677169f7f9af7cd99/uipath_runtime-0.13.2.tar.gz", hash = "sha256:004c91a20f85c0a0f61cce30b0dae267f1d8e086476adcbe7e723724e22d1475", size = 246648, upload-time = "2026-08-25T09:31:46.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/7a/9042e41a71726386d6f7673f843decd5405daff0787bfe127a8ac15abaa4/uipath_runtime-0.12.2-py3-none-any.whl", hash = "sha256:8faa88ac0af208b48f08abfff11530ae0279f1e88a12e9d2935f7f74111ebde1", size = 92087, upload-time = "2026-07-07T11:02:11.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/f9225df568a3f76c2c5c6e47c9c5043d5e2a9c70a4a83b7450010c337bb0/uipath_runtime-0.13.2-py3-none-any.whl", hash = "sha256:33e4fcd9b6edcc01dfa6e87434a3252319c1f1fd0480a2816d591b763b6e4f86", size = 97014, upload-time = "2026-08-25T09:31:44.692Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Releases `uipath` 2.13.23 from the 2.13 line with a single dependency-requirement change.

```diff
-version = "2.13.22"
+version = "2.13.23"
-  "uipath-runtime>=0.12.2, <0.13.0",
+  "uipath-runtime>=0.12.2, <0.14.0",
```

## Why

Every release on the 2.13 line caps `uipath-runtime` below 0.13.0, and 2.14.0 is the first release that widened it. A consumer that has to stay on the 2.13 line therefore cannot install `uipath-runtime` 0.13.x at all: there is exactly one `uipath-runtime` in an environment, and 0.13.2 does not satisfy `<0.13.0`, so resolution is unsatisfiable.

Published metadata is immutable, so the cap cannot be lifted by editing 2.13.22. It needs a new release on the line, which is why this exists. The source is byte-identical to 2.13.22.

## Branch

Cut from `c9b2428a`, the commit that built 2.13.22, per the open-source hotfix procedure. Base branch `base/uipath-2.13.x` is that same commit. Not for `main`, which is already on 2.14.x.

## Verification

- `uv lock` in `packages/uipath` pinned at `uipath-runtime==0.13.2`
- `uv sync --locked --all-extras` clean
- full `packages/uipath` suite green against `uipath-runtime` 0.13.2, exit 0, no failures

The lockfile is pinned at 0.13.2 rather than the newest 0.13.x so CI exercises the exact runtime this widening is being requested for.

## Publishing

CD is `workflow_dispatch`, so dispatch it against the hotfix branch after merge. 2.13.23 is free on PyPI, so this is a patch increment rather than a post-release.