### PR TITLE
fix(eval): surface actionable message on target output key mismatch

### DIFF
--- a/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
+++ b/packages/uipath/src/uipath/eval/evaluators/output_evaluator.py
@@ -128,6 +128,19 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
             return float(obj)
         return obj
 
+    def _describe_key_lookup_failure(
+        self, error: Exception, source: Any, key: "str | list[str]"
+    ) -> str:
+        """Describe which target output key(s) failed to resolve and what was available."""
+        requested = (
+            ", ".join(f"'{k}'" for k in key) if isinstance(key, list) else f"'{key}'"
+        )
+        message = f"Could not resolve target output key {requested}: {error}"
+        if isinstance(source, dict):
+            available = ", ".join(f"'{k}'" for k in source.keys()) or "none"
+            message += f". Available top-level keys: {available}"
+        return message
+
     def _get_actual_output(self, workload_execution: WorkloadExecution) -> Any:
         """Get the actual output from the workload execution.
 
@@ -153,7 +166,9 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                 raise UiPathEvaluationError(
                     code="TARGET_OUTPUT_KEY_NOT_FOUND",
                     title="One or more target output keys not found in actual output",
-                    detail=f"Error: {e}",
+                    detail=self._describe_key_lookup_failure(
+                        e, workload_execution.workload_output, key
+                    ),
                     category=UiPathEvaluationErrorCategory.USER,
                 ) from e
             for k, v in list_result.items():
@@ -168,7 +183,9 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
                 raise UiPathEvaluationError(
                     code="TARGET_OUTPUT_KEY_NOT_FOUND",
                     title="Target output key not found in actual output",
-                    detail=f"Error: {e}",
+                    detail=self._describe_key_lookup_failure(
+                        e, workload_execution.workload_output, key
+                    ),
                     category=UiPathEvaluationErrorCategory.USER,
                 ) from e
         else:
@@ -216,7 +233,7 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
             raise UiPathEvaluationError(
                 code="TARGET_OUTPUT_KEY_NOT_FOUND",
                 title="One or more target output keys not found in expected output",
-                detail=f"Error: {e}",
+                detail=self._describe_key_lookup_failure(e, expected_output, keys),
                 category=UiPathEvaluationErrorCategory.USER,
             ) from e
 
@@ -238,7 +255,7 @@ class BaseOutputEvaluator(BaseEvaluator[T, C, J]):
             raise UiPathEvaluationError(
                 code="TARGET_OUTPUT_KEY_NOT_FOUND",
                 title="Target output key not found in expected output",
-                detail=f"Error: {e}",
+                detail=self._describe_key_lookup_failure(e, expected_output, key),
                 category=UiPathEvaluationErrorCategory.USER,
             ) from e
 

--- a/packages/uipath/src/uipath/eval/models/models.py
+++ b/packages/uipath/src/uipath/eval/models/models.py
@@ -370,20 +370,23 @@ class UiPathEvaluationError(Exception):
     ):
         """Initialize the UiPathEvaluationError."""
         # Get the current traceback as a string
+        full_detail = detail
         if include_traceback:
             tb = traceback.format_exc()
             if (
                 tb and tb.strip() != "NoneType: None"
             ):  # Ensure there's an actual traceback
-                detail = f"{detail}\n\n{tb}"
+                full_detail = f"{detail}\n\n{tb}"
 
         self.error_info = UiPathEvaluationErrorContract(
             code=f"{prefix}.{code}",
             title=title,
-            detail=detail,
+            detail=full_detail,
             category=category,
         )
-        super().__init__(detail)
+        # str(exc) stays human-readable (title + detail); the raw traceback is
+        # still available via error_info.detail for logs/support.
+        super().__init__(f"{title}: {detail}")
 
     @property
     def as_dict(self) -> dict[str, Any]:

--- a/packages/uipath/tests/evaluators/test_evaluator_methods.py
+++ b/packages/uipath/tests/evaluators/test_evaluator_methods.py
@@ -785,6 +785,8 @@ class TestListTargetOutputKey:
         result = await evaluator.evaluate(execution, criteria)
         assert isinstance(result, ErrorEvaluationResult)
         assert result.score == 0.0
+        assert "'missing_key'" in result.details
+        assert "'other'" in result.details
 
     @pytest.mark.asyncio
     async def test_scalar_key_missing_in_expected_raises(self) -> None:
@@ -807,6 +809,9 @@ class TestListTargetOutputKey:
         result = await evaluator.evaluate(execution, criteria)
         assert isinstance(result, ErrorEvaluationResult)
         assert result.score == 0.0
+        assert "'status'" in result.details
+        assert "'other_key'" in result.details
+        assert "Traceback" not in result.details
 
     @pytest.mark.asyncio
     async def test_scalar_key_invalid_json_expected_raises(self) -> None:


### PR DESCRIPTION
Milo hit this in the FUSION-workshop coding-agent authoring path (MST-14878): an LLM judge evaluator had `targetOutputKey: reason`, but the data point's `expectedOutput` only had `decision` and `route`. Normal authoring miss. The run dumped a raw Python traceback ending in `KeyError: 'reason'` instead of a readable eval error.

`output_evaluator.py` already wraps that `KeyError` in a `UiPathEvaluationError` with `TARGET_OUTPUT_KEY_NOT_FOUND`, but `str(exc)` only returned `detail`, and `detail` was `f"Error: {e}"` plus the full traceback appended. `track_evaluation_metrics` writes `str(e)` into the evaluator's `details` field, so the traceback is exactly what landed in the run results.

I changed `str(exc)` to return `f"{title}: {detail}"` and left the traceback on `error_info.detail` for logs/support. The four `TARGET_OUTPUT_KEY_NOT_FOUND` messages now name the missing key(s) and list the keys that were actually present, instead of just echoing `str(KeyError)`.

## What to look at

`__str__` lives on the shared `UiPathEvaluationError` type, not just this code path. Every evaluation error that used to render as a bare `detail` (often traceback and all) now renders as `title: detail`. I think that's the right default everywhere, but it's a behavior change beyond the one evaluator that reported this.

## Testing

- `pytest tests/evaluators/` — full suite green
- Extended `test_scalar_key_missing_in_actual_raises` and `test_scalar_key_missing_in_expected_raises` to assert the surfaced message names the missing key and the available keys, and contains no `Traceback`
- `ruff check .`, `ruff format --check .`, `mypy` on both changed modules — clean