### PR TITLE
ci: run checks and publish on release branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
     paths:
       - 'packages/*/pyproject.toml'
       - '!packages/*/samples/**/pyproject.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
   push:
     branches:
       - main
+      - 'release/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Scopes both workflows to `release/**` in addition to `main`.

```diff
 # ci.yml
   pull_request:
     branches:
       - main
+      - 'release/**'
   push:
     branches:
       - main
+      - 'release/**'

 # cd.yml
   push:
     branches:
       - main
+      - 'release/**'
     paths:
       - 'packages/*/pyproject.toml'
```

## Why

Hotfix releases are cut on `release/*` branches, per the open-source hotfix procedure, but both workflows are scoped to `main` only.

**Checks never run.** `ci.yml` fires only for PRs targeting `main`. The `Actions` ruleset covers `refs/heads/release/*` and requires `lint / Lint`, `commit-lint / Commit Lint`, `SonarCloud Code Analysis` and the six `test / Test (...)` contexts. For a PR into a release branch, nothing produces them, so all of them sit at `Expected — Waiting for status to be reported` indefinitely and the PR is unmergeable without an admin bypass. The ruleset requires checks the workflow config cannot emit for that base.

**Publishing never happens.** `cd.yml` fires only on push to `main`, so merging a hotfix into its release branch publishes nothing and every release needs a manual `workflow_dispatch`. A manual dispatch also runs the workflow file *from the dispatched ref*, which for a branch cut from an older commit means running an older CI definition than `main`'s.

## Is auto-publishing from a release branch safe

Yes. `detect_publishable_packages.py` compares each `packages/*/pyproject.toml` version against PyPI and emits only versions that 404, so a push to a release branch that does not bump a version publishes nothing. The publish step also passes `skip-existing: true`. The `pypi` environment has no deployment branch policy, so a release ref is already permitted to publish.

`release/*` is covered by the `Actions` ruleset, which requires a pull request, so nothing reaches these branches unreviewed.

## Known limitation

This does not retroactively fix a hotfix branch cut from a commit that predates the `uipath-ubuntu-latest` runner rename. Such a branch produces contexts named `test / Test (3.11, ubuntu-latest)`, which do not match the names the ruleset requires, so those PRs still need a bypass or a workflow sync. This change is what stops the problem recurring for branches cut from here on.