### PR TITLE
fix: correct two typos in the input mocker prompt and event-trigger sample

### DIFF
--- a/packages/uipath/samples/event-trigger/README.md
+++ b/packages/uipath/samples/event-trigger/README.md
@@ -10,7 +10,7 @@ UiPath Coded Agents allow you to write automation logic directly in Python while
 
 ### Step 1: Install UiPath Python SDK
 
-1. Open it with your prefered editor
+1. Open it with your preferred editor
 2. In terminal run:
 ```bash
 uv init

--- a/packages/uipath/src/uipath/eval/mocks/_input_mocker.py
+++ b/packages/uipath/src/uipath/eval/mocks/_input_mocker.py
@@ -58,7 +58,7 @@ The current date and time is: {current_datetime}
 Based on the above information, provide a realistic input to the LLM agent. Your response should:
 1. Match the expected input format according to the INPUT_SCHEMA exactly
 2. Be consistent with the style and level of detail in the example inputs
-3. Consider the context of the the agent being tested
+3. Consider the context of the agent being tested
 4. Be realistic and representative of what a real user might say or ask
 
 OUTPUT: ONLY the simulated agent input in the exact format of the INPUT_SCHEMA in valid JSON. Do not include any explanations, quotation marks, or markdown."""


### PR DESCRIPTION
## Summary

Two one-word typo fixes.

- **packages/uipath/src/uipath/eval/mocks/_input_mocker.py**: the generated LLM prompt says `3. Consider the context of the the agent being tested` -> `the agent being tested`. The equivalent line in the sibling `_llm_mocker.py` is already written without the duplication.
- **packages/uipath/samples/event-trigger/README.md**: `Open it with your prefered editor` -> `preferred`.

Neither string is referenced or asserted anywhere else in the repo.

### Please review carefully

The `_input_mocker.py` change is inside an f-string prompt template that is sent to an LLM, not a comment or docstring, so strictly speaking it is a behaviour change. Removing the duplicated word should be neutral-to-positive for the model, but it is a runtime string and I would rather flag it than slip it through.

### Reported but deliberately not changed

`packages/uipath-platform/src/uipath/platform/common/_endpoints_manager.py` declares `loggger = logging.getLogger(__name__)` (three g's) and uses `loggger` on two further lines. It is a genuine misspelling, but it is an identifier rather than text, and renaming identifiers is out of scope for a typo PR. It is module-private and referenced only within that one file, so the rename would be safe — happy to add it as a separate commit or PR if you would like it.

Commit message follows conventional commits for the commitlint check.