### PR TITLE
docs(guardrails): drop LLM-as-judge platform availability note

### DIFF
--- a/packages/uipath/docs/core/guardrails.md
+++ b/packages/uipath/docs/core/guardrails.md
@@ -210,10 +210,6 @@ def generate_code(spec: str) -> str:
 
 ### LLM-as-judge
 
-<!-- REMOVE WHEN: LLM-as-judge feature flag is enabled on all rings -->
-!!! info "Platform Availability"
-    `LLMAsJudgeValidator` ships in the `uipath` package on PyPI, but the LLM-as-judge guardrail it calls is still rolling out on the platform side and isn't enabled on every tenant yet — regardless of which judge models your governance policy permits. Watch the UiPath product release notes for when it lands.
-
 Evaluates content against a rule written in plain language, using a judge LLM to decide whether the payload complies. Use it for policy checks that are hard to express as fixed entities or rules — tone, topicality, disclaimers, domain-specific policies.
 
 ```python


### PR DESCRIPTION
The LLM-as-judge guardrail is now enabled on the platform, so this removes the "Platform Availability" note (and its `<!-- REMOVE WHEN -->` cleanup marker) that flagged it as still rolling out. Docs-only change to `packages/uipath/docs/core/guardrails.md`; the BYOG note is left untouched since its feature flag has not cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)