### PR TITLE
feat(agent): accept the conversationalCaseManager agent variant [PC-5006]

### DIFF
--- a/packages/uipath/pyproject.toml
+++ b/packages/uipath/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath"
-version = "2.14.13"
+version = "2.14.14"
 description = "Python SDK and CLI for UiPath Platform, enabling programmatic interaction with automation services, process management, and deployment tools."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath/src/uipath/agent/models/agent.py
+++ b/packages/uipath/src/uipath/agent/models/agent.py
@@ -184,6 +184,7 @@ class AgentVariant(str, CaseInsensitiveEnum):
     """Agent variant enumeration."""
 
     CASE_MANAGER = "caseManager"
+    CONVERSATIONAL_CASE_MANAGER = "conversationalCaseManager"
 
 
 class AgentGuardrailActionType(str, CaseInsensitiveEnum):

--- a/packages/uipath/tests/agent/models/test_agent.py
+++ b/packages/uipath/tests/agent/models/test_agent.py
@@ -45,6 +45,7 @@ from uipath.agent.models.agent import (
     AgentUnknownGuardrail,
     AgentUnknownResourceConfig,
     AgentUnknownToolResourceConfig,
+    AgentVariant,
     AgentWordOperator,
     AgentWordRule,
     ArgumentEmailRecipient,
@@ -3472,6 +3473,38 @@ class TestAgentDefinitionIsCaseManager:
         )
 
         assert config.is_case_manager is True
+
+    def test_conversational_case_manager_variant_is_accepted(self):
+        """An agent definition carrying the conversational variant parses."""
+        json_data = {
+            "id": "test-conversational-case-manager",
+            "name": "Case Manager Conversational Agent",
+            "version": "1.0.0",
+            "metadata": {
+                "isConversational": True,
+                "variant": "conversationalCaseManager",
+                "storageVersion": "1.0.0",
+            },
+            "settings": {
+                "model": "gpt-4o",
+                "maxTokens": 4096,
+                "temperature": 0,
+                "engine": "conversational-v1",
+            },
+            "inputSchema": {"type": "object", "properties": {}},
+            "outputSchema": {"type": "object", "properties": {}},
+            "resources": [],
+            "messages": [
+                {"role": "system", "content": "You answer questions about a case."}
+            ],
+        }
+
+        config: AgentDefinition = TypeAdapter(AgentDefinition).validate_python(
+            json_data
+        )
+
+        assert config.metadata is not None
+        assert config.metadata.variant is AgentVariant.CONVERSATIONAL_CASE_MANAGER
 
     def test_is_case_manager_false_when_variant_is_none(self):
         """Returns False when metadata.variant is None."""

--- a/packages/uipath/uv.lock
+++ b/packages/uipath/uv.lock
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.14.13"
+version = "2.14.14"
 source = { editable = "." }
 dependencies = [
     { name = "applicationinsights" },


### PR DESCRIPTION
## What changed

- `AgentVariant` gains `CONVERSATIONAL_CASE_MANAGER = "conversationalCaseManager"`.
- One test parses an agent definition carrying the new variant.
- `uipath` version 2.14.13 → 2.14.14.

## Why

Agent Builder marks the conversational Case Management agent with `metadata.variant = "conversationalCaseManager"`. The runtime validates `agent.json` against `AgentVariant`, which only knew `caseManager`, so the agent's job faulted at startup:

```
agent.json failed schema validation: 1 validation error for AgentDefinition
metadata.variant
  Input should be 'caseManager' [type=enum, input_value='conversationalCaseManager', input_type=str]
```

The variant is otherwise only forwarded to telemetry, so accepting the value is the whole fix on the runtime side.

## Checks

From `packages/uipath`: `ruff check`, `ruff format --check`, `mypy` on the model file, and `pytest tests/agent` all pass.
