### PR TITLE
feat(platform): list entities without field definitions

### DIFF
--- a/packages/uipath-platform/pyproject.toml
+++ b/packages/uipath-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-platform"
-version = "0.2.26"
+version = "0.2.27"
 description = "HTTP client library for programmatic access to UiPath Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entities_service.py
@@ -284,12 +284,19 @@ class EntitiesService(BaseService):
         "Deprecated; use list_entities_v3 (v3 API, supports Federated entities)."
     )
     @traced(name="list_entities", run_type="uipath")
-    def list_entities(self) -> List[Entity]:
+    def list_entities(self, include_fields: bool = True) -> List[Entity]:
         """List all entities in Data Service.
+
+        Args:
+            include_fields (bool): When ``False``, list entities without their
+                ``fields`` schema. The response carries the same entity records
+                and is far smaller, which keeps the traced span small on tenants
+                with many entities.
 
         Returns:
             List[Entity]: A list of all entities with their metadata and field definitions.
                 Each entity includes name, display name, fields, record count, and storage information.
+                With ``include_fields=False``, ``Entity.fields`` is ``None``.
 
         Examples:
             List all entities::
@@ -319,8 +326,12 @@ class EntitiesService(BaseService):
                 print(f"Total entities: {len(entities)}")
                 print(f"Total records: {total_records}")
                 print(f"Total storage: {total_storage:.2f} MB")
+
+            List entity names only, without the field schemas::
+
+                entities = entities_service.list_entities(include_fields=False)
         """
-        return self._schema.list_entities()
+        return self._schema.list_entities(include_fields=include_fields)
 
     @traced(name="list_entities_v3", run_type="uipath")
     def list_entities_v3(self) -> List[Entity]:
@@ -335,12 +346,19 @@ class EntitiesService(BaseService):
         "Deprecated; use list_entities_v3_async (v3 API, supports Federated entities)."
     )
     @traced(name="list_entities", run_type="uipath")
-    async def list_entities_async(self) -> List[Entity]:
+    async def list_entities_async(self, include_fields: bool = True) -> List[Entity]:
         """Asynchronously list all entities in the Data Service.
+
+        Args:
+            include_fields (bool): When ``False``, list entities without their
+                ``fields`` schema. The response carries the same entity records
+                and is far smaller, which keeps the traced span small on tenants
+                with many entities.
 
         Returns:
             List[Entity]: A list of all entities with their metadata and field definitions.
                 Each entity includes name, display name, fields, record count, and storage information.
+                With ``include_fields=False``, ``Entity.fields`` is ``None``.
 
         Examples:
             List all entities::
@@ -370,8 +388,14 @@ class EntitiesService(BaseService):
                 print(f"Total entities: {len(entities)}")
                 print(f"Total records: {total_records}")
                 print(f"Total storage: {total_storage:.2f} MB")
+
+            List entity names only, without the field schemas::
+
+                entities = await entities_service.list_entities_async(
+                    include_fields=False
+                )
         """
-        return await self._schema.list_entities_async()
+        return await self._schema.list_entities_async(include_fields=include_fields)
 
     @traced(name="list_entities_v3", run_type="uipath")
     async def list_entities_v3_async(self) -> List[Entity]:

--- a/packages/uipath-platform/src/uipath/platform/entities/_entity_schema_service.py
+++ b/packages/uipath-platform/src/uipath/platform/entities/_entity_schema_service.py
@@ -120,16 +120,20 @@ class EntitySchemaService(BaseService):
         response = await self.request_async(spec.method, spec.endpoint, headers=headers)
         return Entity.model_validate(response.json())
 
-    def list_entities(self, use_v3: bool = False) -> List[Entity]:
+    def list_entities(
+        self, use_v3: bool = False, include_fields: bool = True
+    ) -> List[Entity]:
         """Internal implementation; see :meth:`EntitiesService.list_entities`."""
-        spec = self._list_entities_spec(use_v3=use_v3)
+        spec = self._list_entities_spec(use_v3=use_v3, include_fields=include_fields)
         response = self.request(spec.method, spec.endpoint)
         entities_data = response.json()
         return [Entity.model_validate(entity) for entity in entities_data]
 
-    async def list_entities_async(self, use_v3: bool = False) -> List[Entity]:
+    async def list_entities_async(
+        self, use_v3: bool = False, include_fields: bool = True
+    ) -> List[Entity]:
         """Async variant of :meth:`list_entities`."""
-        spec = self._list_entities_spec(use_v3=use_v3)
+        spec = self._list_entities_spec(use_v3=use_v3, include_fields=include_fields)
         response = await self.request_async(spec.method, spec.endpoint)
         entities_data = response.json()
         return [Entity.model_validate(entity) for entity in entities_data]
@@ -228,8 +232,25 @@ class EntitySchemaService(BaseService):
         return {}
 
     @staticmethod
-    def _list_entities_spec(use_v3: bool = False) -> RequestSpec:
-        """Build the GET spec for listing all entities (non-choice-sets)."""
+    def _list_entities_spec(
+        use_v3: bool = False, include_fields: bool = True
+    ) -> RequestSpec:
+        """Build the GET spec for listing all entities (non-choice-sets).
+
+        ``include_fields=False`` targets the ``simple`` route, which returns the
+        same entity records without their ``fields`` schema — a much smaller
+        response (and traced span) on tenants with many entities. Only the v1
+        surface serves that route.
+        """
+        if not include_fields:
+            if use_v3:
+                raise ValueError(
+                    "include_fields=False is only supported on the v1 entity API."
+                )
+            return RequestSpec(
+                method="GET",
+                endpoint=Endpoint(f"{_V1_ENTITIES}/simple"),
+            )
         return RequestSpec(
             method="GET",
             endpoint=Endpoint(_schema_base(use_v3)),

--- a/packages/uipath-platform/tests/services/test_entities_service.py
+++ b/packages/uipath-platform/tests/services/test_entities_service.py
@@ -2563,6 +2563,74 @@ class TestEntitiesServiceAsyncCoverage:
         entities = await service.list_entities_async()
         assert len(entities) == 1
 
+    def test_list_entities_without_fields(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/Entity/simple",
+            status_code=200,
+            json=[
+                {
+                    "name": "Customers",
+                    "displayName": "Customers",
+                    "entityType": "Entity",
+                    "isRbacEnabled": False,
+                    "recordCount": 3,
+                    "id": "ent-1",
+                },
+                {
+                    "name": "Orders",
+                    "displayName": "Orders",
+                    "entityType": "Entity",
+                    "isRbacEnabled": False,
+                    "recordCount": 7,
+                    "id": "ent-2",
+                },
+            ],
+        )
+        entities = service.list_entities(include_fields=False)
+        assert [e.name for e in entities] == ["Customers", "Orders"]
+        assert all(e.fields is None for e in entities)
+
+    async def test_list_entities_without_fields_async(
+        self,
+        httpx_mock: HTTPXMock,
+        service: EntitiesService,
+        base_url: str,
+        org: str,
+        tenant: str,
+        version: str,
+    ) -> None:
+        httpx_mock.add_response(
+            url=f"{base_url}{org}{tenant}/datafabric_/api/Entity/simple",
+            status_code=200,
+            json=[
+                {
+                    "name": "Customers",
+                    "displayName": "Customers",
+                    "entityType": "Entity",
+                    "isRbacEnabled": False,
+                    "id": "ent-1",
+                }
+            ],
+        )
+        entities = await service.list_entities_async(include_fields=False)
+        assert len(entities) == 1
+        assert entities[0].fields is None
+
+    def test_list_entities_without_fields_rejected_on_v3(
+        self,
+        service: EntitiesService,
+    ) -> None:
+        with pytest.raises(ValueError, match="only supported on the v1 entity API"):
+            service._schema.list_entities(use_v3=True, include_fields=False)
+
     async def test_list_records_async(
         self,
         httpx_mock: HTTPXMock,

--- a/packages/uipath-platform/uv.lock
+++ b/packages/uipath-platform/uv.lock
@@ -1095,7 +1095,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.26"
+version = "0.2.27"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2762,7 +2762,7 @@ wheels = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.2.26"
+version = "0.2.27"
 source = { editable = "../uipath-platform" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Why

`entities.list_entities()` returns every entity with its full `fields` schema. On a busy tenant that is a large payload, and because `@traced` stores the payload twice, the resulting span is several times larger again.

Measured live on a tenant with 11 entities:

| call | response |
| --- | --- |
| `GET datafabric_/api/Entity` | 168 KB |
| `GET datafabric_/api/Entity/simple` | 6.6 KB |

Both return the same 11 entity records (identical id set) with the same metadata — name, displayName, entityType, entityTypeId, folderId, recordCount, storageSizeInMB, isRbacEnabled, createTime, ... The `simple` route just omits `fields`.

## What changed

- `EntitiesService.list_entities(include_fields: bool = True)` and `list_entities_async(include_fields: bool = True)`. With `include_fields=False` the request goes to `datafabric_/api/Entity/simple` and `Entity.fields` is `None`. Default behaviour is unchanged.
- `EntitySchemaService.list_entities` / `list_entities_async` / `_list_entities_spec` take the same keyword.
- `Entity.fields` was already `Optional` with a `None` default, so the `simple` payload parses without a model change.
- The `simple` route exists only on v1 — the v3 route rejects `simple` as an entity id — so `_list_entities_spec` raises `ValueError` for `use_v3=True, include_fields=False`. The v3 public methods do not expose the keyword.
- Bumped `uipath-platform` to 0.2.27.

## Tests

Three tests added next to the existing `list_entities` tests in `packages/uipath-platform/tests/services/test_entities_service.py` (sync, async, and the v3 rejection). `uv run pytest tests/services/test_entities_service.py`: 165 passed. `ruff check`, `ruff format --check` and `mypy` clean for the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)