### PR TITLE
fix(platform)!: drop inert OData params from list_records

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.22"
+version = "0.2.23"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
@@ -593,10 +593,6 @@ class EntitiesService(BaseService):
         start: Optional[int] = None,
         limit: Optional[int] = None,
         expansion_level: Optional[int] = None,
-        filter: Optional[str] = None,
-        orderby: Optional[str] = None,
-        select: Optional[List[str]] = None,
-        expand: Optional[List[str]] = None,
     ) -> EntityRecordsListResponse:
         """List records from an entity with optional pagination and schema validation.
 
@@ -637,14 +633,6 @@ class EntitiesService(BaseService):
             expansion_level (Optional[int]): Depth of foreign-key expansion in the
                 response (``0`` means no expansion). Higher values inline related
                 records up to that many hops.
-            filter (Optional[str]): OData ``$filter`` expression
-                (e.g. ``"status eq 'active'"``).
-            orderby (Optional[str]): OData ``$orderby`` expression
-                (e.g. ``"created_at desc"``).
-            select (Optional[List[str]]): Column projection — field names to
-                include (rendered as ``$select``).
-            expand (Optional[List[str]]): Relationship names to expand inline
-                (rendered as ``$expand``).
 
         Returns:
             EntityRecordsListResponse: A list-compatible response with
@@ -674,15 +662,25 @@ class EntitiesService(BaseService):
                         "Customers", start=50, limit=50
                     )
 
-            With OData filter, sorting, projection, and expansion::
+            With foreign-key expansion::
 
-                records = entities_service.list_records(
+                records = entities_service.list_records("Customers", expansion_level=1)
+
+            To filter, sort, or project, use :meth:`retrieve_records` — this
+            endpoint only pages::
+
+                result = entities_service.retrieve_records(
                     "Customers",
-                    filter="status eq 'active'",
-                    orderby="created_at desc",
-                    select=["name", "email", "status"],
-                    expand=["company"],
-                    expansion_level=1,
+                    filter_group=EntityQueryFilterGroup(
+                        logical_operator=LogicalOperator.And,
+                        query_filters=[
+                            EntityQueryFilter(
+                                field_name="status",
+                                operator=QueryFilterOperator.Equals,
+                                value="active",
+                            )
+                        ],
+                    ),
                 )
 
             With schema validation::
@@ -709,10 +707,6 @@ class EntitiesService(BaseService):
             start=start,
             limit=limit,
             expansion_level=expansion_level,
-            filter=filter,
-            orderby=orderby,
-            select=select,
-            expand=expand,
         )
 
     @traced(name="entity_list_records", run_type="uipath")
@@ -723,10 +717,6 @@ class EntitiesService(BaseService):
         start: Optional[int] = None,
         limit: Optional[int] = None,
         expansion_level: Optional[int] = None,
-        filter: Optional[str] = None,
-        orderby: Optional[str] = None,
-        select: Optional[List[str]] = None,
-        expand: Optional[List[str]] = None,
     ) -> EntityRecordsListResponse:
         """Asynchronously list records from an entity with optional pagination and schema validation.
 
@@ -767,14 +757,6 @@ class EntitiesService(BaseService):
             expansion_level (Optional[int]): Depth of foreign-key expansion in the
                 response (``0`` means no expansion). Higher values inline related
                 records up to that many hops.
-            filter (Optional[str]): OData ``$filter`` expression
-                (e.g. ``"status eq 'active'"``).
-            orderby (Optional[str]): OData ``$orderby`` expression
-                (e.g. ``"created_at desc"``).
-            select (Optional[List[str]]): Column projection — field names to
-                include (rendered as ``$select``).
-            expand (Optional[List[str]]): Relationship names to expand inline
-                (rendered as ``$expand``).
 
         Returns:
             EntityRecordsListResponse: A list-compatible response with
@@ -804,16 +786,14 @@ class EntitiesService(BaseService):
                         "Customers", start=50, limit=50
                     )
 
-            With OData filter, sorting, projection, and expansion::
+            With foreign-key expansion::
 
                 records = await entities_service.list_records_async(
-                    "Customers",
-                    filter="status eq 'active'",
-                    orderby="created_at desc",
-                    select=["name", "email", "status"],
-                    expand=["company"],
-                    expansion_level=1,
+                    "Customers", expansion_level=1
                 )
+
+            To filter, sort, or project, use :meth:`retrieve_records_async` —
+            this endpoint only pages.
 
             With schema validation::
 
@@ -839,10 +819,6 @@ class EntitiesService(BaseService):
             start=start,
             limit=limit,
             expansion_level=expansion_level,
-            filter=filter,
-            orderby=orderby,
-            select=select,
-            expand=expand,
         )
 
     @traced(name="entity_insert_record", run_type="uipath")

--- a/packages/uipath-platform/src/uipath/platform/entities/_entity_data_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entity_data_service.py
@@ -134,7 +134,7 @@ class EntityDataService(BaseService):
         return self._parse_choiceset_values(response)
 
     # ------------------------------------------------------------------
-    # List records (multi-record read with OData filters)
+    # List records (multi-record read: paging and expansion only)
     # ------------------------------------------------------------------
 
     def list_records(

--- a/packages/uipath-platform/src/uipath/platform/entities/_entity_data_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entity_data_service.py
@@ -144,10 +144,6 @@ class EntityDataService(BaseService):
         start: Optional[int] = None,
         limit: Optional[int] = None,
         expansion_level: Optional[int] = None,
-        filter: Optional[str] = None,
-        orderby: Optional[str] = None,
-        select: Optional[List[str]] = None,
-        expand: Optional[List[str]] = None,
     ) -> EntityRecordsListResponse:
         """Internal implementation; see :meth:`EntitiesService.list_records`."""
         spec = self._list_records_spec(
@@ -155,10 +151,6 @@ class EntityDataService(BaseService):
             start=start,
             limit=limit,
             expansion_level=expansion_level,
-            filter=filter,
-            orderby=orderby,
-            select=select,
-            expand=expand,
         )
         response = self.request(spec.method, spec.endpoint, params=spec.params)
         return self._build_records_list_response(response, schema, start, limit)
@@ -170,10 +162,6 @@ class EntityDataService(BaseService):
         start: Optional[int] = None,
         limit: Optional[int] = None,
         expansion_level: Optional[int] = None,
-        filter: Optional[str] = None,
-        orderby: Optional[str] = None,
-        select: Optional[List[str]] = None,
-        expand: Optional[List[str]] = None,
     ) -> EntityRecordsListResponse:
         """Async variant of :meth:`list_records`."""
         spec = self._list_records_spec(
@@ -181,10 +169,6 @@ class EntityDataService(BaseService):
             start=start,
             limit=limit,
             expansion_level=expansion_level,
-            filter=filter,
-            orderby=orderby,
-            select=select,
-            expand=expand,
         )
         response = await self.request_async(
             spec.method, spec.endpoint, params=spec.params
@@ -714,12 +698,14 @@ class EntityDataService(BaseService):
         start: Optional[int] = None,
         limit: Optional[int] = None,
         expansion_level: Optional[int] = None,
-        filter: Optional[str] = None,
-        orderby: Optional[str] = None,
-        select: Optional[List[str]] = None,
-        expand: Optional[List[str]] = None,
     ) -> RequestSpec:
-        """Build the GET spec for the multi-record read endpoint."""
+        """Build the GET spec for the multi-record read endpoint.
+
+        The endpoint implements only ``start``, ``limit`` and ``expansionLevel``.
+        OData-style ``$filter`` / ``$orderby`` / ``$select`` / ``$expand`` params
+        are accepted and silently ignored by the backend, so they are not sent —
+        use :meth:`retrieve_records` (``POST .../query``) to filter or sort.
+        """
         params: Dict[str, Any] = {}
         if start is not None:
             params["start"] = start
@@ -727,14 +713,6 @@ class EntityDataService(BaseService):
             params["limit"] = limit
         if expansion_level is not None:
             params["expansionLevel"] = expansion_level
-        if filter is not None:
-            params["$filter"] = filter
-        if orderby is not None:
-            params["$orderby"] = orderby
-        if select:
-            params["$select"] = ",".join(select)
-        if expand:
-            params["$expand"] = ",".join(expand)
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(

--- a/packages/uipath-platform/tests/services/test_entities_service.py
+++ b/packages/uipath-platform/tests/services/test_entities_service.py
@@ -1733,6 +1733,30 @@ class TestEntitiesServiceNewMethods:
         # Sending them would promise filtering this endpoint cannot do.
         assert [key for key in params if key.startswith("$")] == []
 
+    @pytest.mark.parametrize(
+        "kwarg,value",
+        [
+            ("filter", "status eq 'active'"),
+            ("orderby", "name asc"),
+            ("select", ["Id"]),
+            ("expand", ["Company"]),
+        ],
+    )
+    def test_list_records_rejects_odata_kwargs(
+        self,
+        service: EntitiesService,
+        kwarg: str,
+        value: object,
+    ) -> None:
+        """The /read endpoint cannot filter, sort or project.
+
+        Accepting these kwargs again — directly or via ``**kwargs`` — would
+        return the full unfiltered set while looking like it filtered. Failing
+        loudly points callers at ``retrieve_records`` instead.
+        """
+        with pytest.raises(TypeError, match=kwarg):
+            service.list_records(entity_key=str(uuid.uuid4()), **{kwarg: value})
+
     def test_insert_records_passes_expansion_level_and_fail_on_first(
         self,
         httpx_mock: HTTPXMock,

--- a/packages/uipath-platform/tests/services/test_entities_service.py
+++ b/packages/uipath-platform/tests/services/test_entities_service.py
@@ -1709,10 +1709,6 @@ class TestEntitiesServiceNewMethods:
             start=0,
             limit=3,
             expansion_level=2,
-            filter="status eq 'active'",
-            orderby="name asc",
-            select=["Id", "name"],
-            expand=["Company"],
         )
 
         # New pagination metadata: backend totalCount surfaced verbatim.
@@ -1729,11 +1725,13 @@ class TestEntitiesServiceNewMethods:
         sent = httpx_mock.get_request()
         assert sent is not None
         params = sent.url.params
+        assert params.get("start") == "0"
+        assert params.get("limit") == "3"
         assert params.get("expansionLevel") == "2"
-        assert params.get("$filter") == "status eq 'active'"
-        assert params.get("$orderby") == "name asc"
-        assert params.get("$select") == "Id,name"
-        assert params.get("$expand") == "Company"
+        # The /read endpoint implements paging and expansion only — it accepts
+        # OData params and silently ignores them, returning the unfiltered set.
+        # Sending them would promise filtering this endpoint cannot do.
+        assert [key for key in params if key.startswith("$")] == []
 
     def test_insert_records_passes_expansion_level_and_fail_on_first(
         self,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.22"
+version = "0.2.23"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2762,7 +2762,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.22"
+version = "0.2.23"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Problem

`EntitiesService.list_records` advertises OData filtering:

> `filter (Optional[str])`: OData `$filter` expression (e.g. `"status eq 'active'"`)

The endpoint it calls — `GET datafabric_/api/EntityService/entity/{key}/read` — does not implement it. It accepts `$filter`, `$orderby`, `$select` and `$expand`, ignores them, and returns the full unfiltered set. The failure mode is a **silent wrong answer**: a filtered query returns every record, with no error.

Verified against a live tenant (`TestEntity`, 32 records), via the SDK and raw `httpx`:

| Request | Result |
|---|---|
| no params | 32 records |
| `$filter=Name eq '<one real match>'` | **32 records** |
| `$filter=Name eq 'definitely-no-such-value-xyz'` | **32 records** |
| `$filter=bogus syntax (((` | **HTTP 200, 32 records** |
| `$select=Name` | 32 records, all 7 columns |
| `$orderby=Name desc` | order unchanged |
| `filter=…` (no `$`) / `query=…` | 32 records |

What the endpoint *does* honour:

| Param | Honoured | Evidence |
|---|---|---|
| `start` | yes | `start=30` → 2 of 32; `start=100` → 0 |
| `limit` | yes | `1`/`2`/`31` → exact; `1000` → 32; `0` → 32 (treated as unset); `-1` → HTTP 400 `Invalid limit -1` |
| `expansionLevel` | yes | `0` → bare guid, `1` → `{Id}`, `2` → full nested record |

`GET api/v2/.../read` returns 404, so there is no newer read endpoint these params were written against.

## Why CI didn't catch it

The four params were added in #1616 alongside the (working) structured query API. The covering test asserted only that `pytest-httpx` received them:

```python
assert params.get("$filter") == "status eq 'active'"
assert params.get("$orderby") == "name asc"
```

That passes whether or not the server implements any of it — the mock replies with whatever the test told it to.

## Change

Remove `filter`, `orderby`, `select` and `expand` from `list_records` / `list_records_async` and from `_list_records_spec`. This restores the pre-#1616 parameter surface (`entity_key`, `schema`, `start`, `limit`) plus `expansion_level`, which does work — nothing that ever functioned is lost.

Filtering, sorting and projection already have a working home in `retrieve_records` (`POST .../query`, `EntityQueryFilterGroup`); docstrings and examples now point there. `_list_records_spec` records why the params are not sent, so they don't get re-added.

The test now asserts the positive contract *and* the negative one:

```python
assert params.get("start") == "0"
assert params.get("limit") == "3"
assert params.get("expansionLevel") == "2"
assert [key for key in params if key.startswith("$")] == []
```

Note for reviewers: filtering a related entity's field via `retrieve_records` needs `field_name="Rel.Id"` **and** `expansion_level>=1`, otherwise the backend rejects it with *"Filtering or sorting fields from related entities has to be expanded in the query"*. Filtering on the bare relationship name (`CreatedBy eq '<guid>'`) is silently ignored — same class of trap, on the endpoint that otherwise works.

## Verification

Live tenant, with this branch's source:

```
limit=2, expansion_level=2 -> returned=2 total=32
  CreatedBy expanded to: <full nested SystemUser record>
start=30                   -> returned=2 total=32
filter=…                   -> TypeError: got an unexpected keyword argument 'filter'
```

`uipath-platform` suite passes, `ruff check` / `ruff format --check` clean, `mypy src` clean (163 files).

## Breaking change

`list_records()` / `list_records_async()` no longer accept `filter`, `orderby`, `select` or `expand`. Passing them raises `TypeError` instead of silently returning unfiltered records. Callers migrate to `retrieve_records()` with an `EntityQueryFilterGroup`.

Happy to swap this for a deprecation window (keep the params, raise `NotImplementedError`) if reviewers prefer a softer landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
