### PR TITLE
ci: do not run cd when a branch is created

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,8 @@ jobs:
   detect-publishable-packages:
     runs-on: uipath-ubuntu-latest
     outputs:
-      packages: ${{ steps.detect.outputs.packages }}
-      count: ${{ steps.detect.outputs.count }}
+      packages: ${{ steps.detect.outputs.packages || '[]' }}
+      count: ${{ steps.detect.outputs.count || '0' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
@@ -34,6 +34,7 @@ jobs:
 
       - name: Detect publishable packages
         id: detect
+        if: ${{ !github.event.created }}
         run: python .github/scripts/detect_publishable_packages.py
 
   # --- Tier 0: uipath-core (no internal dependencies) ---


### PR DESCRIPTION
CD triggers on pushes to `main` and `release/**` filtered to `packages/*/pyproject.toml`. Creating a `release/*` branch at a commit that touched one of those files is a push that can match the filter, so the branch creation itself starts a CD run.

This repo already resolves safely, because `detect_publishable_packages.py` asks PyPI whether each local version exists and the publish steps use `skip-existing: true`. The remaining gap is the same as in the sibling repos: if a version bump on `main` was never actually published, branch creation would publish it from a branch nobody treated as a release. The `pypi` environment has no protection rules or deployment branch policy, so there is no second gate.

Skip detection on branch creation rather than skipping the whole job. Several downstream jobs use `always()`, so a skipped `detect-publishable-packages` would leave them evaluating `fromJson('')` and erroring. Falling back to `'[]'` and `'0'` in the job outputs keeps the expressions valid and makes every downstream `contains(...)` false, so the tiers skip cleanly. The fallback also covers the case where the script exits without writing its outputs.

Manual `workflow_dispatch` runs are unaffected, since the property is absent there and evaluates as falsy. Merging a hotfix PR into a release branch is a normal push with commits, so `created` is false and the publish still runs as intended.